### PR TITLE
invalidate cache on account chnage

### DIFF
--- a/Source/Public/Set-VSTeamAccount.ps1
+++ b/Source/Public/Set-VSTeamAccount.ps1
@@ -64,7 +64,8 @@ function Set-VSTeamAccount {
    }
 
    process {
-      # invalidate cache when changing account/collection, otherwise dynamic parameters being picked for a wrong collection
+      # invalidate cache when changing account/collection
+      # otherwise dynamic parameters being picked for a wrong collection
       [VSTeamProjectCache]::timestamp = -1
       
       # Bind the parameter to a friendly variable

--- a/Source/Public/Set-VSTeamAccount.ps1
+++ b/Source/Public/Set-VSTeamAccount.ps1
@@ -64,6 +64,9 @@ function Set-VSTeamAccount {
    }
 
    process {
+      # invalidate cache when changing account/collection, otherwise dynamic parameters being picked for a wrong collection
+      [VSTeamProjectCache]::timestamp = -1
+      
       # Bind the parameter to a friendly variable
       $Profile = $PSBoundParameters['Profile']
 


### PR DESCRIPTION
# PR Summary

when frequently changing accounts/switching to a new collection, for example when iterating through collections, cache becomes invalid. meaning that in case collection has changed, the cache contains wrong list of projects and it needs to be updated.

so we need to invalidate cache each time we switch account

## PR Checklist

- [x] [Write Help] - no need in additional help
- [x] [Write Unit Test] - covered by existing tests
- [x] [Update VSTeam.psd1] - no need additional format files
- [ ] [Update CHANGELOG.md] - do i need to update change log befor it is merged?
