### PR TITLE
handle unsupported api for service fabric endpoints

### DIFF
--- a/integration/test/010_projects.Tests.ps1
+++ b/integration/test/010_projects.Tests.ps1
@@ -192,11 +192,6 @@ Describe 'VSTeam Integration Tests' {
                -subscriptionId '00000000-0000-0000-0000-000000000000' -subscriptionTenantId '00000000-0000-0000-0000-000000000000' `
                -servicePrincipalId '00000000-0000-0000-0000-000000000000' -servicePrincipalKey 'fakekey' } | Should Not Throw
       }
-
-      It 'Add-VSTeamServiceFabricEndpoint Should add servcie endpoint' {
-            { Add-VSTeamServiceFabricEndpoint -ProjectName $newProjectName -endpointName 'ServiceFabricTestEndoint' `
-            -url "tcp://10.0.0.1:19000" -useWindowsSecurity $false } | Should Not Be $null 
-      }
       
       It 'Get-VSTeamServiceEndpoint Should return service endpoints' {
          $actual = Get-VSTeamServiceEndpoint -ProjectName $newProjectName
@@ -208,6 +203,19 @@ Describe 'VSTeam Integration Tests' {
          Get-VSTeamServiceEndpoint -ProjectName $newProjectName | Remove-VSTeamServiceEndpoint -ProjectName $newProjectName -Force
 
          Get-VSTeamServiceEndpoint -ProjectName $newProjectName | Should Be $null
+      }
+
+      # Not supported on TFS 2017
+      if ($api -ne 'TFS2017') {
+         It 'Add-VSTeamServiceFabricEndpoint Should add servcie endpoint' {
+            { Add-VSTeamServiceFabricEndpoint -ProjectName $newProjectName -endpointName 'ServiceFabricTestEndoint' `
+                  -url "tcp://10.0.0.1:19000" -useWindowsSecurity $false } | Should Not Be $null 
+         }
+      } else {
+         It 'Add-VSTeamServiceFabricEndpoint not supported on TFS2017 Should throw' {
+            { Add-VSTeamServiceFabricEndpoint -ProjectName $newProjectName -endpointName 'ServiceFabricTestEndoint' `
+                  -url "tcp://10.0.0.1:19000" -useWindowsSecurity $false } | Should Throw
+         }
       }
    }
 

--- a/integration/test/010_projects.Tests.ps1
+++ b/integration/test/010_projects.Tests.ps1
@@ -195,7 +195,7 @@ Describe 'VSTeam Integration Tests' {
 
       It 'Add-VSTeamServiceFabricEndpoint Should add servcie endpoint' {
             { Add-VSTeamServiceFabricEndpoint -ProjectName $newProjectName -endpointName 'ServiceFabricTestEndoint' `
-            -url "tcp://10.0.0.1:19000" -useWindowsSecurity $false } | Should Not Throw
+            -url "tcp://10.0.0.1:19000" -useWindowsSecurity $false } | Should Not Be $null 
       }
       
       It 'Get-VSTeamServiceEndpoint Should return service endpoints' {

--- a/src/serviceendpoints.psm1
+++ b/src/serviceendpoints.psm1
@@ -65,6 +65,12 @@ function _trackProgress {
    }
 }
 
+function _supportsServiceFabricEndpoint {
+   if (-not $VSTeamVersionTable.ServiceFabricEndpoint) {
+       throw 'This account does not support Service Fabric endpoints.'
+   } 
+}
+
 function Remove-VSTeamServiceEndpoint {
    [CmdletBinding(SupportsShouldProcess = $true, ConfirmImpact = "High")]
    param(
@@ -262,6 +268,10 @@ function Add-VSTeamServiceFabricEndpoint {
    }
 
    Process {
+
+      # This will throw if this account does not support ServiceFabricEndpoint
+      _supportsServiceFabricEndpoint
+
       # Bind the parameter to a friendly variable
       $ProjectName = $PSBoundParameters["ProjectName"]
 
@@ -315,7 +325,7 @@ function Add-VSTeamServiceFabricEndpoint {
             
       # Call the REST API
       $resp = _callAPI -ProjectName $projectName -Area 'distributedtask' -Resource 'serviceendpoints'  `
-         -Method Post -ContentType 'application/json' -body $body -Version $VSTeamVersionTable.DistributedTask
+         -Method Post -ContentType 'application/json' -body $body -Version $VSTeamVersionTable.ServiceFabricEndpoint
 
       _trackProgress -projectName $projectName -resp $resp -title 'Creating Service Endpoint' -msg "Creating $endpointName"
 

--- a/src/team.psm1
+++ b/src/team.psm1
@@ -373,6 +373,7 @@ function Set-VSTeamAPIVersion {
             $VSTeamVersionTable.DistributedTask = '4.0-preview'
             $VSTeamVersionTable.Tfvc = '3.2'
             $VSTeamVersionTable.MemberEntitlementManagement = ''
+            $VSTeamVersionTable.ServiceFabricEndpoint = '3.2'
          }
          'VSTS' { 
             $VSTeamVersionTable.Version = 'VSTS'
@@ -383,6 +384,7 @@ function Set-VSTeamAPIVersion {
             $VSTeamVersionTable.DistributedTask = '4.1-preview'
             $VSTeamVersionTable.Tfvc = '4.0'
             $VSTeamVersionTable.MemberEntitlementManagement = '4.1-preview'
+            $VSTeamVersionTable.ServiceFabricEndpoint = '4.1-preview'
          }
          Default {
             $VSTeamVersionTable.Version = 'TFS2017'
@@ -393,6 +395,7 @@ function Set-VSTeamAPIVersion {
             $VSTeamVersionTable.DistributedTask = '3.0-preview'
             $VSTeamVersionTable.Tfvc = '3.0'
             $VSTeamVersionTable.MemberEntitlementManagement = ''
+            $VSTeamVersionTable.ServiceFabricEndpoint = ''
          }
       }
    }
@@ -405,6 +408,7 @@ function Set-VSTeamAPIVersion {
    Write-Verbose "DistributedTask: $($VSTeamVersionTable.DistributedTask)"
    Write-Verbose "Tfvc: $($VSTeamVersionTable.Tfvc)"
    Write-Verbose "MemberEntitlementManagement: $($VSTeamVersionTable.MemberEntitlementManagement)"
+   Write-Verbose "ServiceFabricEndpoint: $($VSTeamVersionTable.ServiceFabricEndpoint)"
 }
 
 function Invoke-VSTeamRequest {
@@ -457,6 +461,7 @@ $Global:VSTeamVersionTable = @{
    'DistributedTask'             = '3.0-preview'
    'Tfvc'                        = '3.0'
    'MemberEntitlementManagement' = ''
+   'ServiceFabricEndpoint'       = ''
    'ModuleVersion'               = _getModuleVersion
 }
 

--- a/unit/test/serviceendpoints.Tests.ps1
+++ b/unit/test/serviceendpoints.Tests.ps1
@@ -7,6 +7,21 @@ Import-Module $PSScriptRoot\..\..\src\serviceendpoints.psm1 -Force
 InModuleScope serviceendpoints {
     $VSTeamVersionTable.Account = 'https://test.visualstudio.com'
 
+
+    Describe 'ServiceEndpoints TFS2017 Errors'{
+      
+      Context 'Add-VSTeamServiceFabricEndpoint' {  
+         Mock ConvertTo-Json { throw 'Should not be called' } -Verifiable
+         
+         It 'Should throw' {
+             { Add-VSTeamServiceFabricEndpoint -projectName 'project' -endpointName 'PM_DonovanBrown' -url "tcp://0.0.0.0:19000" -useWindowsSecurity $false } | Should Throw
+         }
+         
+         It 'ConvertTo-Json should not be called' {
+            Assert-MockCalled ConvertTo-Json -Exactly 0 
+         }
+     }
+    }
     Describe 'ServiceEndpoints' {
         . "$PSScriptRoot\mockProjectNameDynamicParamNoPSet.ps1"
 
@@ -72,102 +87,6 @@ InModuleScope serviceendpoints {
 
             It 'should create a new AzureRM Serviceendpoint' {
                 Add-VSTeamAzureRMServiceEndpoint -projectName 'project' -displayName 'PM_DonovanBrown' -subscriptionId '00000000-0000-0000-0000-000000000000' -subscriptionTenantId '00000000-0000-0000-0000-000000000000'
-
-                Assert-MockCalled Invoke-RestMethod -Exactly -Scope It -Times 1 -ParameterFilter { $Method -eq 'Post' }
-            }
-        }
-
-        Context 'Add-VSTeamServiceFabricEndpoint' {
-            Mock Write-Progress
-            Mock Invoke-RestMethod { return @{id = '23233-2342'} } -ParameterFilter { $Method -eq 'Post'}
-            Mock Invoke-RestMethod {
-   
-                # This $i is in the module. Because we use InModuleScope
-                # we can see it
-                if ($i -gt 9) {
-                    return @{
-                        isReady         = $true
-                        operationStatus = @{state = 'Ready'}
-                    }
-                }
-   
-                return @{
-                    isReady         = $false
-                    createdBy       = @{}
-                    authorization   = @{}
-                    data            = @{}
-                    operationStatus = @{state = 'InProgress'}
-                }
-            }
-   
-            It 'should create a new Service Fabric Serviceendpoint' {
-                Add-VSTeamServiceFabricEndpoint -projectName 'project' -endpointName 'PM_DonovanBrown' -url "tcp://0.0.0.0:19000" -useWindowsSecurity $false
-   
-                Assert-MockCalled Invoke-RestMethod -Exactly -Scope It -Times 1 -ParameterFilter { $Method -eq 'Post' }
-            }
-        }
-
-        Context 'Add-VSTeamServiceFabricEndpoint with AzureAD authentication' {
-            Mock Write-Progress
-            Mock Invoke-RestMethod { return @{id = '23233-2342'} } -ParameterFilter { $Method -eq 'Post'}
-            Mock Invoke-RestMethod {
-
-                # This $i is in the module. Because we use InModuleScope
-                # we can see it
-                if ($i -gt 9) {
-                    return [PSCustomObject]@{
-                        isReady         = $true
-                        operationStatus = [PSCustomObject]@{state = 'Ready'}
-                    }
-                }
-
-                return [PSCustomObject]@{
-                    isReady         = $false
-                    createdBy       = [PSCustomObject]@{}
-                    authorization   = [PSCustomObject]@{}
-                    data            = [PSCustomObject]@{}
-                    operationStatus = [PSCustomObject]@{state = 'InProgress'}
-                }
-            }
-
-            It 'should create a new Service Fabric Serviceendpoint' {
-                $password = '00000000-0000-0000-0000-000000000000' | ConvertTo-SecureString -AsPlainText -Force
-                $username = "Test User"
-                $serverCertThumbprint = "0000000000000000000000000000000000000000"
-                Add-VSTeamServiceFabricEndpoint -projectName 'project' -endpointName 'PM_DonovanBrown' -url "tcp://0.0.0.0:19000" -username $username -password $password -serverCertThumbprint $serverCertThumbprint
-
-                Assert-MockCalled Invoke-RestMethod -Exactly -Scope It -Times 1 -ParameterFilter { $Method -eq 'Post' }
-            }
-        }
-
-        Context 'Add-VSTeamServiceFabricEndpoint with Certificate authentication' {
-            Mock Write-Progress
-            Mock Invoke-RestMethod { return @{id = '23233-2342'} } -ParameterFilter { $Method -eq 'Post'}
-            Mock Invoke-RestMethod {
-
-                # This $i is in the module. Because we use InModuleScope
-                # we can see it
-                if ($i -gt 9) {
-                    return [PSCustomObject]@{
-                        isReady         = $true
-                        operationStatus = [PSCustomObject]@{state = 'Ready'}
-                    }
-                }
-
-                return [PSCustomObject]@{
-                    isReady         = $false
-                    createdBy       = [PSCustomObject]@{}
-                    authorization   = [PSCustomObject]@{}
-                    data            = [PSCustomObject]@{}
-                    operationStatus = [PSCustomObject]@{state = 'InProgress'}
-                }
-            }
-
-            It 'should create a new Service Fabric Serviceendpoint' {
-                $password = '00000000-0000-0000-0000-000000000000' | ConvertTo-SecureString -AsPlainText -Force
-                $base64Cert = "0000000000000000000000000000000000000000"
-                $serverCertThumbprint = "0000000000000000000000000000000000000000"
-                Add-VSTeamServiceFabricEndpoint -projectName 'project' -endpointName 'PM_DonovanBrown' -url "tcp://0.0.0.0:19000" -serverCertThumbprint $serverCertThumbprint -certificate $base64Cert -certificatePassword $password
 
                 Assert-MockCalled Invoke-RestMethod -Exactly -Scope It -Times 1 -ParameterFilter { $Method -eq 'Post' }
             }
@@ -271,5 +190,107 @@ InModuleScope serviceendpoints {
                 Assert-MockCalled Invoke-RestMethod -Exactly -Scope It -Times 1 -ParameterFilter { $Method -eq 'Post' }
             }
         }
+    }
+
+    Describe 'ServiceEndpoints VSTS' {
+      . "$PSScriptRoot\mockProjectNameDynamicParamNoPSet.ps1"
+
+      $VSTeamVersionTable.ServiceFabricEndpoint = '4.1-preview'
+
+      Context 'Add-VSTeamServiceFabricEndpoint' {
+         Mock Write-Progress
+         Mock Invoke-RestMethod { return @{id = '23233-2342'} } -ParameterFilter { $Method -eq 'Post'}
+         Mock Invoke-RestMethod {
+
+             # This $i is in the module. Because we use InModuleScope
+             # we can see it
+             if ($i -gt 9) {
+                 return @{
+                     isReady         = $true
+                     operationStatus = @{state = 'Ready'}
+                 }
+             }
+
+             return @{
+                 isReady         = $false
+                 createdBy       = @{}
+                 authorization   = @{}
+                 data            = @{}
+                 operationStatus = @{state = 'InProgress'}
+             }
+         }
+
+         It 'should create a new Service Fabric Serviceendpoint' {
+             Add-VSTeamServiceFabricEndpoint -projectName 'project' -endpointName 'PM_DonovanBrown' -url "tcp://0.0.0.0:19000" -useWindowsSecurity $false
+
+             Assert-MockCalled Invoke-RestMethod -Exactly -Scope It -Times 1 -ParameterFilter { $Method -eq 'Post' }
+         }
+     }
+
+     Context 'Add-VSTeamServiceFabricEndpoint with AzureAD authentication' {
+         Mock Write-Progress
+         Mock Invoke-RestMethod { return @{id = '23233-2342'} } -ParameterFilter { $Method -eq 'Post'}
+         Mock Invoke-RestMethod {
+
+             # This $i is in the module. Because we use InModuleScope
+             # we can see it
+             if ($i -gt 9) {
+                 return [PSCustomObject]@{
+                     isReady         = $true
+                     operationStatus = [PSCustomObject]@{state = 'Ready'}
+                 }
+             }
+
+             return [PSCustomObject]@{
+                 isReady         = $false
+                 createdBy       = [PSCustomObject]@{}
+                 authorization   = [PSCustomObject]@{}
+                 data            = [PSCustomObject]@{}
+                 operationStatus = [PSCustomObject]@{state = 'InProgress'}
+             }
+         }
+
+         It 'should create a new Service Fabric Serviceendpoint' {
+             $password = '00000000-0000-0000-0000-000000000000' | ConvertTo-SecureString -AsPlainText -Force
+             $username = "Test User"
+             $serverCertThumbprint = "0000000000000000000000000000000000000000"
+             Add-VSTeamServiceFabricEndpoint -projectName 'project' -endpointName 'PM_DonovanBrown' -url "tcp://0.0.0.0:19000" -username $username -password $password -serverCertThumbprint $serverCertThumbprint
+
+             Assert-MockCalled Invoke-RestMethod -Exactly -Scope It -Times 1 -ParameterFilter { $Method -eq 'Post' }
+         }
+     }
+
+     Context 'Add-VSTeamServiceFabricEndpoint with Certificate authentication' {
+         Mock Write-Progress
+         Mock Invoke-RestMethod { return @{id = '23233-2342'} } -ParameterFilter { $Method -eq 'Post'}
+         Mock Invoke-RestMethod {
+
+             # This $i is in the module. Because we use InModuleScope
+             # we can see it
+             if ($i -gt 9) {
+                 return [PSCustomObject]@{
+                     isReady         = $true
+                     operationStatus = [PSCustomObject]@{state = 'Ready'}
+                 }
+             }
+
+             return [PSCustomObject]@{
+                 isReady         = $false
+                 createdBy       = [PSCustomObject]@{}
+                 authorization   = [PSCustomObject]@{}
+                 data            = [PSCustomObject]@{}
+                 operationStatus = [PSCustomObject]@{state = 'InProgress'}
+             }
+         }
+
+         It 'should create a new Service Fabric Serviceendpoint' {
+             $password = '00000000-0000-0000-0000-000000000000' | ConvertTo-SecureString -AsPlainText -Force
+             $base64Cert = "0000000000000000000000000000000000000000"
+             $serverCertThumbprint = "0000000000000000000000000000000000000000"
+             Add-VSTeamServiceFabricEndpoint -projectName 'project' -endpointName 'PM_DonovanBrown' -url "tcp://0.0.0.0:19000" -serverCertThumbprint $serverCertThumbprint -certificate $base64Cert -certificatePassword $password
+
+             Assert-MockCalled Invoke-RestMethod -Exactly -Scope It -Times 1 -ParameterFilter { $Method -eq 'Post' }
+         }
+     }
     }
 }


### PR DESCRIPTION
as per @DarqueWarrior  comment on #52, this prevents TFS2017 accounts from using the service farbic endpoint cmdlet, as it is not supported.