### PR TITLE
adapt integration test to additional VSTS pool 'Hosted Ubuntu 1604'

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,12 @@ The cases of every file is very important. This module is to be used on Windows,
 
 ## Release Notes
 
+### 3.0.3
+
+Merged [Pull Request](https://github.com/DarqueWarrior/vsteam/pull/66) from [Kai Walter](https://github.com/KaiWalter) which included the following:
+
+Updated integration tests to account for the new hosted agent pool.
+
 ### 3.0.2
 
 Added Get-VSTeamGitRef to retrieve the branches for adding Pull Request support in the future.

--- a/VSTeam.psd1
+++ b/VSTeam.psd1
@@ -13,7 +13,7 @@
    RootModule        = ''
 
    # Version number of this module.
-   ModuleVersion     = '3.0.2'
+   ModuleVersion     = '3.0.3'
 
    # Supported PSEditions
    # CompatiblePSEditions = @()

--- a/integration/test/010_projects.Tests.ps1
+++ b/integration/test/010_projects.Tests.ps1
@@ -162,7 +162,7 @@ Describe 'VSTeam Integration Tests' -Tag 'integration' {
             $actual.name | Should Be 'Default'
          }
          else {
-            $actual.Count | Should Be 5
+            $actual.Count | Should Be 6
          }
       }
    }
@@ -177,7 +177,7 @@ Describe 'VSTeam Integration Tests' -Tag 'integration' {
          }
          else {
             $global:queueId = $actual[0].id
-            $actual.Count | Should Be 5
+            $actual.Count | Should Be 6
          }
       }
 
@@ -234,7 +234,7 @@ Describe 'VSTeam Integration Tests' -Tag 'integration' {
 
       # Not supported on TFS 2017
       if ($api -ne 'TFS2017') {
-         It 'Add-VSTeamServiceFabricEndpoint Should add servcie endpoint' {
+         It 'Add-VSTeamServiceFabricEndpoint Should add service endpoint' {
             { Add-VSTeamServiceFabricEndpoint -ProjectName $newProjectName -endpointName 'ServiceFabricTestEndoint' `
                   -url "tcp://10.0.0.1:19000" -useWindowsSecurity $false } | Should Not Be $null
          }


### PR DESCRIPTION
# PR Summary

VSTS now has 6 agent pools / queues which breaks the integration test
