### PR TITLE
Get-VSTeamVariableGroup fixes

### DIFF
--- a/Source/Public/Get-VSTeamVariableGroup.ps1
+++ b/Source/Public/Get-VSTeamVariableGroup.ps1
@@ -30,9 +30,9 @@ function Get-VSTeamVariableGroup {
             $resp = _callAPI -ProjectName $ProjectName -Area 'distributedtask' -Resource 'variablegroups' -Version $([VSTeamVersions]::VariableGroups) -Method Get `
                -QueryString @{groupName = $Name}
 
-            _applyTypesToVariableGroup -item $resp
+            _applyTypesToVariableGroup -item $resp.value
 
-            Write-Output $resp
+            Write-Output $resp.value
          }
          else {
             # Call the REST API

--- a/Source/Public/Get-VSTeamVariableGroup.ps1
+++ b/Source/Public/Get-VSTeamVariableGroup.ps1
@@ -30,6 +30,8 @@ function Get-VSTeamVariableGroup {
             $resp = _callAPI -ProjectName $ProjectName -Area 'distributedtask' -Resource 'variablegroups' -Version $([VSTeamVersions]::VariableGroups) -Method Get `
                -QueryString @{groupName = $Name}
 
+            _applyTypesToVariableGroup -item $resp
+
             Write-Output $resp
          }
          else {

--- a/unit/test/variableGroups.Tests.ps1
+++ b/unit/test/variableGroups.Tests.ps1
@@ -56,7 +56,7 @@ InModuleScope VSTeam {
          Mock Invoke-RestMethod {
 
             $collection = Get-Content $sampleFile2017 | ConvertFrom-Json
-            return $collection.value | Where-Object {$_.name -eq "TestVariableGroup1"}
+            return $collection | Where-Object {$_.value.name -eq "TestVariableGroup1"}
          }
 
          It 'Should return one variable group' {


### PR DESCRIPTION
# PR Summary

<!-- summarize your PR between here and the checklist -->

- a minor tweak to [my last accepted PR](https://github.com/DarqueWarrior/vsteam/pull/191): I didn't _applyTypesToVarGroup on the object returned
- When getting by name: Write-Output $resp.value instead of Write-Output $resp
