### PR TITLE
old license was not populated when updating a user by id

### DIFF
--- a/src/users.psm1
+++ b/src/users.psm1
@@ -160,14 +160,13 @@ function Update-VSTeamUser
          }
 
          $id = $user.id
-         $licenseOld = $user.accessLevel.accountLicenseType
-
       }
       else
       {
-         $user = Get-VSTeamUser -Id $id
-         $licenseOld = $user.accessLevel.accountLicenseType
+         $user = Get-VSTeamUser -Id $id         
       }
+
+      $licenseOld = $user.accessLevel.accountLicenseType
 
       $obj = @{
          from = ""

--- a/src/users.psm1
+++ b/src/users.psm1
@@ -166,6 +166,7 @@ function Update-VSTeamUser
       else
       {
          $user = Get-VSTeamUser -Id $id
+         $licenseOld = $user.accessLevel.accountLicenseType
       }
 
       $obj = @{


### PR DESCRIPTION
# PR Summary

When updating a user by id, the old license was not set and an exception was raised when emitting the  "Updated user license for $( $user.userName ) ($( $user.email )) from ($licenseOld) to ($License)" message.

