### PR TITLE
Fixed issue with output when mapping drive with Set-VSTeamAccount

### DIFF
--- a/.docs/Set-VSTeamAccount.md
+++ b/.docs/Set-VSTeamAccount.md
@@ -29,7 +29,7 @@ You will be prompted for the account name and personal access token.
 ### -------------------------- EXAMPLE 2 --------------------------
 
 ```PowerShell
-PS C:\> Set-VSTeamAccount -Account mydemos -PersonalAccessToken 7a8ilh6db4aforlrnrqmdrxdztkjvcc4uhlh5vgbmgap3mziwnga
+PS C:\> Set-VSTeamAccount -Account mydemos -PersonalAccessToken 7a8ilh6db4aforlrnrthisisnotreal4uhlh5vgbmgap3mziwnga
 ```
 
 Allows you to provide all the information on the command line.
@@ -53,12 +53,12 @@ Will add the account from the profile provided.
 ### -------------------------- EXAMPLE 5 --------------------------
 
 ```PowerShell
-PS C:\> Set-VSTeamAccount -Profile demonstrations -Drive demo
+PS C:\> Set-VSTeamAccount -Profile demonstrations -Drive demo | Invoke-Expression
 PS C:\> Set-Location demo:
 PS demo:\> Get-ChildItem
 ```
 
-Will add the account from the profile provided and mount a drive named demo that you can navigate like a file system.
+Will add the account from the profile provided and mount a drive named demo that you can navigate like a file system. If you do not pipe to Invoke-Expression you can simply copy and paste the output and execute it.
 
 ### -------------------------- EXAMPLE 6 --------------------------
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## 6.0.1
+
+Fixing issue with mapping drive.
+
+You can now use Set-VSTeamAccount with Invoke-Expression to switch accounts and map a drive on a single line. i.e.:
+
+Set-VSTeamAccount -Profile Test -Drive t | iex
+
+This will switch to the account in the Test profile and map a drive t: to the account.
+
 ## 6.0.0
 
 Each function is now broken out into a separate file. The folder structure was changed with the core content moved into the Source folder. All the PSM1's were moved to PS1's files.  There is now a single PSM1 now.

--- a/Source/Public/Set-VSTeamAccount.ps1
+++ b/Source/Public/Set-VSTeamAccount.ps1
@@ -133,14 +133,15 @@ function Set-VSTeamAccount {
       }
 
       if ($Force -or $pscmdlet.ShouldProcess($Account, "Set Account")) {
-         Clear-VSTeamDefaultProject
+         # Piped to null so callers can pipe to Invoke-Expression to mount the drive on one line.
+         Clear-VSTeamDefaultProject *> $null
          _setEnvironmentVariables -Level $Level -Pat $encodedPat -Acct $account -BearerToken $token -Version $Version
 
          Set-VSTeamAPIVersion -Target (_getVSTeamAPIVersion -Instance $account -Version $Version)
 
          if ($Drive) {
             # Assign to null so nothing is writen to output.
-            Write-Output "`nTo map a drive run the following command:`nNew-PSDrive -Name $Drive -PSProvider SHiPS -Root 'VSTeam#VSTeamAccount'`n" -ForegroundColor Black -BackgroundColor Yellow
+            Write-Output "# To map a drive run the following command or pipe to iex:`nNew-PSDrive -Name $Drive -PSProvider SHiPS -Root 'VSTeam#VSTeamAccount'"
          }
       }
    }

--- a/Source/VSTeam.psd1
+++ b/Source/VSTeam.psd1
@@ -13,7 +13,7 @@
    RootModule        = 'VSTeam.psm1'
 
    # Version number of this module.
-   ModuleVersion     = '6.0.0'
+   ModuleVersion     = '6.0.1'
 
    # Supported PSEditions
    # CompatiblePSEditions = @()


### PR DESCRIPTION
# PR Summary

Switching from Write-Host to Write-Output messed up the out of -Drive on Set-VSTeamAcount 

## PR Checklist

- [x] [Write Help](https://github.com/DarqueWarrior/vsteam/blob/master/.github/CONTRIBUTING.md#write-help)
- [x] [Write Unit Test](https://github.com/DarqueWarrior/vsteam/blob/master/.github/CONTRIBUTING.md#write-unit-test)
- [x] [Update VSTeam.psd1](https://github.com/DarqueWarrior/vsteam/blob/master/.github/CONTRIBUTING.md#add-a-format-file)
- [x] [Update CHANGELOG.md](https://github.com/DarqueWarrior/vsteam/blob/master/.github/CONTRIBUTING.md#add-a-format-file)
