### PR TITLE
Remove deadlock when endpoint creation failed

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,10 @@ To get started you can visit this blog [PowerShell I would like you to meet TFS 
 The cases of every file is very important. This module is to be used on Windows, Linux and OSx so case is important.  If the casing does not match Linux and OSx might fail.
 
 # Release Notes
+## 1.0.4
+Merge [Pull Request](https://github.com/DarqueWarrior/vsteam/pull/26) from [Michel Perfetti](https://github.com/miiitch) which included the following:
+
+- Remove deadlock when endpoint creation failed 
 ## 1.0.3
 Explicit export of alias
 Fixed typo in help
@@ -25,31 +29,31 @@ Renamed from Team to VSTeam. An alias for every function with it's original name
 ## 0.1.34
 Added support to queue a build by ID using the Add-VSTeamBuild function. The Add-VSTeamBuild function also fully qualifies the names of build definitions when you tab complete from command line.
 
-I added new fullname extended property to build definition type.
+I added new full name extended property to build definition type.
 
 Added support so you can update a project by ID as well as by Name.
 ## 0.1.33
 The variable to test if you are on Mac OS changed from IsOSX to IsMacOS. Because I have Set-StrictMode -Version Latest trying to access a variable that is not set will crash.
 
 ## 0.1.32
-Merge [Pull Request](https://github.com/DarqueWarrior/team/pull/16) from [Fergal](https://github.com/ObsidianPhoenix) which included the following:
+Merge [Pull Request](https://github.com/DarqueWarrior/vsteam/pull/16) from [Fergal](https://github.com/ObsidianPhoenix) which included the following:
 
 - Added Support for Build Tags
 - Added the ability to update KeepForever, and the Build Number
 - Added the ability to pull artifact data from the build
 
 ## 0.1.31
-Merge [Pull Request](https://github.com/DarqueWarrior/team/pull/17) from [Kees Verhaar](https://github.com/KeesV) which included the following:
+Merge [Pull Request](https://github.com/DarqueWarrior/vsteam/pull/17) from [Kees Verhaar](https://github.com/KeesV) which included the following:
 
 - Add ProjectName as a property on team member so it can be used further down the pipeline
 
 ## 0.1.30
-Merge [Pull Request](https://github.com/DarqueWarrior/team/pull/15) from [Kees Verhaar](https://github.com/KeesV) which included the following:
+Merge [Pull Request](https://github.com/DarqueWarrior/vsteam/pull/15) from [Kees Verhaar](https://github.com/KeesV) which included the following:
 
 - Add support for teams
 
 ## 0.1.29
-Merge [Pull Request](https://github.com/DarqueWarrior/team/pull/12) from [Andy Neillans](https://github.com/aneillans) which included the following:
+Merge [Pull Request](https://github.com/DarqueWarrior/vsteam/pull/12) from [Andy Neillans](https://github.com/aneillans) which included the following:
 
 - Fixed for on-premise URLS being incorrectly classed as VSTS accounts
 - Fixed for projects validation if you have more than 100 projects
@@ -61,7 +65,7 @@ Added ID to approval default output
 Clearing code analysis warnings
 
 ## 0.1.26
-Merge [Pull Request](https://github.com/DarqueWarrior/team/pull/10) from [Roberto Peña](https://github.com/eulesv) which included the following:
+Merge [Pull Request](https://github.com/DarqueWarrior/vsteam/pull/10) from [Roberto Peña](https://github.com/eulesv) which included the following:
 
 - Adding a regular expression to validate VSTS account
 
@@ -72,7 +76,7 @@ Merge [Pull Request](https://github.com/DarqueWarrior/team/pull/10) from [Robert
 - Added support so you can start a release from a Git commit
 
 ## 0.1.23
-Merge [Pull Request](https://github.com/DarqueWarrior/team/pull/8) from [Michel Perfetti](https://github.com/miiitch) which included the following:
+Merge [Pull Request](https://github.com/DarqueWarrior/vsteam/pull/8) from [Michel Perfetti](https://github.com/miiitch) which included the following:
 
 - Support for the [SonarQube extension](https://marketplace.visualstudio.com/items?itemName=SonarSource.sonarqube)
 
@@ -82,7 +86,7 @@ Merge [Pull Request](https://github.com/DarqueWarrior/team/pull/8) from [Michel 
 ## 0.1.21
 - Added Get-VSTeamBuildLog that returns the logs of the provided build
 
-Merge [Pull Request](https://github.com/DarqueWarrior/team/pull/6)from [Michel Perfetti](https://github.com/miiitch) which included the following:
+Merge [Pull Request](https://github.com/DarqueWarrior/vsteam/pull/6)from [Michel Perfetti](https://github.com/miiitch) which included the following:
 
 - Added serviceEndpoint parameters to Add-VSTeamAzureRMServiceEndpoint cmdlet: if the serviceEndPoint parameters are not specified, the Automatic mode is used
 - The _trackProgress function was changed too to reflect the return code of the api (https://www.visualstudio.com/en-us/docs/integrate/api/endpoints/endpoints)
@@ -92,15 +96,15 @@ Merge [Pull Request](https://github.com/DarqueWarrior/team/pull/6)from [Michel P
 Removed test folder from module
 
 ## 0.1.18
-Merge [Pull Request](https://github.com/DarqueWarrior/team/pull/5) from [Christopher Mank](https://github.com/ChristopherMank) which included the following:
+Merge [Pull Request](https://github.com/DarqueWarrior/vsteam/pull/5) from [Christopher Mank](https://github.com/ChristopherMank) which included the following:
 - Created new function in the release module named 'Add-VSTeamReleaseEnvironment'. New function deploys an environment from an existing release.
 
 ## 0.1.16
-Merge [Pull Request](https://github.com/DarqueWarrior/team/pull/4) from [Andy Neillans](https://github.com/aneillans) which included the following:
+Merge [Pull Request](https://github.com/DarqueWarrior/vsteam/pull/4) from [Andy Neillans](https://github.com/aneillans) which included the following:
 - Bug fix for broken PAT code handling.
 
 ## 0.1.15
-Merge [Pull Request](https://github.com/DarqueWarrior/team/pull/3) from [Andy Neillans](https://github.com/aneillans) which included the following:
+Merge [Pull Request](https://github.com/DarqueWarrior/vsteam/pull/3) from [Andy Neillans](https://github.com/aneillans) which included the following:
 - Corrected typos in help files.
 - Refactored location of common methods.
 - Implemented using DefaultCredentials when using TFS.  This removes the need to create a PAT.

--- a/VSTeam.psd1
+++ b/VSTeam.psd1
@@ -13,7 +13,7 @@
    RootModule        = ''
 
    # Version number of this module.
-   ModuleVersion     = '1.0.3'
+   ModuleVersion     = '1.0.4'
 
    # Supported PSEditions
    # CompatiblePSEditions = @()

--- a/src/serviceendpoints.psm1
+++ b/src/serviceendpoints.psm1
@@ -84,29 +84,32 @@ function _trackProgress {
    $y = 10
 
    $url = _buildURL -projectName $projectName -id $resp.id
-  $isReady = $false
-   # Track status
-    while (-not $isReady) {
-        $status = _checkStatus $url
-        $isReady = $status.isReady;
-        if (-not $isReady) {
-            $operationStatus = $status.operationStatus.state
-      
-            if ($operationStatus -eq "Failed") {
-                Write-Error $status.operationStatus.statusMessage
-                return $false
-            }
-        }
-       
-        # oscillate back a forth to show progress
-        $i += $x
-        Write-Progress -Activity $title -Status $msg -PercentComplete ($i / $y * 100)
+   $isReady = $false
 
-        if ($i -eq $y -or $i -eq 0) {
-            $x *= -1
-        }
-    }
-    return $true
+   # Track status
+   while (-not $isReady) {
+      $status = _checkStatus $url
+      $isReady = $status.isReady;
+
+      if (-not $isReady) {
+         $operationStatus = $status.operationStatus.state
+      
+         if ($operationStatus -eq "Failed") {
+            Write-Error $status.operationStatus.statusMessage
+            return $false
+         }
+      }
+       
+      # oscillate back a forth to show progress
+      $i += $x
+      Write-Progress -Activity $title -Status $msg -PercentComplete ($i / $y * 100)
+
+      if ($i -eq $y -or $i -eq 0) {
+         $x *= -1
+      }
+   }
+   
+   return $true
 }
 
 function Remove-VSTeamServiceEndpoint {
@@ -217,9 +220,11 @@ function Add-VSTeamSonarQubeEndpoint {
          }
          throw
       }
-      $success=_trackProgress -projectName $projectName -resp $resp -title 'Creating Service Endpoint' -msg "Creating $endpointName"
+
+      $success = _trackProgress -projectName $projectName -resp $resp -title 'Creating Service Endpoint' -msg "Creating $endpointName"
+      
       if ($success) {
-          return Get-VSTeamServiceEndpoint -projectName $projectName -id $resp.id
+         return Get-VSTeamServiceEndpoint -projectName $projectName -id $resp.id
       }
    }
 }
@@ -291,10 +296,10 @@ function Add-VSTeamAzureRMServiceEndpoint {
          $resp = Invoke-RestMethod -UserAgent (_getUserAgent) -Method Post -Body $body -ContentType "application/json" -Uri $url -Headers @{Authorization = "Basic $env:TEAM_PAT"}
       }
 
-      $success= _trackProgress -projectName $projectName -resp $resp -title 'Creating Service Endpoint' -msg "Creating $endpointName"
+      $success = _trackProgress -projectName $projectName -resp $resp -title 'Creating Service Endpoint' -msg "Creating $endpointName"
 
       if ($success) {
-          return Get-VSTeamServiceEndpoint -projectName $projectName -id $resp.id
+         return Get-VSTeamServiceEndpoint -projectName $projectName -id $resp.id
       }
    }
 }
@@ -363,8 +368,8 @@ Set-Alias Remove-AzureRMServiceEndpoint Remove-VSTeamServiceEndpoint
 Set-Alias Remove-SonarQubeEndpoint Remove-VSTeamServiceEndpoint
 
 Export-ModuleMember `
- -Function Get-VSTeamServiceEndpoint, Add-VSTeamAzureRMServiceEndpoint, Remove-VSTeamServiceEndpoint, 
-  Add-VSTeamSonarQubeEndpoint `
- -Alias Get-ServiceEndpoint, Add-AzureRMServiceEndpoint, Remove-ServiceEndpoint, Add-SonarQubeEndpoint,
-  Remove-VSTeamAzureRMServiceEndpoint, Remove-VSTeamSonarQubeEndpoint, Remove-AzureRMServiceEndpoint,
-  Remove-SonarQubeEndpoint
+   -Function Get-VSTeamServiceEndpoint, Add-VSTeamAzureRMServiceEndpoint, Remove-VSTeamServiceEndpoint, 
+Add-VSTeamSonarQubeEndpoint `
+   -Alias Get-ServiceEndpoint, Add-AzureRMServiceEndpoint, Remove-ServiceEndpoint, Add-SonarQubeEndpoint,
+Remove-VSTeamAzureRMServiceEndpoint, Remove-VSTeamSonarQubeEndpoint, Remove-AzureRMServiceEndpoint,
+Remove-SonarQubeEndpoint

--- a/src/serviceendpoints.psm1
+++ b/src/serviceendpoints.psm1
@@ -92,9 +92,9 @@ function _trackProgress {
       $isReady = $status.isReady;
 
       if (-not $isReady) {
-         $operationStatus = $status.operationStatus.state
+         $state = $status.operationStatus.state
       
-         if ($operationStatus -eq "Failed") {
+         if ($state -eq "Failed") {
             Write-Error $status.operationStatus.statusMessage
             return $false
          }

--- a/src/serviceendpoints.psm1
+++ b/src/serviceendpoints.psm1
@@ -95,8 +95,7 @@ function _trackProgress {
          $state = $status.operationStatus.state
       
          if ($state -eq "Failed") {
-            Write-Error $status.operationStatus.statusMessage
-            return $false
+            throw $status.operationStatus.statusMessage
          }
       }
        
@@ -108,8 +107,6 @@ function _trackProgress {
          $x *= -1
       }
    }
-   
-   return $true
 }
 
 function Remove-VSTeamServiceEndpoint {
@@ -221,11 +218,9 @@ function Add-VSTeamSonarQubeEndpoint {
          throw
       }
 
-      $success = _trackProgress -projectName $projectName -resp $resp -title 'Creating Service Endpoint' -msg "Creating $endpointName"
+      _trackProgress -projectName $projectName -resp $resp -title 'Creating Service Endpoint' -msg "Creating $endpointName"
       
-      if ($success) {
-         return Get-VSTeamServiceEndpoint -projectName $projectName -id $resp.id
-      }
+      return Get-VSTeamServiceEndpoint -projectName $projectName -id $resp.id
    }
 }
 
@@ -296,11 +291,9 @@ function Add-VSTeamAzureRMServiceEndpoint {
          $resp = Invoke-RestMethod -UserAgent (_getUserAgent) -Method Post -Body $body -ContentType "application/json" -Uri $url -Headers @{Authorization = "Basic $env:TEAM_PAT"}
       }
 
-      $success = _trackProgress -projectName $projectName -resp $resp -title 'Creating Service Endpoint' -msg "Creating $endpointName"
+      _trackProgress -projectName $projectName -resp $resp -title 'Creating Service Endpoint' -msg "Creating $endpointName"
 
-      if ($success) {
-         return Get-VSTeamServiceEndpoint -projectName $projectName -id $resp.id
-      }
+      return Get-VSTeamServiceEndpoint -projectName $projectName -id $resp.id
    }
 }
 

--- a/unit/test/serviceendpoints.Tests.ps1
+++ b/unit/test/serviceendpoints.Tests.ps1
@@ -100,5 +100,40 @@ InModuleScope serviceendpoints {
                 Assert-MockCalled Invoke-RestMethod -Exactly -Scope It -Times 1 -ParameterFilter { $Method -eq 'Post' }
             }
         }
+
+
+
+        Context 'Add-VSTeamAzureRMServiceEndpoint-With-Failure' {
+            Mock Write-Progress
+            Mock Invoke-RestMethod { return @{id = '23233-2342'} } -ParameterFilter { $Method -eq 'Post'}
+            Mock Invoke-RestMethod {
+
+                # This $i is in the module. Because we use InModuleScope
+                # we can see it
+                if ($i -gt 9) {
+                    return @{
+                        isReady         = $false
+                        operationStatus = @{
+                            state = 'Failed'
+                            statusMessage = 'Simulated failed request'
+                        }
+                    }
+                }
+
+                return @{
+                    isReady         = $false
+                    createdBy       = @{}
+                    authorization   = @{}
+                    data            = @{}
+                    operationStatus = @{state = 'InProgress'}
+                }
+            }
+
+            It 'should not create a new AzureRM Serviceendpoint' {
+                Add-VSTeamAzureRMServiceEndpoint -projectName 'project' -displayName 'PM_DonovanBrown' -subscriptionId '121d7d3b-2911-4154-9aa8-65132fe82e74' -subscriptionTenantId '72f988bf-86f1-41af-91ab-2d7cd011db47'
+
+                Assert-MockCalled Invoke-RestMethod -Exactly -Scope It -Times 1 -ParameterFilter { $Method -eq 'Post' }
+            }
+        }
    }
 }

--- a/unit/test/serviceendpoints.Tests.ps1
+++ b/unit/test/serviceendpoints.Tests.ps1
@@ -11,11 +11,11 @@ InModuleScope serviceendpoints {
 
       Context 'Get-VSTeamServiceEndpoint' {
          Mock Invoke-RestMethod { return @{
-               value=@{
-                  createdBy=@{}
-                  authorization=@{}
-                  data=@{}
-                  operationStatus=@{}
+               value = @{
+                  createdBy       = @{}
+                  authorization   = @{}
+                  data            = @{}
+                  operationStatus = @{}
                }
             }}
 
@@ -31,36 +31,36 @@ InModuleScope serviceendpoints {
       Context 'Remove-VSTeamServiceEndpoint' {
          Mock Invoke-RestMethod -UserAgent (_getUserAgent)
 
-         It 'should delete service endpoint'{
+         It 'should delete service endpoint' {
             Remove-VSTeamServiceEndpoint -projectName project -id 5 -Force
 
             Assert-MockCalled Invoke-RestMethod -Exactly -Scope It -Times 1 -ParameterFilter {
                $Uri -eq 'https://test.visualstudio.com/DefaultCollection/project/_apis/distributedtask/serviceendpoints/5?api-version=3.0-preview.1' -and `
-               $Method -eq 'Delete'
+                  $Method -eq 'Delete'
             }
          }
       }
 
       Context 'Add-VSTeamAzureRMServiceEndpoint' {
          Mock Write-Progress
-         Mock Invoke-RestMethod { return @{id='23233-2342'} } -ParameterFilter { $Method -eq 'Post'}
+         Mock Invoke-RestMethod { return @{id = '23233-2342'} } -ParameterFilter { $Method -eq 'Post'}
          Mock Invoke-RestMethod {
 
             # This $i is in the module. Because we use InModuleScope
             # we can see it
             if ($i -gt 9) {
                return @{
-                  isReady=$true
-                  operationStatus=@{state='Ready'}
+                  isReady         = $true
+                  operationStatus = @{state = 'Ready'}
                }
             }
 
             return @{
-               isReady=$false
-               createdBy=@{}
-               authorization=@{}
-               data=@{}
-               operationStatus=@{state='InProgress'}
+               isReady         = $false
+               createdBy       = @{}
+               authorization   = @{}
+               data            = @{}
+               operationStatus = @{state = 'InProgress'}
             }
          }
 
@@ -71,69 +71,73 @@ InModuleScope serviceendpoints {
          }
       }
 
-        Context 'Add-VSTeamSonarQubeEndpoint' {
-            Mock Write-Progress
-            Mock Invoke-RestMethod { return @{id = '23233-2342'} } -ParameterFilter { $Method -eq 'Post'}
-            Mock Invoke-RestMethod {
+      Context 'Add-VSTeamSonarQubeEndpoint' {
+         Mock Write-Progress
+         Mock Invoke-RestMethod { return @{id = '23233-2342'} } -ParameterFilter { $Method -eq 'Post'}
+         Mock Invoke-RestMethod {
 
-                # This $i is in the module. Because we use InModuleScope
-                # we can see it
-                if ($i -gt 9) {
-                    return @{
-                        isReady         = $true
-                        operationStatus = @{state = 'Ready'}
-                    }
-                }
-
-                return @{
-                    isReady         = $false
-                    createdBy       = @{}
-                    authorization   = @{}
-                    data            = @{}
-                    operationStatus = @{state = 'InProgress'}
-                }
+            # This $i is in the module. Because we use InModuleScope
+            # we can see it
+            if ($i -gt 9) {
+               return @{
+                  isReady         = $true
+                  operationStatus = @{state = 'Ready'}
+               }
             }
 
-            It 'should create a new SonarQube Serviceendpoint' {
-                Add-VSTeamSonarQubeEndpoint -projectName 'project' -endpointName 'PM_DonovanBrown' -sonarqubeUrl 'http://mysonarserver.local' -personalAccessToken '72f988bf-86f1-41af-91ab-2d7cd011db47'
-
-                Assert-MockCalled Invoke-RestMethod -Exactly -Scope It -Times 1 -ParameterFilter { $Method -eq 'Post' }
+            return @{
+               isReady         = $false
+               createdBy       = @{}
+               authorization   = @{}
+               data            = @{}
+               operationStatus = @{state = 'InProgress'}
             }
-        }
+         }
+
+         It 'should create a new SonarQube Serviceendpoint' {
+            Add-VSTeamSonarQubeEndpoint -projectName 'project' -endpointName 'PM_DonovanBrown' -sonarqubeUrl 'http://mysonarserver.local' -personalAccessToken '72f988bf-86f1-41af-91ab-2d7cd011db47'
+
+            Assert-MockCalled Invoke-RestMethod -Exactly -Scope It -Times 1 -ParameterFilter { $Method -eq 'Post' }
+         }
+      }
 
 
 
-        Context 'Add-VSTeamAzureRMServiceEndpoint-With-Failure' {
-            Mock Write-Progress
-            Mock Invoke-RestMethod { return @{id = '23233-2342'} } -ParameterFilter { $Method -eq 'Post'}
-            Mock Invoke-RestMethod {
+      Context 'Add-VSTeamAzureRMServiceEndpoint-With-Failure' {
+         Mock Write-Progress
+         Mock Invoke-RestMethod { return @{id = '23233-2342'} } -ParameterFilter { $Method -eq 'Post'}
+         Mock Invoke-RestMethod {
 
-                # This $i is in the module. Because we use InModuleScope
-                # we can see it
-                if ($i -gt 9) {
-                    return @{
-                        isReady         = $false
-                        operationStatus = @{
-                            state = 'Failed'
-                            statusMessage = 'Simulated failed request'
-                        }
-                    }
-                }
-
-                return @{
-                    isReady         = $false
-                    createdBy       = @{}
-                    authorization   = @{}
-                    data            = @{}
-                    operationStatus = @{state = 'InProgress'}
-                }
+            # This $i is in the module. Because we use InModuleScope
+            # we can see it
+            if ($i -gt 9) {
+               return @{
+                  isReady         = $false
+                  operationStatus = @{
+                     state         = 'Failed'
+                     statusMessage = 'Simulated failed request'
+                  }
+               }
             }
 
-            It 'should not create a new AzureRM Serviceendpoint' {
-                Add-VSTeamAzureRMServiceEndpoint -projectName 'project' -displayName 'PM_DonovanBrown' -subscriptionId '121d7d3b-2911-4154-9aa8-65132fe82e74' -subscriptionTenantId '72f988bf-86f1-41af-91ab-2d7cd011db47'
-
-                Assert-MockCalled Invoke-RestMethod -Exactly -Scope It -Times 1 -ParameterFilter { $Method -eq 'Post' }
+            return @{
+               isReady         = $false
+               createdBy       = @{}
+               authorization   = @{}
+               data            = @{}
+               operationStatus = @{state = 'InProgress'}
             }
-        }
+         }
+
+         It 'should not create a new AzureRM Serviceendpoint' {
+            {
+               Add-VSTeamAzureRMServiceEndpoint -projectName 'project' `
+                  -displayName 'PM_DonovanBrown' -subscriptionId '121d7d3b-2911-4154-9aa8-65132fe82e74' `
+                  -subscriptionTenantId '72f988bf-86f1-41af-91ab-2d7cd011db47'
+            } | Should Throw
+
+            Assert-MockCalled Invoke-RestMethod -Exactly -Scope It -Times 1 -ParameterFilter { $Method -eq 'Post' }
+         }
+      }
    }
 }


### PR DESCRIPTION
If and endpoint creation failed, the status of the endpoint is kept at $false and the _trackProgress method never ends.

If the status is $false, I add a check on the operational status to verify if the creation is still in progress. If there is a failure I write the failure message on the error output