### PR TITLE
Add/Update Var Group: Support for Body Param

### DIFF
--- a/.docs/Add-VSTeamVariableGroup.md
+++ b/.docs/Add-VSTeamVariableGroup.md
@@ -63,6 +63,27 @@ $methodParameters = @{
 Add-VSTeamVariableGroup @methodParameters
 ```
 
+### -------------------------- EXAMPLE 3 --------------------------
+
+```powershell
+# Copy variable group varGroupName from project sourceProjectName to project targetProjectName.  If varGroupName already exists, we'll update it; else, we'll add it.
+
+$Name = "varGroupName"
+$FromProject  = "sourceProjectName"
+$ToProject = "targetProjectName"
+
+$FromVariableGroupObject = Get-VSTeamVariableGroup -Name $Name -ProjectName $FromProject
+$body = ConvertTo-Json -InputObject $FromVariableGroupObject -Depth 100 -Compress
+$toVariableGroupObject = Get-VSTeamVariableGroup -Name $Name -ProjectName $ToProject
+if ($toVariableGroupObject) {
+   Update-VSTeamVariableGroup -Body $body -ProjectName $ToProject -Id $toVariableGroupObject.id
+}
+else {
+   Add-VSTeamVariableGroup -Body $body -ProjectName $ToProject   
+}
+
+```
+
 ## PARAMETERS
 
 <!-- #include "./params/projectName.md" -->
@@ -73,6 +94,7 @@ The variable group description
 
 ```yaml
 Type: String
+Parameter Sets: ByHashtable
 Aliases:
 
 Required: True
@@ -88,6 +110,7 @@ The variable group name
 
 ```yaml
 Type: String
+Parameter Sets: ByHashtable
 Aliases:
 
 Required: True
@@ -103,6 +126,7 @@ The variable group ProviderData.  This parameter is not available in TFS2017. Th
 
 ```yaml
 Type: Hashtable
+Parameter Sets: ByHashtable
 Aliases:
 
 Required: False
@@ -118,6 +142,7 @@ The variable group type.  This parameter is not available in TFS2017; all variab
 
 ```yaml
 Type: String
+Parameter Sets: ByHashtable
 Aliases:
 Accepted values: Vsts, AzureKeyVault
 
@@ -134,6 +159,23 @@ The variable group variables.
 
 ```yaml
 Type: Hashtable
+Parameter Sets: ByHashtable
+Aliases:
+
+Required: True
+Position: Named
+Default value: None
+Accept pipeline input: True (ByPropertyName)
+Accept wildcard characters: False
+```
+
+### -Body
+
+The json that represents the variable group as a string
+
+```yaml
+Type: String
+Parameter Sets: ByBody
 Aliases:
 
 Required: True

--- a/.docs/Update-VSTeamVariableGroup.md
+++ b/.docs/Update-VSTeamVariableGroup.md
@@ -56,6 +56,27 @@ $methodParameters = @{
 Update-VSTeamVariableGroup @methodParameters
 ```
 
+### -------------------------- EXAMPLE 2 --------------------------
+
+```powershell
+# Copy variable group varGroupName from project sourceProjectName to project targetProjectName.  If varGroupName already exists, we'll update it; else, we'll add it.
+
+$Name = "varGroupName"
+$FromProject  = "sourceProjectName"
+$ToProject = "targetProjectName"
+
+$FromVariableGroupObject = Get-VSTeamVariableGroup -Name $Name -ProjectName $FromProject
+$body = ConvertTo-Json -InputObject $FromVariableGroupObject -Depth 100 -Compress
+$toVariableGroupObject = Get-VSTeamVariableGroup -Name $Name -ProjectName $ToProject
+if ($toVariableGroupObject) {
+   Update-VSTeamVariableGroup -Body $body -ProjectName $ToProject -Id $toVariableGroupObject.id
+}
+else {
+   Add-VSTeamVariableGroup -Body $body -ProjectName $ToProject   
+}
+
+```
+
 ## PARAMETERS
 
 ### -Confirm
@@ -129,6 +150,7 @@ The variable group description
 
 ```yaml
 Type: String
+Parameter Sets: ByHashtable
 Aliases:
 
 Required: True
@@ -144,6 +166,7 @@ The variable group name
 
 ```yaml
 Type: String
+Parameter Sets: ByHashtable
 Aliases:
 
 Required: True
@@ -159,6 +182,7 @@ The variable group ProviderData.  This parameter is not available in TFS2017. Th
 
 ```yaml
 Type: Hashtable
+Parameter Sets: ByHashtable
 Aliases:
 
 Required: False
@@ -174,6 +198,7 @@ The variable group type.  This parameter is not available in TFS2017; all variab
 
 ```yaml
 Type: String
+Parameter Sets: ByHashtable
 Aliases:
 Accepted values: Vsts, AzureKeyVault
 
@@ -190,6 +215,23 @@ The variable group variables.
 
 ```yaml
 Type: Hashtable
+Parameter Sets: ByHashtable
+Aliases:
+
+Required: True
+Position: Named
+Default value: None
+Accept pipeline input: True (ByPropertyName)
+Accept wildcard characters: False
+```
+
+### -Body
+
+The json that represents the task group as a string
+
+```yaml
+Type: String
+Parameter Sets: ByBody
 Aliases:
 
 Required: True

--- a/Source/Public/Add-VSTeamVariableGroup.ps1
+++ b/Source/Public/Add-VSTeamVariableGroup.ps1
@@ -1,19 +1,22 @@
 function Add-VSTeamVariableGroup {
    param(
-      [Parameter(Mandatory = $true, ValueFromPipelineByPropertyName = $true)]
+      [Parameter(ParameterSetName = 'ByHashtable', Mandatory = $true, ValueFromPipelineByPropertyName = $true)]
       [string] $Name,
 
-      [Parameter(Mandatory = $true, ValueFromPipelineByPropertyName = $true)]
+      [Parameter(ParameterSetName = 'ByHashtable', Mandatory = $true, ValueFromPipelineByPropertyName = $true)]
       [string] $Description,
 
-      [Parameter(Mandatory = $true, ValueFromPipelineByPropertyName = $true)]
-      [hashtable] $Variables
+      [Parameter(ParameterSetName = 'ByHashtable', Mandatory = $true, ValueFromPipelineByPropertyName = $true)]
+      [hashtable] $Variables,
+
+      [Parameter(ParameterSetName = 'ByBody', Mandatory = $true, ValueFromPipelineByPropertyName = $true)]
+      [string] $Body
    )
 
    DynamicParam {
       $dp = _buildProjectNameDynamicParam
 
-      if ([VSTeamVersions]::Version -ne "TFS2017") {
+      if ([VSTeamVersions]::Version -ne "TFS2017" -and $PSCmdlet.ParameterSetName -eq "ByHashtable") {
          $ParameterName = 'Type'
          $rp = _buildDynamicParam -ParameterName $ParameterName -arrSet ('Vsts', 'AzureKeyVault') -Mandatory $true
          $dp.Add($ParameterName, $rp)
@@ -30,22 +33,25 @@ function Add-VSTeamVariableGroup {
       # Bind the parameter to a friendly variable
       $ProjectName = $PSBoundParameters["ProjectName"]
 
-      $body = @{
+      if ([string]::IsNullOrWhiteSpace($Body))
+      {
+         $bodyAsHashtable = @{
          name        = $Name
          description = $Description
          variables   = $Variables
       }
       if ([VSTeamVersions]::Version -ne "TFS2017") {
          $Type = $PSBoundParameters['Type']
-         $body.Add("type", $Type)
+            $bodyAsHashtable.Add("type", $Type)
 
          $ProviderData = $PSBoundParameters['ProviderData']
          if ($null -ne $ProviderData) {
-            $body.Add("providerData", $ProviderData)
+               $bodyAsHashtable.Add("providerData", $ProviderData)
          }
       }
 
-      $body = $body | ConvertTo-Json
+         $body = $bodyAsHashtable | ConvertTo-Json
+      }
 
       # Call the REST API
       $resp = _callAPI -ProjectName $projectName -Area 'distributedtask' -Resource 'variablegroups'  `

--- a/Source/Public/Update-VSTeamVariableGroup.ps1
+++ b/Source/Public/Update-VSTeamVariableGroup.ps1
@@ -4,14 +4,17 @@ function Update-VSTeamVariableGroup {
       [Parameter(Mandatory = $true, ValueFromPipelineByPropertyName = $true)]
       [string] $Id,
 
-      [Parameter(Mandatory = $true, ValueFromPipelineByPropertyName = $true)]
+      [Parameter(ParameterSetName = 'ByHashtable', Mandatory = $true, ValueFromPipelineByPropertyName = $true)]
       [string] $Name,
 
-      [Parameter(Mandatory = $true, ValueFromPipelineByPropertyName = $true)]
+      [Parameter(ParameterSetName = 'ByHashtable', Mandatory = $true, ValueFromPipelineByPropertyName = $true)]
       [string] $Description,
 
-      [Parameter(Mandatory = $true, ValueFromPipelineByPropertyName = $true)]
+      [Parameter(ParameterSetName = 'ByHashtable', Mandatory = $true, ValueFromPipelineByPropertyName = $true)]
       [hashtable] $Variables,
+
+      [Parameter(ParameterSetName = 'ByBody', Mandatory = $true, ValueFromPipelineByPropertyName = $true)]
+      [string] $Body,
 
       [switch] $Force
    )
@@ -19,7 +22,7 @@ function Update-VSTeamVariableGroup {
    DynamicParam {
       $dp = _buildProjectNameDynamicParam
 
-      if ([VSTeamVersions]::Version -ne "TFS2017") {
+      if ([VSTeamVersions]::Version -ne "TFS2017" -and $PSCmdlet.ParameterSetName -eq "ByHashtable") {
          $ParameterName = 'Type'
          $rp = _buildDynamicParam -ParameterName $ParameterName -arrSet ('Vsts', 'AzureKeyVault') -Mandatory $true
          $dp.Add($ParameterName, $rp)
@@ -36,22 +39,26 @@ function Update-VSTeamVariableGroup {
       # Bind the parameter to a friendly variable
       $ProjectName = $PSBoundParameters["ProjectName"]
 
-      $body = @{
+      
+      if ([string]::IsNullOrWhiteSpace($Body))
+      {
+         $bodyAsHashtable = @{
          name        = $Name
          description = $Description
          variables   = $Variables
       }
       if ([VSTeamVersions]::Version -ne "TFS2017") {
          $Type = $PSBoundParameters['Type']
-         $body.Add("type", $Type)
+            $bodyAsHashtable.Add("type", $Type)
 
          $ProviderData = $PSBoundParameters['ProviderData']
          if ($null -ne $ProviderData) {
-            $body.Add("providerData", $ProviderData)
+               $bodyAsHashtable.Add("providerData", $ProviderData)
          }
       }
 
-      $body = $body | ConvertTo-Json
+         $body = $bodyAsHashtable | ConvertTo-Json
+      }
 
       if ($Force -or $pscmdlet.ShouldProcess($Id, "Update Variable Group")) {
          # Call the REST API

--- a/unit/test/variableGroups.Tests.ps1
+++ b/unit/test/variableGroups.Tests.ps1
@@ -237,6 +237,16 @@ InModuleScope VSTeam {
 
             Assert-MockCalled Invoke-RestMethod -Exactly -Scope It -Times 1 -ParameterFilter { $Method -eq 'Post' }
          }
+         
+         It "should create a new var group when passing the json as the body" {
+            $body = Get-Content $sampleFileVSTS -Raw
+            $projName = "project"
+            Add-VSTeamVariableGroup -Body $body -ProjectName $projName
+
+            Assert-MockCalled Invoke-RestMethod -Exactly -Scope It -Times 1 -ParameterFilter { 
+               $Uri -eq "https://dev.azure.com/test/$projName/_apis/distributedtask/variablegroups/?api-version=$([VSTeamVersions]::VariableGroups)" -and
+               $Method -eq 'Post' }
+         }
       }
 
       Context 'Update-VSTeamVariableGroup' {
@@ -269,6 +279,18 @@ InModuleScope VSTeam {
 
             Assert-MockCalled Invoke-RestMethod -Exactly -Scope It -Times 1 -ParameterFilter {
                $Uri -eq "https://dev.azure.com/test/project/_apis/distributedtask/variablegroups/$($testParameters.id)?api-version=$([VSTeamVersions]::VariableGroups)" -and
+               $Method -eq 'Put'
+            }
+         }
+
+         It "should update an existing var group when passing the json as the body" {
+            $body = Get-Content $sampleFileVSTS -Raw
+            $projName = "project"
+            $id = "1"
+            Update-VSTeamVariableGroup -Body $body -ProjectName $projName -Id $id
+            
+            Assert-MockCalled Invoke-RestMethod -Exactly -Scope It -Times 1 -ParameterFilter {
+               $Uri -eq "https://dev.azure.com/test/$projName/_apis/distributedtask/variablegroups/$($id)?api-version=$([VSTeamVersions]::VariableGroups)" -and
                $Method -eq 'Put'
             }
          }


### PR DESCRIPTION
# PR Summary

Add/Update Var Group: Support for Body Param, so that json can be directly provided rather than a hashtable of variables.  See the example in the documentation for more use case details.

## PR Checklist

- [x] [Write Help](https://github.com/DarqueWarrior/vsteam/blob/master/.github/CONTRIBUTING.md#write-help)
- [x] [Write Unit Test](https://github.com/DarqueWarrior/vsteam/blob/master/.github/CONTRIBUTING.md#write-unit-test)