### PR TITLE
Adding better error handling when response is null

### DIFF
--- a/src/common.ps1
+++ b/src/common.ps1
@@ -77,7 +77,7 @@ function _handleException {
 
    $handled = $false
 
-   if ($ex.Exception.PSObject.Properties.Match('Response').count -gt 0 -and $ex.Exception.Response.StatusCode -ne "BadRequest") {
+   if ($ex.Exception.PSObject.Properties.Match('Response').count -gt 0 -and $null -ne $ex.Exception.Response -and $ex.Exception.Response.StatusCode -ne "BadRequest") {
       $handled = $true
       $msg = "An error occurred: $($ex.Exception.Message)"
       Write-Warning $msg


### PR DESCRIPTION
Response could be null causing StatusCode to not be populated.

# PR Summary

Minor change to verify the Response is not null before attempting to check the StatusCode
To test this fix, temporarily set your team account to a non-existent (or unavailable - E.G. behind VPN) url.

## PR Checklist

- [ ] [Write Help](https://github.com/DarqueWarrior/vsteam/blob/master/.github/CONTRIBUTING.md#write-help)
- [ ] [Write Unit Test](https://github.com/DarqueWarrior/vsteam/blob/master/.github/CONTRIBUTING.md#write-unit-test)
- [ ] [Update VSTeam.psd1](https://github.com/DarqueWarrior/vsteam/blob/master/.github/CONTRIBUTING.md#add-a-format-file)
- [ ] [Update CHANGELOG.md](https://github.com/DarqueWarrior/vsteam/blob/master/.github/CONTRIBUTING.md#add-a-format-file)
