### PR TITLE
Fixed add-vsteambuild bug with build definition name.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 4.0.10
+
+Fixed bug where you could not add a build by build definition name.
+
 ## 4.0.9
 
 Merged [Pull Request](https://github.com/DarqueWarrior/vsteam/pull/102) from [Brian Schmitt](https://github.com/brianschmitt) which included the following:

--- a/VSTeam.psd1
+++ b/VSTeam.psd1
@@ -13,7 +13,7 @@
    RootModule        = ''
 
    # Version number of this module.
-   ModuleVersion     = '4.0.9'
+   ModuleVersion     = '4.0.10'
 
    # Supported PSEditions
    # CompatiblePSEditions = @()

--- a/src/builds.psm1
+++ b/src/builds.psm1
@@ -249,7 +249,7 @@ function Add-VSTeamBuild {
       else {
          # Find the BuildDefinition id from the name
          $id = Get-VSTeamBuildDefinition -ProjectName "$ProjectName" -Type All |
-            Where-Object { $_.fullname -eq $BuildDefinition } |
+            Where-Object { $_.name -eq $BuildDefinition } |
             Select-Object -ExpandProperty id
       }
 

--- a/unit/test/builds.Tests.ps1
+++ b/unit/test/builds.Tests.ps1
@@ -8,6 +8,8 @@ InModuleScope builds {
    # this some test may fail
    Remove-VSTeamAccount | Out-Null
 
+   $resultsVSTS = Get-Content "$PSScriptRoot\sampleFiles\buildDefvsts.json" -Raw | ConvertFrom-Json
+
    # Sample result of a single build
    $singleResult = [PSCustomObject]@{
       logs              = [PSCustomObject]@{}
@@ -150,13 +152,14 @@ InModuleScope builds {
 
       Context 'Add-VSTeamBuild by name' {
          Mock Invoke-RestMethod { return $singleResult }
+         Mock Get-VSTeamBuildDefinition { return [VSTeamBuildDefinition]::new($resultsVSTS.value[0], 'project') }
 
          It 'should add build' {
-            Add-VSTeamBuild -ProjectName project -BuildDefinitionName 'folder\MyBuildDef'
+            Add-VSTeamBuild -ProjectName project -BuildDefinitionName 'aspdemo-CI'
 
             # Call to queue build.
             Assert-MockCalled Invoke-RestMethod -Exactly -Scope It -Times 1 -ParameterFilter {
-               ($Body | ConvertFrom-Json).definition.id -eq 2 -and
+               ($Body | ConvertFrom-Json).definition.id -eq 699 -and
                $Uri -eq "https://dev.azure.com/test/project/_apis/build/builds/?api-version=$([VSTeamVersions]::Build)"
             }
          }


### PR DESCRIPTION
# PR Summary

Fixed bug with add-vsteambuild

## PR Checklist

- [ ] [Write Help](https://github.com/DarqueWarrior/vsteam/blob/master/.github/CONTRIBUTING.md#write-help)
- [ ] [Write Unit Test](https://github.com/DarqueWarrior/vsteam/blob/master/.github/CONTRIBUTING.md#write-unit-test)
- [x] [Update VSTeam.psd1](https://github.com/DarqueWarrior/vsteam/blob/master/.github/CONTRIBUTING.md#add-a-format-file)
- [x] [Update CHANGELOG.md](https://github.com/DarqueWarrior/vsteam/blob/master/.github/CONTRIBUTING.md#add-a-format-file)
