### PR TITLE
Build sourcebranchname

### DIFF
--- a/.docs/Add-VSTeamBuild.md
+++ b/.docs/Add-VSTeamBuild.md
@@ -11,20 +11,21 @@
 ### ByName (Default)
 
 ```powershell
-Add-VSTeamBuild [-ProjectName] <String> [-BuildDefinitionName <String>] [-QueueName <String>] [-BuildParameters <System.Collections.Hashtable>]
+Add-VSTeamBuild [-ProjectName] <String> [-BuildDefinitionName <String>] [-QueueName <String>] [-SourceBranch <String>] [-BuildParameters <System.Collections.Hashtable>]
 ```
 
 ### ByID
 
 ```powershell
-Add-VSTeamBuild [-ProjectName] <String> [-BuildDefinitionId <Int32>] [-QueueName <String>] [-BuildParameters <System.Collections.Hashtable>]
+Add-VSTeamBuild [-ProjectName] <String> [-BuildDefinitionId <Int32>] [-QueueName <String>] [-SourceBranch <String>] [-BuildParameters <System.Collections.Hashtable>]
 ```
 
 ## DESCRIPTION
 
 Add-VSTeamBuild will queue a new build.
 
-You can override the queue in the build defintion by using the QueueName
+You can override the default queue in the build defintion by using the QueueName
+parameter. You can override the default source branch by using the SourceBranch
 parameter. You can also set specific build parameters by using the BuildParameters
 parameter.
 
@@ -47,6 +48,19 @@ Demo-CI           Demo-CI-45   notStarted
 This example sets the default project so you can tab complete the BuildDefinition parameter.
 
 ### -------------------------- EXAMPLE 2 --------------------------
+
+```powershell
+PS C:\> Set-VSTeamDefaultProject Demo
+PS C:\> Add-VSTeamBuild -BuildDefinition Demo-CI -SourceBranch 'refs/heads/develop'
+
+Build Definition Build Number  Status     Result
+---------------- ------------  ------     ------
+Demo-CI           Demo-CI-45   notStarted
+```
+
+This example queues the build for the 'develop' branch, overriding the default branch in the build definition.
+
+### -------------------------- EXAMPLE 3 --------------------------
 
 ```powershell
 PS C:\> Set-VSTeamDefaultProject Demo
@@ -111,6 +125,22 @@ Accept pipeline input: True (ByPropertyName)
 Accept wildcard characters: False
 ```
 
+### -SourceBranch
+
+Which source branch to use for this build. Overrides default branch in build definition.
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases: 
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
 ### -BuildParameters
 
 A hashtable with build parameters.
@@ -140,6 +170,10 @@ Build Defintion ID
 ### System.String
 
 Queue Name
+
+### System.String
+
+Source Branch
 
 ### System.Collections.Hashtable
 

--- a/.docs/Add-VSTeamBuild.md
+++ b/.docs/Add-VSTeamBuild.md
@@ -24,7 +24,7 @@ Add-VSTeamBuild [-ProjectName] <String> [-BuildDefinitionId <Int32>] [-QueueName
 
 Add-VSTeamBuild will queue a new build.
 
-You can override the default queue in the build defintion by using the QueueName
+You can override the queue in the build defintion by using the QueueName
 parameter. You can override the default source branch by using the SourceBranch
 parameter. You can also set specific build parameters by using the BuildParameters
 parameter.

--- a/.docs/Add-VSTeamBuild.md
+++ b/.docs/Add-VSTeamBuild.md
@@ -51,7 +51,7 @@ This example sets the default project so you can tab complete the BuildDefinitio
 
 ```powershell
 PS C:\> Set-VSTeamDefaultProject Demo
-PS C:\> Add-VSTeamBuild -BuildDefinition Demo-CI -SourceBranch 'refs/heads/develop'
+PS C:\> Add-VSTeamBuild -BuildDefinition Demo-CI -SourceBranch refs/heads/develop
 
 Build Definition Build Number  Status     Result
 ---------------- ------------  ------     ------

--- a/VSTeam.psd1
+++ b/VSTeam.psd1
@@ -13,7 +13,7 @@
    RootModule        = ''
 
    # Version number of this module.
-   ModuleVersion     = '2.1.9'
+   ModuleVersion     = '2.1.10'
 
    # Supported PSEditions
    # CompatiblePSEditions = @()

--- a/src/builds.psm1
+++ b/src/builds.psm1
@@ -193,6 +193,9 @@ function Add-VSTeamBuild {
       [Int32] $BuildDefinitionId,
 
       [Parameter(Mandatory = $false)]
+      [string] $SourceBranch,
+
+      [Parameter(Mandatory = $false)]
       [hashtable] $BuildParameters
    )
    DynamicParam {
@@ -259,6 +262,10 @@ function Add-VSTeamBuild {
             Select-Object -ExpandProperty Id
 
          $body.Add('queue', @{ id = $queueId })
+      }
+
+      if ($SourceBranch) {
+         $body.Add('sourceBranch', $SourceBranch)
       }
 
       if ($BuildParameters) {

--- a/unit/test/builds.Tests.ps1
+++ b/unit/test/builds.Tests.ps1
@@ -523,7 +523,7 @@ InModuleScope builds {
 
          $Global:PSDefaultParameterValues["*:projectName"] = 'Project'
 
-         Add-VSTeamBuild -projectName project -BuildDefinitionId 2 -QueueName MyQueue -BuildParameters @{'system.debug'='true'}
+         Add-VSTeamBuild -projectName project -BuildDefinitionId 2 -QueueName MyQueue -SourceBranch refs/heads/dev
 
          It 'should add build' {
             # Call to queue build.


### PR DESCRIPTION
Added optional -SourceBranch parameter to Add-VSTeamBuild. Setting this overrides the default source branch set in the build definition for the build.