### PR TITLE
Get-VSTeamPullRequest documentation was linking to Get-VSTeamWorkItem documentation

### DIFF
--- a/.docs/Get-VSTeamPullRequest.md
+++ b/.docs/Get-VSTeamPullRequest.md
@@ -4,13 +4,13 @@
 
 ## SYNOPSIS
 
-<!-- #include "./synopsis/Get-VSTeamWorkItem.md" -->
+<!-- #include "./synopsis/Get-VSTeamPullRequest.md" -->
 
 ## SYNTAX
 
 ## DESCRIPTION
 
-<!-- #include "./synopsis/Get-VSTeamWorkItem.md" -->
+<!-- #include "./synopsis/Get-VSTeamPullRequest.md" -->
 
 ## EXAMPLES
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 6.3.6
+
+Merged [Pull Request](https://github.com/DarqueWarrior/vsteam/pull/200) from [Chris Gardner](https://github.com/ChrisLGardner) which included the following:
+
+Get-VSTeamPullRequest documentation was linking to Get-VSTeamWorkItem documentation
+
 ## 6.3.5
 
 Updated Build-Module.ps1 to support static code analysis and running unit tests.

--- a/Source/VSTeam.psd1
+++ b/Source/VSTeam.psd1
@@ -12,7 +12,7 @@
    RootModule        = 'VSTeam.psm1'
 
    # Version number of this module.
-   ModuleVersion     = '6.3.5'
+   ModuleVersion     = '6.3.6'
 
    # Supported PSEditions
    # CompatiblePSEditions = @()


### PR DESCRIPTION
# PR Summary

Documentation for Get-VSTeamPullRequest was using the Synopsis and Description for Get-VSTeamWorkItem

## PR Checklist

- [ ] [Write Help](https://github.com/DarqueWarrior/vsteam/blob/master/.github/CONTRIBUTING.md#write-help)
- [ ] [Write Unit Test](https://github.com/DarqueWarrior/vsteam/blob/master/.github/CONTRIBUTING.md#write-unit-test)
- [ ] [Update VSTeam.psd1](https://github.com/DarqueWarrior/vsteam/blob/master/.github/CONTRIBUTING.md#add-a-format-file)
- [X] [Update CHANGELOG.md](https://github.com/DarqueWarrior/vsteam/blob/master/.github/CONTRIBUTING.md#add-a-format-file)
