### PR TITLE
Adding Update-VSTeamProfile.

### DIFF
--- a/.docs/Update-VSTeamProfile.md
+++ b/.docs/Update-VSTeamProfile.md
@@ -1,0 +1,89 @@
+<!-- #include "./common/header.md" -->
+
+# Update-VSTeamProfile
+
+## SYNOPSIS
+
+<!-- #include "./synopsis/Update-VSTeamProfile.md" -->
+
+## SYNTAX
+
+## DESCRIPTION
+
+## EXAMPLES
+
+### -------------------------- EXAMPLE 1 --------------------------
+
+```PowerShell
+PS C:\> Update-VSTeamProfile -Name ProfileName
+```
+
+You will be prompted for the account name and personal access token.
+
+### -------------------------- EXAMPLE 2 --------------------------
+
+```PowerShell
+PS C:\> Update-VSTeamProfile -Name mydemos -PersonalAccessToken 7a8ilh6db4aforlrnrqmdrxdztkjvcc4uhlh5vgbteserp3mziwnga
+```
+
+Allows you to provide all the information on the command line.
+
+### -------------------------- EXAMPLE 3 --------------------------
+
+```PowerShell
+PS C:\> Get-VSTeamProfile | Where-Object version -eq vsts | Select-Object -skip 1 | Update-VSTeamProfile -PersonalAccessToken 7a8ilh6db4aforlrnrqmdrxdztkjvcc4uhlh5vgbteserp3mziwnga -Force
+```
+
+This will update all but the first VSTS profile
+
+## PARAMETERS
+
+### -PAT
+
+A secured string to capture your personal access token.
+
+This will allow you to provide your personal access token
+without displaying it in plain text.
+
+To use pat simply omit it from the Update-VSTeamProfile command.
+
+```yaml
+Type: SecureString
+Parameter Sets: Secure
+Required: True
+```
+
+### -PersonalAccessToken
+
+The personal access token from VSTS/TFS to use to access this account.
+
+```yaml
+Type: String
+Parameter Sets: Plain
+Required: True
+Position: 2
+```
+
+### -Name
+
+Name of the profile to be updated
+
+```yaml
+Type: String
+Required: True
+Position: 3
+```
+
+<!-- #include "./params/Force.md" -->
+
+## INPUTS
+
+## OUTPUTS
+
+## NOTES
+
+## RELATED LINKS
+
+[Update-VSTeamAccount](Add-VSTeamAccount.md)
+
+[Set-VSTeamDefaultProject](Set-VSTeamDefaultProject.md)

--- a/.docs/synopsis/Update-VSTeamProfile.md
+++ b/.docs/synopsis/Update-VSTeamProfile.md
@@ -1,0 +1,1 @@
+Allows you to update the Personal Access Token for your profile.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,24 @@
 # Changelog
 
+## 3.0.6
+
+Added Update-VSTeamProfile to allow easy updating of the PAT for each profile.
+
+## 3.0.5
+
+Merged [Pull Request 70](https://github.com/DarqueWarrior/vsteam/pull/70) and [Pull Request 72](https://github.com/DarqueWarrior/vsteam/pull/72) from [Geert van der Cruijsen](https://github.com/Geertvdc) which included the following:
+
+- Added a function to remove vsts agents from a pool by calling Remove-Agent or Remove-VSTeamAgent
+- Disable & Enable agents in pool
+
+Add [Pull Request 70](https://github.com/DarqueWarrior/vsteam/pull/71) from [Kai Walter](https://github.com/KaiWalter) which included the following:
+
+Integration tests for Build Definitions
+
+## 3.0.4
+
+The ProjectName dynamic parameter that enables Tab Complete of project names was getting called approximately 20 times when tab completing a function name. To reduce the number of calls a rudimentary cache was put in place.
+
 ## 3.0.3
 
 Merged [Pull Request](https://github.com/DarqueWarrior/vsteam/pull/66) from [Kai Walter](https://github.com/KaiWalter) which included the following:
@@ -63,7 +82,7 @@ Account
       - Ref1
       - Ref2
 
-Polished the classes defined for the provider. Also updated some of the fucntions to return the same classes as the provider.  The classes all have a hidden _internalObj property that contains the raw object returned from the REST API call. Not all the properties of the object are exposed via properties of the class. This property will provide access to them if you need them.
+Polished the classes defined for the provider. Also updated some of the functions to return the same classes as the provider.  The classes all have a hidden _internalObj property that contains the raw object returned from the REST API call. Not all the properties of the object are exposed via properties of the class. This property will provide access to them if you need them.
 
 Updated the format.ps1xml files to show more data when the provider is used and to format the provider output to be more consistent with a normal file system. The + and . modes were replaced with d----- and ----- for directories and leafs.
 
@@ -191,7 +210,7 @@ Removed the External Module Dependencies so SHiPS is installed with the module.
 
 ## 2.1.0
 
-Lots of code refactorying and clean up.
+Lots of code refactoring and clean up.
 
 Replaced Add-VSTeamReleaseEnvironment with Set-VSTeamEnvironmentStatus.
 

--- a/README.md
+++ b/README.md
@@ -53,3 +53,11 @@ During the release the module is installed on macOS, Linux and Window and tested
 ## Change Log
 
 [Change Log](CHANGELOG.md)
+
+## Maintainers
+
+- [Donovan Brown](https://github.com/darquewarrior) - [@DonovanBrown](https://twitter.com/DonovanBrown)
+
+## License
+
+This project is [licensed under the MIT License](LICENSE).

--- a/VSTeam.psd1
+++ b/VSTeam.psd1
@@ -13,7 +13,7 @@
    RootModule        = ''
 
    # Version number of this module.
-   ModuleVersion     = '3.0.5'
+   ModuleVersion     = '3.0.6'
 
    # Supported PSEditions
    # CompatiblePSEditions = @()
@@ -205,7 +205,8 @@
       'Get-VSTeamAgent',
       'Remove-VSTeamAgent',
       'Enable-VSTeamAgent',
-      'Disable-VSTeamAgent')
+      'Disable-VSTeamAgent',
+      'Update-VSTeamProfile')
 
    # Cmdlets to export from this module, for best performance, do not use wildcards and do not delete the entry, use an empty array if there are no cmdlets to export.
    # CmdletsToExport = @()
@@ -308,7 +309,8 @@
       'Get-Agent',
       'Remove-Agent',
       'Enable-Agent',
-      'Disable-Agent')
+      'Disable-Agent',
+      'Update-Profile')
 
    # DSC resources to export from this module
    # DscResourcesToExport = @()

--- a/docs/Team.md
+++ b/docs/Team.md
@@ -351,6 +351,10 @@ Updates a build definition for a team project.
 
 Updates an existing policy in the specified project.
 
+### [Update-VSTeamProfile](Update-VSTeamProfile.md)
+
+Allows you to update the Personal Access Token for your profile.
+
 ### [Update-VSTeamProject](Update-VSTeamProject.md)
 
 Updates the project name, description or both.

--- a/docs/readme.md
+++ b/docs/readme.md
@@ -356,6 +356,10 @@ Updates a build definition for a team project.
 
 Updates an existing policy in the specified project.
 
+### [Update-VSTeamProfile](Update-VSTeamProfile.md)
+
+Allows you to update the Personal Access Token for your profile.
+
 ### [Update-VSTeamProject](Update-VSTeamProject.md)
 
 Updates the project name, description or both.

--- a/en-US/VSTeam-Help.xml
+++ b/en-US/VSTeam-Help.xml
@@ -13066,6 +13066,191 @@ Demo-CI           Demo-CI-45   notStarted</dev:code>
   </command:command>
   <command:command xmlns:maml="http://schemas.microsoft.com/maml/2004/10" xmlns:command="http://schemas.microsoft.com/maml/dev/command/2004/10" xmlns:dev="http://schemas.microsoft.com/maml/dev/2004/10" xmlns:MSHelp="http://msdn.microsoft.com/mshelp">
     <command:details>
+      <command:name>Update-VSTeamProfile</command:name>
+      <command:verb>Update</command:verb>
+      <command:noun>VSTeamProfile</command:noun>
+      <maml:description>
+        <maml:para>Allows you to update the Personal Access Token for your profile.</maml:para>
+      </maml:description>
+    </command:details>
+    <maml:description>
+      <maml:para></maml:para>
+    </maml:description>
+    <command:syntax>
+      <command:syntaxItem>
+        <maml:name>Update-VSTeamProfile</maml:name>
+        <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="false" position="3" aliases="none">
+          <maml:name>Name</maml:name>
+          <maml:Description>
+            <maml:para>Name of the profile to be updated</maml:para>
+          </maml:Description>
+          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="false" position="named" aliases="none">
+          <maml:name>PAT</maml:name>
+          <maml:Description>
+            <maml:para>A secured string to capture your personal access token.</maml:para>
+            <maml:para>This will allow you to provide your personal access token without displaying it in plain text.</maml:para>
+            <maml:para>To use pat simply omit it from the Update-VSTeamProfile command.</maml:para>
+          </maml:Description>
+          <command:parameterValue required="true" variableLength="false">SecureString</command:parameterValue>
+          <dev:type>
+            <maml:name>SecureString</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="false" position="named" aliases="none">
+          <maml:name>Force</maml:name>
+          <maml:Description>
+            <maml:para>Forces the command without confirmation</maml:para>
+          </maml:Description>
+          <dev:type>
+            <maml:name>SwitchParameter</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>False</dev:defaultValue>
+        </command:parameter>
+      </command:syntaxItem>
+      <command:syntaxItem>
+        <maml:name>Update-VSTeamProfile</maml:name>
+        <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="false" position="2" aliases="none">
+          <maml:name>PersonalAccessToken</maml:name>
+          <maml:Description>
+            <maml:para>The personal access token from VSTS/TFS to use to access this account.</maml:para>
+          </maml:Description>
+          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="false" position="3" aliases="none">
+          <maml:name>Name</maml:name>
+          <maml:Description>
+            <maml:para>Name of the profile to be updated</maml:para>
+          </maml:Description>
+          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="false" position="named" aliases="none">
+          <maml:name>Force</maml:name>
+          <maml:Description>
+            <maml:para>Forces the command without confirmation</maml:para>
+          </maml:Description>
+          <dev:type>
+            <maml:name>SwitchParameter</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>False</dev:defaultValue>
+        </command:parameter>
+      </command:syntaxItem>
+    </command:syntax>
+    <command:parameters>
+      <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="false" position="named" aliases="none">
+        <maml:name>PAT</maml:name>
+        <maml:Description>
+          <maml:para>A secured string to capture your personal access token.</maml:para>
+          <maml:para>This will allow you to provide your personal access token without displaying it in plain text.</maml:para>
+          <maml:para>To use pat simply omit it from the Update-VSTeamProfile command.</maml:para>
+        </maml:Description>
+        <command:parameterValue required="true" variableLength="false">SecureString</command:parameterValue>
+        <dev:type>
+          <maml:name>SecureString</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="false" position="2" aliases="none">
+        <maml:name>PersonalAccessToken</maml:name>
+        <maml:Description>
+          <maml:para>The personal access token from VSTS/TFS to use to access this account.</maml:para>
+        </maml:Description>
+        <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+        <dev:type>
+          <maml:name>String</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="false" position="3" aliases="none">
+        <maml:name>Name</maml:name>
+        <maml:Description>
+          <maml:para>Name of the profile to be updated</maml:para>
+        </maml:Description>
+        <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+        <dev:type>
+          <maml:name>String</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="false" position="named" aliases="none">
+        <maml:name>Force</maml:name>
+        <maml:Description>
+          <maml:para>Forces the command without confirmation</maml:para>
+        </maml:Description>
+        <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+        <dev:type>
+          <maml:name>SwitchParameter</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>False</dev:defaultValue>
+      </command:parameter>
+    </command:parameters>
+    <command:inputTypes />
+    <command:returnValues />
+    <maml:alertSet>
+      <maml:alert>
+        <maml:para></maml:para>
+      </maml:alert>
+    </maml:alertSet>
+    <command:examples>
+      <command:example>
+        <maml:title>-------------------------- EXAMPLE 1 --------------------------</maml:title>
+        <dev:code>PS C:\&gt; Update-VSTeamProfile -Name ProfileName</dev:code>
+        <dev:remarks>
+          <maml:para>You will be prompted for the account name and personal access token.</maml:para>
+        </dev:remarks>
+      </command:example>
+      <command:example>
+        <maml:title>-------------------------- EXAMPLE 2 --------------------------</maml:title>
+        <dev:code>PS C:\&gt; Update-VSTeamProfile -Name mydemos -PersonalAccessToken 7a8ilh6db4aforlrnrqmdrxdztkjvcc4uhlh5vgbteserp3mziwnga</dev:code>
+        <dev:remarks>
+          <maml:para>Allows you to provide all the information on the command line.</maml:para>
+        </dev:remarks>
+      </command:example>
+      <command:example>
+        <maml:title>-------------------------- EXAMPLE 3 --------------------------</maml:title>
+        <dev:code>PS C:\&gt; Get-VSTeamProfile | Where-Object version -eq vsts | Select-Object -skip 1 | Update-VSTeamProfile -PersonalAccessToken 7a8ilh6db4aforlrnrqmdrxdztkjvcc4uhlh5vgbteserp3mziwnga -Force</dev:code>
+        <dev:remarks>
+          <maml:para>This will update all but the first VSTS profile</maml:para>
+        </dev:remarks>
+      </command:example>
+    </command:examples>
+    <command:relatedLinks>
+      <maml:navigationLink>
+        <maml:linkText>Update-VSTeamAccount</maml:linkText>
+        <maml:uri></maml:uri>
+      </maml:navigationLink>
+      <maml:navigationLink>
+        <maml:linkText>Set-VSTeamDefaultProject</maml:linkText>
+        <maml:uri></maml:uri>
+      </maml:navigationLink>
+    </command:relatedLinks>
+  </command:command>
+  <command:command xmlns:maml="http://schemas.microsoft.com/maml/2004/10" xmlns:command="http://schemas.microsoft.com/maml/dev/command/2004/10" xmlns:dev="http://schemas.microsoft.com/maml/dev/2004/10" xmlns:MSHelp="http://msdn.microsoft.com/mshelp">
+    <command:details>
       <command:name>Update-VSTeamProject</command:name>
       <command:verb>Update</command:verb>
       <command:noun>VSTeamProject</command:noun>

--- a/integration/test/000_team.Tests.ps1
+++ b/integration/test/000_team.Tests.ps1
@@ -8,12 +8,14 @@ if ($null -eq $env:TEAM_CIBUILD) {
 ##############################################################
 #     THESE TEST ARE DESTRUCTIVE. USE AN EMPTY ACCOUNT.      #
 ##############################################################
-# Before running these tests you must set the following
-# Environment variables.
-# $env:API_VERSION = TFS2017, TFS2018 or VSTS depending on the value used for ACCT
-# $env:EMAIL = Email of user to remove and re-add to account
-# $env:ACCT = VSTS Account Name or full TFS URL including collection
-# $env:PAT = Personal Access token of ACCT
+# Before running these tests you must set the following      #
+# Environment variables.                                     #
+# $env:API_VERSION = TFS2017, TFS2018 or VSTS depending on   #
+#                    the value used for ACCT                 #
+# $env:EMAIL = Email of user to remove and re-add to account #
+# $env:ACCT = VSTS Account Name or full TFS URL including    #
+#             collection                                     #
+# $env:PAT = Personal Access token of ACCT                   #
 ##############################################################
 #     THESE TEST ARE DESTRUCTIVE. USE AN EMPTY ACCOUNT.      #
 ##############################################################

--- a/integration/test/010_projects.Tests.ps1
+++ b/integration/test/010_projects.Tests.ps1
@@ -8,14 +8,14 @@ if ($null -eq $env:TEAM_CIBUILD) {
 ##############################################################
 #     THESE TEST ARE DESTRUCTIVE. USE AN EMPTY ACCOUNT.      #
 ##############################################################
-# Before running these tests you must set the following
-# Environment variables.
-# $env:API_VERSION = TFS2017, TFS2018 or VSTS depending on
-#                    the value used for ACCT
-# $env:EMAIL = Email of user to remove and re-add to account
-# $env:ACCT = VSTS Account Name or full TFS URL including
-#             collection
-# $env:PAT = Personal Access token of ACCT
+# Before running these tests you must set the following      #
+# Environment variables.                                     #
+# $env:API_VERSION = TFS2017, TFS2018 or VSTS depending on   #
+#                    the value used for ACCT                 #
+# $env:EMAIL = Email of user to remove and re-add to account #
+# $env:ACCT = VSTS Account Name or full TFS URL including    #
+#             collection                                     #
+# $env:PAT = Personal Access token of ACCT                   #
 ##############################################################
 #     THESE TEST ARE DESTRUCTIVE. USE AN EMPTY ACCOUNT.      #
 ##############################################################

--- a/src/common.ps1
+++ b/src/common.ps1
@@ -443,7 +443,8 @@ function _buildDynamicParam {
       [string] $ParameterName = 'QueueName',
       [array] $arrSet,
       [bool] $Mandatory = $false,
-      [string] $ParameterSetName
+      [string] $ParameterSetName,
+      [int] $Position = -1
    )
    # Create the collection of attributes
    $AttributeCollection = New-Object System.Collections.ObjectModel.Collection[System.Attribute]
@@ -452,6 +453,10 @@ function _buildDynamicParam {
    $ParameterAttribute = New-Object System.Management.Automation.ParameterAttribute
    $ParameterAttribute.Mandatory = $Mandatory
    $ParameterAttribute.ValueFromPipelineByPropertyName = $true
+   
+   if($Position -ne -1) {
+      $ParameterAttribute.Position = $Position
+   }
 
    if ($ParameterSetName) {
       $ParameterAttribute.ParameterSetName = $ParameterSetName

--- a/src/profile.psm1
+++ b/src/profile.psm1
@@ -191,8 +191,7 @@ function Add-VSTeamProfile {
       # The @() forces even 1 item to an array
       $profiles = @(Get-VSTeamProfile | Where-Object URL -ne $Account)
 
-      # Without the Out-Null the original size is showing in output.
-      $profiles += [PSCustomObject]@{
+      $newProfile = [PSCustomObject]@{
          Name    = $Name
          URL     = $Account
          Type    = $authType
@@ -201,16 +200,102 @@ function Add-VSTeamProfile {
          Version = (_getVSTeamAPIVersion -Instance $Account -Version $Version)
       }
 
+      $profiles += $newProfile
+
       $contents = ConvertTo-Json $profiles
 
       Set-Content -Path $profilesPath -Value $contents
    }
 }
 
+function Update-VSTeamProfile {
+   [CmdletBinding(DefaultParameterSetName = 'Secure', SupportsShouldProcess = $true, ConfirmImpact = "Medium")]
+   param(
+      [parameter(ParameterSetName = 'Plain', Mandatory = $true, HelpMessage = 'Personal Access Token')]
+      [string] $PersonalAccessToken,
+
+      [parameter(ParameterSetName = 'Secure', Mandatory = $true, HelpMessage = 'Personal Access Token')]
+      [securestring] $SecurePersonalAccessToken,
+
+      [switch] $Force
+   )
+
+   DynamicParam {
+      # Create the dictionary
+      $RuntimeParameterDictionary = New-Object System.Management.Automation.RuntimeDefinedParameterDictionary
+
+      $profileArrSet = Get-VSTeamProfile | Select-Object -ExpandProperty Name
+
+      if ($profileArrSet) {
+         $profileParam = _buildDynamicParam -ParameterName 'Name' -Mandatory $true -Position 0 -arrSet $profileArrSet
+      }
+      else {
+         $profileParam = _buildDynamicParam -ParameterName 'Name' -Mandatory $true -Position 0
+      }
+
+      $RuntimeParameterDictionary.Add('Name', $profileParam)
+
+      return $RuntimeParameterDictionary
+   }
+
+   process {
+      $Name = $PSBoundParameters['Name']
+
+      if ($Force -or $pscmdlet.ShouldProcess($Name, "Update-VSTeamProfile")) {
+         if ($SecurePersonalAccessToken) {
+            # Even when promoted for a Secure Personal Access Token you can just
+            # press enter. This leads to an empty PAT so error below.
+
+            # Convert the securestring to a normal string
+            # this was the one technique that worked on Mac, Linux and Windows
+            $_pat = _convertSecureStringTo_PlainText -SecureString $SecurePersonalAccessToken
+         }
+         else {
+            $_pat = $PersonalAccessToken
+         }
+
+         $token = ''
+         $authType = 'Pat'
+         $encodedPat = [System.Convert]::ToBase64String([System.Text.Encoding]::UTF8.GetBytes(":$_pat"))
+
+         $profile = Get-VSTeamProfile | Where-Object Name -eq $Name
+
+         if ($profile) {
+            # See if this item is already in there
+            # I am testing URL because the user may provide a different
+            # name and I don't want two with the same URL.
+            # The @() forces even 1 item to an array
+            # Now get an array of all profiles but this one and update this one.
+            $profiles = @(Get-VSTeamProfile | Where-Object Name -ne $Name)
+
+            $newProfile = [PSCustomObject]@{
+               Name    = $Name
+               URL     = $profile.URL
+               Type    = $authType
+               Pat     = $encodedPat
+               Token   = $token
+               Version = $profile.Version
+            }
+
+            $profiles += $newProfile
+
+            $contents = ConvertTo-Json $profiles
+
+            Set-Content -Path $profilesPath -Value $contents
+         }
+         else {
+            # This will happen when they don't have any profiles. 
+            Write-Warning 'Profile not found'
+         }
+      }
+   }
+}
+
 Set-Alias Get-Profile Get-VSTeamProfile
 Set-Alias Add-Profile Add-VSTeamProfile
 Set-Alias Remove-Profile Remove-VSTeamProfile
+Set-Alias Update-Profile Update-VSTeamProfile
 
 Export-ModuleMember `
-   -Function Get-VSTeamProfile, Add-VSTeamProfile, Remove-VSTeamProfile `
-   -Alias Get-Profile, Add-Profile, Remove-Profile
+   -Function Get-VSTeamProfile, Add-VSTeamProfile, Remove-VSTeamProfile, Update-VSTeamProfile `
+   -Alias Get-Profile, Add-Profile, Remove-Profile, Update-Profile

--- a/unit/test/profile.Tests.ps1
+++ b/unit/test/profile.Tests.ps1
@@ -229,5 +229,51 @@ InModuleScope profile {
             $actual[0].Type | Should be 'OnPremise'
          }
       }
+   
+      Context 'Update-VSTeamProfile entry does not exist' {
+         Mock Get-VSTeamProfile { return '[{"Name":"test","URL":"https://test.visualstudio.com","Type":"Pat","Pat":"12345","Version":"VSTS"}]' | ConvertFrom-Json | ForEach-Object { $_ } }
+
+         It 'Should throw' {
+            { Update-VSTeamProfile -Name Testing -PersonalAccessToken 678910 } | Should -Throw
+         }
+      }
+
+      Context 'Add-VSTeamProfile with PAT to empty file' {
+         Mock Set-Content { }
+         Mock Write-Warning -Verifiable
+         Mock Get-VSTeamProfile { }
+
+         Update-VSTeamProfile -name demos -PersonalAccessToken 12345
+
+         It 'Should save profile to disk' {
+            Assert-VerifiableMock
+         }
+      }
+
+      Context 'Update-VSTeamProfile with securePersonalAccessToken' {
+         Mock Set-Content { } -Verifiable -ParameterFilter { $Path -eq $expectedPath -and $Value -like "*OjY3ODkxMA==*" -and $Value -like "*https://test.visualstudio.com*" -and $Value -like "*VSTS*" }
+         Mock Set-Content { }
+         Mock Get-VSTeamProfile { return '[{"Name":"test","URL":"https://test.visualstudio.com/","Type":"Pat","Pat":"12345","Version":"VSTS"}]' | ConvertFrom-Json | ForEach-Object { $_ } }
+
+         $password = '678910' | ConvertTo-SecureString -AsPlainText -Force
+
+         Update-VSTeamProfile -Name test -SecurePersonalAccessToken $password
+
+         It 'Should update profile' {
+            Assert-VerifiableMock
+         }
+      }
+
+      Context 'Update-VSTeamProfile with PAT' {
+         Mock Set-Content { } -Verifiable -ParameterFilter { $Path -eq $expectedPath -and $Value -like "*OjY3ODkxMA==*" -and $Value -like "*https://test.visualstudio.com*" -and $Value -like "*VSTS*" }
+         Mock Set-Content { }
+         Mock Get-VSTeamProfile { return '[{"Name":"test","URL":"https://test.visualstudio.com/","Type":"Pat","Pat":"12345","Version":"VSTS"}]' | ConvertFrom-Json | ForEach-Object { $_ } }
+
+         Update-VSTeamProfile -Name test -PersonalAccessToken 678910
+
+         It 'Should update profile' {
+            Assert-VerifiableMock
+         }
+      }
    }
 }


### PR DESCRIPTION
# PR Summary

I had to revoke a lot of personal access tokens and had to update my profiles. This function allows me to just update the PAT and not the rest of the information.

## PR Checklist

- [x] [Write Help](https://github.com/DarqueWarrior/vsteam/blob/master/.github/CONTRIBUTING.md#write-help)
- [x] [Write Unit Test](https://github.com/DarqueWarrior/vsteam/blob/master/.github/CONTRIBUTING.md#write-unit-test)
- [x] [Update VSTeam.psd1](https://github.com/DarqueWarrior/vsteam/blob/master/.github/CONTRIBUTING.md#add-a-format-file)
- [x] [Update README.md](https://github.com/DarqueWarrior/vsteam/blob/master/.github/CONTRIBUTING.md#add-a-format-file)
