### PR TITLE
Update VSTeamBuildDefinition.ps1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 6.2.2
+
+Merged [Pull Request](https://github.com/DarqueWarrior/vsteam/pull/158) from [Ryan](https://github.com/RPhay) which included the following:
+
+Fixes issue [Get-VSTeamBuildDefinition fails #155](https://github.com/DarqueWarrior/vsteam/issues/155)
+
 ## 6.2.1
 
 Merged [Pull Request](https://github.com/DarqueWarrior/vsteam/pull/156) from [Daniel Sturm](https://github.com/danstur) which included the following:

--- a/Source/Classes/VSTeamBuildDefinition.ps1
+++ b/Source/Classes/VSTeamBuildDefinition.ps1
@@ -32,7 +32,9 @@ class VSTeamBuildDefinition : VSTeamDirectory {
       $this.id = $obj.id
       $this.Path = $obj.path
       $this.Revision = $obj.revision
-      $this.Variables = $obj.variables
+      if ( $obj.PSObject.Properties.name -match 'Variables' ) {
+         $this.Variables = $obj.variables
+      }
       $this.CreatedOn = $obj.createdDate
       $this.JobAuthorizationScope = $obj.jobAuthorizationScope
       $this.AuthoredBy = [VSTeamUserEntitlement]::new($obj.authoredBy, $Projectname)

--- a/Source/Classes/VSTeamBuildDefinitionProcessPhase.ps1
+++ b/Source/Classes/VSTeamBuildDefinitionProcessPhase.ps1
@@ -24,9 +24,11 @@ class VSTeamBuildDefinitionProcessPhase : VSTeamDirectory {
       }
 
       $this.StepCount = 0
-      foreach ($step in $obj.steps) {
-         $this.StepCount++
-         $this.Steps += [VSTeamBuildDefinitionProcessPhaseStep]::new($step, $this.StepCount, $Projectname)
+      if ( $obj.PSObject.Properties.name -match 'steps' ) {
+         foreach ($step in $obj.steps) {
+            $this.StepCount++
+            $this.Steps += [VSTeamBuildDefinitionProcessPhaseStep]::new($step, $this.StepCount, $Projectname)
+         }
       }
 
       $this._internalObj = $obj

--- a/Source/VSTeam.psd1
+++ b/Source/VSTeam.psd1
@@ -12,7 +12,7 @@
    RootModule        = 'VSTeam.psm1'
 
    # Version number of this module.
-   ModuleVersion     = '6.2.1'
+   ModuleVersion     = '6.2.2'
 
    # Supported PSEditions
    # CompatiblePSEditions = @()


### PR DESCRIPTION
Added check for existence of $obj.variables which does not exist in all cases.  This resolves issue 155 (https://github.com/DarqueWarrior/vsteam/issues/155).  Also added check for $obj.steps which does not exist in all cases (no known associated issue #).

# PR Summary

<!-- summarize your PR between here and the checklist -->

## PR Checklist

- [ ] [Write Help](https://github.com/DarqueWarrior/vsteam/blob/master/.github/CONTRIBUTING.md#write-help)
- [ ] [Write Unit Test](https://github.com/DarqueWarrior/vsteam/blob/master/.github/CONTRIBUTING.md#write-unit-test)
- [ ] [Update VSTeam.psd1](https://github.com/DarqueWarrior/vsteam/blob/master/.github/CONTRIBUTING.md#add-a-format-file)
- [ ] [Update CHANGELOG.md](https://github.com/DarqueWarrior/vsteam/blob/master/.github/CONTRIBUTING.md#add-a-format-file)
