### PR TITLE
 Add parameter to Add-VSTeamWorkItem to support setting parent work item

### DIFF
--- a/.docs/Add-VSTeamWorkItem.md
+++ b/.docs/Add-VSTeamWorkItem.md
@@ -89,6 +89,15 @@ Type: String
 Required: True
 ```
 
+### -ParentId
+
+The Id of the parent work item that this work item will be related to.
+
+```yaml
+Type: Int
+Required: False
+```
+
 ## INPUTS
 
 ### System.String

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 5.0.2
+
+Merged [Pull Request](https://github.com/DarqueWarrior/vsteam/pull/129) from [Adam Murray](https://github.com/muzzar78) which included the following:
+
 - Added ParentId parameter to Add-VSTeamWorkItem to allow the parent work item to be set
 
 ## 5.0.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Changelog
 
+- Added ParentId parameter to Add-VSTeamWorkItem to allow the parent work item to be set
+
 ## 5.0.1
 
 Merged [Pull Request](https://github.com/DarqueWarrior/vsteam/pull/128) from [Fifth Street Partners](https://github.com/fifthstreetpartners) which included the following:

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ You can review the status of every stage of the pipeline below.
 
 |         Stage                       |             Status           |
 |-------------------------------------|------------------------------|
-| Build                               | [![Build status](https://loecda.visualstudio.com/Team%20Module/_apis/build/status/Team%20Module-CI)](https://loecda.visualstudio.com/Team%20Module/_build/latest?definitionId=5)|
+| Build                               | [![Build status](https://loecda.visualstudio.com/Team%20Module/_apis/build/status/CI)](https://loecda.visualstudio.com/Team%20Module/_build/latest?definitionId=52)|
 | Linux Team Foundation Server 2017   | [![Environment status](https://loecda.vsrm.visualstudio.com/_apis/public/Release/badge/3e857acd-880f-4056-a46b-1de672ca55cc/1/7)](https://loecda.visualstudio.com/Team%20Module/_releases2?definitionId=1&view=mine&_a=releases) |
 | macOS Team Foundation Server 2017   | [![Environment status](https://loecda.vsrm.visualstudio.com/_apis/public/Release/badge/3e857acd-880f-4056-a46b-1de672ca55cc/1/6)](https://loecda.visualstudio.com/Team%20Module/_releases2?definitionId=1&view=mine&_a=releases) |
 | Windows Team Foundation Server 2017 | [![Environment status](https://loecda.vsrm.visualstudio.com/_apis/public/Release/badge/3e857acd-880f-4056-a46b-1de672ca55cc/1/2)](https://loecda.visualstudio.com/Team%20Module/_releases2?definitionId=1&view=mine&_a=releases) |

--- a/VSTeam.psd1
+++ b/VSTeam.psd1
@@ -13,7 +13,7 @@
    RootModule        = ''
 
    # Version number of this module.
-   ModuleVersion     = '5.0.1'
+   ModuleVersion     = '5.0.2'
 
    # Supported PSEditions
    # CompatiblePSEditions = @()

--- a/docs/Add-VSTeamProject.md
+++ b/docs/Add-VSTeamProject.md
@@ -48,11 +48,9 @@ Position: 0
 
 ### -ProcessTemplate
 
-The name of the process template to use for the project. The acceptable values for this parameter are:
+The name of the process template to use for the project.
 
-- Agile
-- Scrum
-- CMMI
+You can tab complete from a list of available projects.
 
 ```yaml
 Type: String
@@ -86,3 +84,5 @@ Type: SwitchParameter
 [Add-VSTeamAccount](Add-VSTeamAccount.md)
 
 [Remove-VSTeamProject](Remove-VSTeamProject.md)
+
+[Get-VSTeamProcess](Get-VSTeamProcess.md)

--- a/docs/Add-VSTeamWorkItem.md
+++ b/docs/Add-VSTeamWorkItem.md
@@ -104,6 +104,15 @@ Type: String
 Required: True
 ```
 
+### -ParentId
+
+The Id of the parent work item that this work item will be related to.
+
+```yaml
+Type: Int
+Required: False
+```
+
 ## INPUTS
 
 ### System.String

--- a/docs/Get-VSTeamWorkItem.md
+++ b/docs/Get-VSTeamWorkItem.md
@@ -21,7 +21,7 @@ Returns one or more a work items from your project.
 PS C:\> Get-VSTeamWorkItem -Ids 47,48
 ```
 
-This command gets work items with IDs 47 and 48 by using the ID parameter.
+This command gets work items with IDs 47 and 48 by using the IDs parameter.
 
 ## PARAMETERS
 

--- a/docs/Team.md
+++ b/docs/Team.md
@@ -187,6 +187,10 @@ Get the policy types in the specified Visual Studio Team Services or Team Founda
 
 Returns the agent pools.
 
+### [Get-VSTeamProcess](Get-VSTeamProcess.md)
+
+Returns a list of process templates in the Team Services or Team Foundation Server account.
+
 ### [Get-VSTeamProfile](Get-VSTeamProfile.md)
 
 Returns the saved profiles.

--- a/docs/readme.md
+++ b/docs/readme.md
@@ -192,6 +192,10 @@ Get the policy types in the specified Visual Studio Team Services or Team Founda
 
 Returns the agent pools.
 
+### [Get-VSTeamProcess](Get-VSTeamProcess.md)
+
+Returns a list of process templates in the Team Services or Team Foundation Server account.
+
 ### [Get-VSTeamProfile](Get-VSTeamProfile.md)
 
 Returns the saved profiles.

--- a/src/workitems.psm1
+++ b/src/workitems.psm1
@@ -32,7 +32,7 @@ function Add-VSTeamWorkItem {
       [string]$AssignedTo,
 
       [Parameter(Mandatory = $false)]
-      [string]$ParentId
+      [int]$ParentId
    )
 
    DynamicParam {
@@ -64,7 +64,7 @@ function Add-VSTeamWorkItem {
 
       # The type has to start with a $
       $WorkItemType = "`$$($PSBoundParameters["WorkItemType"])"
-      
+
       # Constructing the contents to be send.
       # Empty parameters will be skipped when converting to json.
       $body = @(

--- a/src/workitems.psm1
+++ b/src/workitems.psm1
@@ -29,7 +29,10 @@ function Add-VSTeamWorkItem {
       [string]$IterationPath,
 
       [Parameter(Mandatory = $false)]
-      [string]$AssignedTo
+      [string]$AssignedTo,
+
+      [Parameter(Mandatory = $false)]
+      [string]$ParentId
    )
 
    DynamicParam {
@@ -61,7 +64,7 @@ function Add-VSTeamWorkItem {
 
       # The type has to start with a $
       $WorkItemType = "`$$($PSBoundParameters["WorkItemType"])"
-
+      
       # Constructing the contents to be send.
       # Empty parameters will be skipped when converting to json.
       $body = @(
@@ -85,6 +88,18 @@ function Add-VSTeamWorkItem {
             path  = "/fields/System.AssignedTo"
             value = $AssignedTo
          }) | Where-Object { $_.value}
+
+         if ($ParentId) {
+            $parentUri = _buildRequestURI -ProjectName $ProjectName -Area 'wit' -Resource 'workitems' -id $ParentId
+            $body += @{
+               op    = "add"
+               path  = "/relations/-"
+               value = @{
+                  "rel" = "System.LinkTypes.Hierarchy-Reverse"
+                  "url" = $parentURI
+               }
+            }
+         }
 
       # It is very important that even if the user only provides
       # a single value above that the item is an array and not

--- a/unit/test/workitem.Tests.ps1
+++ b/unit/test/workitem.Tests.ps1
@@ -59,6 +59,26 @@ InModuleScope workitems {
                $Uri -eq "https://dev.azure.com/test/test/_apis/wit/workitems/`$Task?api-version=$([VSTeamVersions]::Core)"
             }
          }
+
+         It 'With Default Project should add work item with parent' {
+            $Global:PSDefaultParameterValues["*:projectName"] = 'test'
+            Add-VSTeamWorkItem -ProjectName test -WorkItemType Task -Title Test1 -Description Testing -ParentId 25
+
+            Assert-MockCalled Invoke-RestMethod -Exactly -Scope It -Times 1 -ParameterFilter {
+               $Method -eq 'Post' -and
+               $Body -like '`[*' -and # Make sure the body is an array
+               $Body -like '*Test1*' -and
+               $Body -like '*Testing*' -and
+               $Body -like '*/fields/System.Title*' -and
+               $Body -like '*/fields/System.Description*' -and
+               $Body -like '*/relations/-*' -and
+               $Body -like '*_apis/wit/workitems/25*' -and
+               $Body -like '*System.LinkTypes.Hierarchy-Reverse*' -and
+               $Body -like '*`]' -and # Make sure the body is an array
+               $ContentType -eq 'application/json-patch+json' -and
+               $Uri -eq "https://dev.azure.com/test/test/_apis/wit/workitems/`$Task?api-version=$([VSTeamVersions]::Core)"
+            }
+         }
       }
 
       Context 'Update-WorkItem' {


### PR DESCRIPTION
# PR Summary

Add parameter to Add-VSTeamWorkItem to support setting parent work item. This is based on the info in issue https://github.com/DarqueWarrior/vsteam/issues/98 and should resolve this issue.

## PR Checklist

- [x] [Write Help](https://github.com/DarqueWarrior/vsteam/blob/master/.github/CONTRIBUTING.md#write-help)
- [x] [Write Unit Test](https://github.com/DarqueWarrior/vsteam/blob/master/.github/CONTRIBUTING.md#write-unit-test)
- [x] [Update VSTeam.psd1](https://github.com/DarqueWarrior/vsteam/blob/master/.github/CONTRIBUTING.md#add-a-format-file)
- [x] [Update CHANGELOG.md](https://github.com/DarqueWarrior/vsteam/blob/master/.github/CONTRIBUTING.md#add-a-format-file)
