### PR TITLE
Remove-VSTeamAccessControlEntry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## 6.4.2
 
-Merged [Pull Request](https://github.com/DarqueWarrior/vsteam/pull/<pull-request-number>) from [Steven Cady](https://github.com/cadacious) which included the following:
+Merged [Pull Request](https://github.com/DarqueWarrior/vsteam/pull/221) from [Steven Cady](https://github.com/cadacious) which included the following:
 
 Added Remove-VSTeamAccessControlEntry to delete users/groups from Access Control Lists within security namespaces. Supports removing single or multiple entries. Only supports removing vsts origin users/groups.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 Merged [Pull Request](https://github.com/DarqueWarrior/vsteam/pull/<pull-request-number>) from [Steven Cady](https://github.com/cadacious) which included the following:
 
-Added Remove-VSTeamAccessControlEntry to delete users/groups from Access Control Lists within security namespaces. Supports removing single or multiple entries. Can remove vsts origin or aad origin, but not in the same run. Origin defaults to vsts if not specified.
+Added Remove-VSTeamAccessControlEntry to delete users/groups from Access Control Lists within security namespaces. Supports removing single or multiple entries. Only supports removing vsts origin users/groups.
 
 ## 6.4.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,24 @@
 # Changelog
-
-## 6.4.2
+## 6.4.3
 
 Merged [Pull Request](https://github.com/DarqueWarrior/vsteam/pull/224) from [Steven Cady](https://github.com/cadacious) which included the following:
 
 Added Remove-VSTeamAccessControlEntry to delete users/groups from Access Control Lists within security namespaces. Supports removing single or multiple entries. Only supports removing vsts origin users/groups.
+
+## 6.4.2
+
+Merged [Pull Request](https://github.com/DarqueWarrior/vsteam/pull/226) from [Asif Mithawala](https://github.com/asifma) which included the following:
+
+Added property checks in VSTeamJobRequest
+
+Merged [Pull Request](https://github.com/DarqueWarrior/vsteam/pull/227) from [Sebastian Schütze](https://github.com/SebastianSchuetze) which included the following:
+
+Added Remove-VSTeamWorkItem to delete work items
+
+- Added a parameter to filter unit tests
+- Added documentation on parameters of Build-Module.ps1 in code and for README.MD
+- Removed references to update the .PSD1 file in the PR template as well as in the contribution doc, since it does not seem to be needed anymore, because it is generated automatically.
+- Added coverage.xml to the .gitignore file
 
 ## 6.4.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 6.4.2
+
+Merged [Pull Request](https://github.com/DarqueWarrior/vsteam/pull/<pull-request-number>) from [Steven Cady](https://github.com/cadacious) which included the following:
+
+Added Remove-VSTeamAccessControlEntry to delete users/groups from Access Control Lists within security namespaces. Supports removing single or multiple entries. Can remove vsts origin or aad origin, but not in the same run. Origin defaults to vsts if not specified.
+
 ## 6.4.1
 
 Fixed issue [Description on variable groups is not a required field #208](https://github.com/DarqueWarrior/vsteam/issues/208).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## 6.4.2
 
-Merged [Pull Request](https://github.com/DarqueWarrior/vsteam/pull/221) from [Steven Cady](https://github.com/cadacious) which included the following:
+Merged [Pull Request](https://github.com/DarqueWarrior/vsteam/pull/224) from [Steven Cady](https://github.com/cadacious) which included the following:
 
 Added Remove-VSTeamAccessControlEntry to delete users/groups from Access Control Lists within security namespaces. Supports removing single or multiple entries. Only supports removing vsts origin users/groups.
 

--- a/Source/Public/Remove-VSTeamAccessControlEntry.ps1
+++ b/Source/Public/Remove-VSTeamAccessControlEntry.ps1
@@ -37,7 +37,13 @@ function Remove-VSTeamAccessControlEntry {
             foreach($UniqueDescriptor in $Descriptor.Split(","))
             {
                 $UniqueDescriptor = ($UniqueDescriptor).split(".")[1]
-                $UniqueDescriptor = [System.Text.Encoding]::UTF8.GetString([System.Convert]::FromBase64String($UniqueDescriptor))
+                try{
+                    $UniqueDescriptor = [System.Text.Encoding]::UTF8.GetString([System.Convert]::FromBase64String($UniqueDescriptor))
+                }
+                catch
+                {
+                    Throw "Could not convert base64 string to string."
+                }
                 $UniqueDescriptor = "Microsoft.TeamFoundation.Identity;"+"$UniqueDescriptor"
 
                 $Descriptors += $UniqueDescriptor
@@ -48,7 +54,15 @@ function Remove-VSTeamAccessControlEntry {
         else 
         {
             $Descriptor = ($descriptor).split(".")[1]
-            $Descriptor = [System.Text.Encoding]::UTF8.GetString([System.Convert]::FromBase64String($Descriptor))
+            try
+            {
+                 $Descriptor = [System.Text.Encoding]::UTF8.GetString([System.Convert]::FromBase64String($Descriptor))
+            }
+            catch
+            {
+                 Return "Could not convert base64 string to string."
+            }
+            
             $Descriptor = "Microsoft.TeamFoundation.Identity;"+"$descriptor"
 
             [Uri]$Uri = "$($env:TEAM_ACCT)/_apis/accesscontrolentries/$($securityNamespaceId)?token=$($token)&descriptors=$($descriptor)&api-version=5.1"
@@ -56,5 +70,7 @@ function Remove-VSTeamAccessControlEntry {
 
         # Call the REST API
         $resp = _callAPI -method DELETE -Url $Uri -ContentType "application/json"
+
+	return $resp
     }
  }

--- a/Source/Public/Remove-VSTeamAccessControlEntry.ps1
+++ b/Source/Public/Remove-VSTeamAccessControlEntry.ps1
@@ -29,7 +29,7 @@ function Remove-VSTeamAccessControlEntry {
                 $uniqueDescriptor = ($uniqueDescriptor).split(".")[1]
                 try {
                     
-                    $uniqueDescriptor = [System.Text.Encoding]::UTF8.GetString([System.Convert]::FromBase64String("Uy0xLTktMTU1MTM3NDI0NS0xMzk4ODc2NjMwLTEwMTQ0ODQ4MTMtMzE5MDA4NTI4Ny0xNDU4NTkwODY1LTEtMzE1MjE3NTkwMy03NjE1NjY3OTMtMjgwMTUwMjI2Ny0zMjU5Mjg5MTIy"))
+                    $uniqueDescriptor = [System.Text.Encoding]::UTF8.GetString([System.Convert]::FromBase64String("$uniqueDescriptor"))
                 }
                 catch [FormatException]{
                     Write-Error "Could not convert base64 string to string."

--- a/Source/Public/Remove-VSTeamAccessControlEntry.ps1
+++ b/Source/Public/Remove-VSTeamAccessControlEntry.ps1
@@ -1,0 +1,60 @@
+function Remove-VSTeamAccessControlEntry {
+    [CmdletBinding(DefaultParameterSetName = 'ByNamespace')]
+    param(
+       [Parameter(ParameterSetName = 'ByNamespace', Mandatory = $true, ValueFromPipeline = $true)]
+       [VSTeamSecurityNamespace] $SecurityNamespace,
+ 
+       [Parameter(ParameterSetName = 'ByNamespaceId', Mandatory = $true)]
+       [ValidateScript({
+          try {
+              [System.Guid]::Parse($_) | Out-Null
+              $true
+          } catch {
+              $false
+          }
+       })]
+       [string] $SecurityNamespaceId,
+ 
+       [Parameter(ParameterSetName = 'ByNamespace', Mandatory = $true)]
+       [Parameter(ParameterSetName = 'ByNamespaceId', Mandatory = $true)]
+       [string] $Token,
+ 
+       [Parameter(ParameterSetName = 'ByNamespace', Mandatory = $true)]
+       [Parameter(ParameterSetName = 'ByNamespaceId', Mandatory = $true)]
+       [string] $Descriptor
+    )
+ 
+    process {
+        if ($SecurityNamespace)
+        {
+            $SecurityNamespaceId = $SecurityNamespace.ID
+        }
+
+        if ($Descriptor -like "*,*")
+        {
+            $Descriptors = @()
+
+            foreach($UniqueDescriptor in $Descriptor.Split(","))
+            {
+                $UniqueDescriptor = ($UniqueDescriptor).split(".")[1]
+                $UniqueDescriptor = [System.Text.Encoding]::UTF8.GetString([System.Convert]::FromBase64String($UniqueDescriptor))
+                $UniqueDescriptor = "Microsoft.TeamFoundation.Identity;"+"$UniqueDescriptor"
+
+                $Descriptors += $UniqueDescriptor
+            }
+
+            [Uri]$Uri = "$($env:TEAM_ACCT)/_apis/accesscontrolentries/$($securityNamespaceId)?token=$($token)&descriptors=$($descriptors -join ",")&api-version=5.1"
+        }
+        else 
+        {
+            $Descriptor = ($descriptor).split(".")[1]
+            $Descriptor = [System.Text.Encoding]::UTF8.GetString([System.Convert]::FromBase64String($Descriptor))
+            $Descriptor = "Microsoft.TeamFoundation.Identity;"+"$descriptor"
+
+            [Uri]$Uri = "$($env:TEAM_ACCT)/_apis/accesscontrolentries/$($securityNamespaceId)?token=$($token)&descriptors=$($descriptor)&api-version=5.1"
+        }
+
+        # Call the REST API
+        $resp = _callAPI -method DELETE -Url $Uri -ContentType "application/json"
+    }
+ }

--- a/Source/VSTeam.psd1
+++ b/Source/VSTeam.psd1
@@ -12,7 +12,7 @@
    RootModule        = 'VSTeam.psm1'
 
    # Version number of this module.
-   ModuleVersion     = '6.4.1'
+   ModuleVersion     = '6.4.2'
 
    # Supported PSEditions
    # CompatiblePSEditions = @()

--- a/docs/Remove-VSTeamAccessControlEntry.md
+++ b/docs/Remove-VSTeamAccessControlEntry.md
@@ -1,0 +1,141 @@
+
+
+
+# Remove-VSTeamAccessControlEntry
+
+## SYNOPSIS
+
+Removes specified ACEs in the ACL for the provided token. The request URI contains the namespace ID, the target token, and a single or list of descriptors that should be removed. Only supports removing AzD based users/groups.
+
+## SYNTAX
+
+## DESCRIPTION
+
+Removes specified ACEs in the ACL for the provided token. The request URI contains the namespace ID, the target token, and a single or list of descriptors that should be removed. Only supports removing AzD based users/groups.
+
+## EXAMPLES
+
+## PARAMETERS
+
+### -SecurityNamespace
+
+VSTeamSecurityNamespace object.
+
+```yaml
+Type: VSTeamSecurityNamespace
+Required: True
+```
+
+### -SecurityNamespaceId
+
+Security namespace identifier.
+
+Valid IDs are:
+
+AzD:
+- Analytics (58450c49-b02d-465a-ab12-59ae512d6531)
+- AnalyticsViews (d34d3680-dfe5-4cc6-a949-7d9c68f73cba)
+- ReleaseManagement (7c7d32f7-0e86-4cd6-892e-b35dbba870bd)
+- ReleaseManagement2 (c788c23e-1b46-4162-8f5e-d7585343b5de)
+- Identity (5a27515b-ccd7-42c9-84f1-54c998f03866)
+- WorkItemTrackingAdministration (445d2788-c5fb-4132-bbef-09c4045ad93f)
+- DistributedTask (101eae8c-1709-47f9-b228-0e476c35b3ba)
+- WorkItemQueryFolders (71356614-aad7-4757-8f2c-0fb3bff6f680)
+- GitRepositories (2e9eb7ed-3c0a-47d4-87c1-0ffdd275fd87)
+- VersionControlItems2 (3c15a8b7-af1a-45c2-aa97-2cb97078332e)
+- EventSubscriber (2bf24a2b-70ba-43d3-ad97-3d9e1f75622f)
+- WorkItemTrackingProvision (5a6cd233-6615-414d-9393-48dbb252bd23)
+- ServiceEndpoints (49b48001-ca20-4adc-8111-5b60c903a50c)
+- ServiceHooks (cb594ebe-87dd-4fc9-ac2c-6a10a4c92046)
+- Chat (bc295513-b1a2-4663-8d1a-7017fd760d18)
+- Collection (3e65f728-f8bc-4ecd-8764-7e378b19bfa7)
+- Proxy (cb4d56d2-e84b-457e-8845-81320a133fbb)
+- Plan (bed337f8-e5f3-4fb9-80da-81e17d06e7a8)
+- Process (2dab47f9-bd70-49ed-9bd5-8eb051e59c02)
+- AccountAdminSecurity (11238e09-49f2-40c7-94d0-8f0307204ce4)
+- Library (b7e84409-6553-448a-bbb2-af228e07cbeb)
+- Environment (83d4c2e6-e57d-4d6e-892b-b87222b7ad20)
+- Project (52d39943-cb85-4d7f-8fa8-c6baac873819)
+- EventSubscription (58b176e7-3411-457a-89d0-c6d0ccb3c52b)
+- CSS (83e28ad4-2d72-4ceb-97b0-c7726d5502c3)
+- TeamLabSecurity (9e4894c3-ff9a-4eac-8a85-ce11cafdc6f1)
+- ProjectAnalysisLanguageMetrics (fc5b7b85-5d6b-41eb-8534-e128cb10eb67)
+- Tagging (bb50f182-8e5e-40b8-bc21-e8752a1e7ae2)
+- MetaTask (f6a4de49-dbe2-4704-86dc-f8ec1a294436)
+- Iteration (bf7bfa03-b2b7-47db-8113-fa2e002cc5b1)
+- Favorites (fa557b48-b5bf-458a-bb2b-1b680426fe8b)
+- Registry (4ae0db5d-8437-4ee8-a18b-1f6fb38bd34c)
+- Graph (c2ee56c9-e8fa-4cdd-9d48-2c44f697a58e)
+- ViewActivityPaneSecurity (dc02bf3d-cd48-46c3-8a41-345094ecc94b)
+- Job (2a887f97-db68-4b7c-9ae3-5cebd7add999)
+- WorkItemTracking (73e71c45-d483-40d5-bdba-62fd076f7f87)
+- StrongBox (4a9e8381-289a-4dfd-8460-69028eaa93b3)
+- Server (1f4179b3-6bac-4d01-b421-71ea09171400)
+- TestManagement  (e06e1c24-e93d-4e4a-908a-7d951187b483)
+- SettingEntries (6ec4592e-048c-434e-8e6c-8671753a8418)
+- BuildAdministration (302acaca-b667-436d-a946-87133492041c)
+- Location (2725d2bc-7520-4af4-b0e3-8d876494731f)
+- Boards (251e12d9-bea3-43a8-bfdb-901b98c0125e)
+- UtilizationPermissions (83abde3a-4593-424e-b45f-9898af99034d)
+- WorkItemsHub (c0e7a722-1cad-4ae6-b340-a8467501e7ce)
+- WebPlatform (0582eb05-c896-449a-b933-aa3d99e121d6)
+- VersionControlPrivileges (66312704-deb5-43f9-b51c-ab4ff5e351c3)
+- Workspaces (93bafc04-9075-403a-9367-b7164eac6b5c)
+- CrossProjectWidgetView (093cbb02-722b-4ad6-9f88-bc452043fa63)
+- WorkItemTrackingConfiguration (35e35e8e-686d-4b01-aff6-c369d6e36ce0)
+- Discussion Threads (0d140cae-8ac1-4f48-b6d1-c93ce0301a12)
+- BoardsExternalIntegration (5ab15bc8-4ea1-d0f3-8344-cab8fe976877)
+- DataProvider (7ffa7cf4-317c-4fea-8f1d-cfda50cfa956)
+- Social (81c27cc8-7a9f-48ee-b63f-df1e1d0412dd)
+- Security (9a82c708-bfbe-4f31-984c-e860c2196781)
+- IdentityPicker (a60e0d84-c2f8-48e4-9c0c-f32da48d5fd1)
+- ServicingOrchestration (84cc1aa4-15bc-423d-90d9-f97c450fc729)
+- Build (33344d9c-fc72-4d6f-aba5-fa317101a7e9)
+- DashboardsPrivileges (8adf73b7-389a-4276-b638-fe1653f7efc7)
+- VersionControlItems (a39371cf-0841-4c16-bbd3-276e341bc052)
+
+VSSPS:
+- EventSubscriber (2bf24a2b-70ba-43d3-ad97-3d9e1f75622f) (VSSPS)
+- EventSubscription (58b176e7-3411-457a-89d0-c6d0ccb3c52b) (VSSPS)
+- Registry (4ae0db5d-8437-4ee8-a18b-1f6fb38bd34c) (VSSPS)
+- Graph (c2ee56c9-e8fa-4cdd-9d48-2c44f697a58e) (VSSPS)
+- Invitation (ea0b4d1e-577a-4797-97b5-2f5755e548d5) (VSSPS)
+- SystemGraph (b24dfdf1-285a-4ea6-a55b-32549a68121d) (VSSPS)
+- Job (2a887f97-db68-4b7c-9ae3-5cebd7add999) (VSSPS)
+- CommerceCollectionSecurity (307be2d3-12ed-45c2-aacf-6598760efca7) (VSSPS)
+- StrongBox (4a9e8381-289a-4dfd-8460-69028eaa93b3) (VSSPS)
+- GroupLicensing (c6a4fd35-b508-49eb-8ea7-7189df5f3698) (VSSPS)
+- Server (1f4179b3-6bac-4d01-b421-71ea09171400) (VSSPS)
+- SettingEntries (6ec4592e-048c-434e-8e6c-8671753a8418) (VSSPS)
+- RemotableTemplateTest (ccdcb71c-4780-4a42-9bb4-8bce07a7628f) (VSSPS)
+- Location (2725d2bc-7520-4af4-b0e3-8d876494731f) (VSSPS)
+- WebPlatform (0582eb05-c896-449a-b933-aa3d99e121d6) (VSSPS)
+- DataProvider (7ffa7cf4-317c-4fea-8f1d-cfda50cfa956) (VSSPS)
+- Security (9a82c708-bfbe-4f31-984c-e860c2196781) (VSSPS)
+- IdentityPicker (a60e0d84-c2f8-48e4-9c0c-f32da48d5fd1) (VSSPS)
+- ServicingOrchestration (84cc1aa4-15bc-423d-90d9-f97c450fc729) (VSSPS)
+
+```yaml
+Type: String
+Required: True
+```
+
+### -Token
+
+The security Token
+
+```yaml
+Type: String
+Required: True
+```
+
+## INPUTS
+
+## OUTPUTS
+
+## NOTES
+
+### This function outputs a warning if the ACE removal from the ACL returns $False. This can be due to the wrong descriptor being provided, or the descriptor already not being on the ACL.
+
+## RELATED LINKS
+

--- a/docs/Remove-VSTeamAccessControlEntry.md
+++ b/docs/Remove-VSTeamAccessControlEntry.md
@@ -14,6 +14,53 @@ Removes specified ACEs in the ACL for the provided token. The request URI contai
 Removes specified ACEs in the ACL for the provided token. The request URI contains the namespace ID, the target token, and a single or list of descriptors that should be removed. Only supports removing AzD based users/groups.
 
 ## EXAMPLES
+### -------------------------- EXAMPLE 1 --------------------------
+
+```PowerShell
+PS C:\> Remove-VSTeamAccessControlEntry -securityNamespaceId "2e9eb7ed-3c0a-47d4-87c1-0ffdd275fd87" -token "repov2/$projectid/$repoid" -descriptor @("vssgp.Uy0xLTktMTU1MTM3NDI0NS0xMzk4ODc2NjMwLTEwMTQ0ODQ4MTMtMzE5MDA4NTI4Ny0xNDU4NTkwODY1LTEtMzE1MjE3NTkwMy03NjE1NjY3OTMtMjgwMTUwMjI2Ny0zMjU5Mjg5MTIy")
+```
+
+This will remove the specified descriptor from the specified repository, using the security namespace id, while confirming for the remove action.
+
+### -------------------------- EXAMPLE 2 --------------------------
+
+```PowerShell
+PS C:\> Remove-VSTeamAccessControlEntry -securityNamespaceId "2e9eb7ed-3c0a-47d4-87c1-0ffdd275fd87" -token "repov2/$projectid/$repoid" -descriptor @("vssgp.Uy0xLTktMTU1MTM3NDI0NS0xMzk4ODc2NjMwLTEwMTQ0ODQ4MTMtMzE5MDA4NTI4Ny0xNDU4NTkwODY1LTEtMzE1MjE3NTkwMy03NjE1NjY3OTMtMjgwMTUwMjI2Ny0zMjU5Mjg5MTIy") -confirm:$false
+```
+
+This will remove the specified descriptor from the specified repository, using the security namespace id, with no confirmation for the remove action.
+
+### -------------------------- EXAMPLE 3 --------------------------
+
+```PowerShell
+PS C:\> Remove-VSTeamAccessControlEntry -securityNamespaceId "2e9eb7ed-3c0a-47d4-87c1-0ffdd275fd87" -token "repov2/$projectid/$repoid" -descriptor @("descriptor1","descriptor2")
+```
+
+This will remove multiple descriptors from the specified repository, using the security namespace id, while confirming for the remove action.
+
+### -------------------------- EXAMPLE 4 --------------------------
+
+```PowerShell
+PS C:\> Remove-VSTeamAccessControlEntry -securityNamespace [VSTeamSecurityNamespace]$securityNamespace -token "repov2/$projectid/$repoid" -descriptor @("vssgp.Uy0xLTktMTU1MTM3NDI0NS0xMzk4ODc2NjMwLTEwMTQ0ODQ4MTMtMzE5MDA4NTI4Ny0xNDU4NTkwODY1LTEtMzE1MjE3NTkwMy03NjE1NjY3OTMtMjgwMTUwMjI2Ny0zMjU5Mjg5MTIy")
+```
+
+This will remove the specified descriptor from the specified repository, using a security namespace object, while confirming for the remove action.
+
+### -------------------------- EXAMPLE 5 --------------------------
+
+```PowerShell
+PS C:\> Remove-VSTeamAccessControlEntry -securityNamespace [VSTeamSecurityNamespace]$securityNamespace -token "repov2/$projectid/$repoid" -descriptor @("vssgp.Uy0xLTktMTU1MTM3NDI0NS0xMzk4ODc2NjMwLTEwMTQ0ODQ4MTMtMzE5MDA4NTI4Ny0xNDU4NTkwODY1LTEtMzE1MjE3NTkwMy03NjE1NjY3OTMtMjgwMTUwMjI2Ny0zMjU5Mjg5MTIy") -confirm:$false
+```
+
+This will remove the specified descriptor from the specified repository, using a security namespace object, with no confirmation for the remove action.
+
+### -------------------------- EXAMPLE 6 --------------------------
+
+```PowerShell
+PS C:\> Remove-VSTeamAccessControlEntry -securityNamespace [VSTeamSecurityNamespace]$securityNamespace -token "repov2/$projectid/$repoid" -descriptor @("descriptor1","descriptor2")
+```
+
+This will remove multiple descriptors from the specified repository, using a security namespace object, while confirming for the remove action.
 
 ## PARAMETERS
 
@@ -124,8 +171,23 @@ Required: True
 
 The security Token
 
+Valid token formats are:
+
+- Git Repository (repov2/$projectID/$repositoryID)
+- Build Definition ($projectID/$buildDefinitionID)
+- Release Definition ($projectID/$releaseDefinitionID, $projectID/Path/to/Release/$releaseDefinitionID)
+
 ```yaml
 Type: String
+Required: True
+```
+
+### -Descriptor
+
+An array of descriptors of users/groups to be removed
+
+```yaml
+Type: System.Array
 Required: True
 ```
 
@@ -135,7 +197,7 @@ Required: True
 
 ## NOTES
 
-### This function outputs a warning if the ACE removal from the ACL returns $False. This can be due to the wrong descriptor being provided, or the descriptor already not being on the ACL.
+### This function outputs a non-terminating error if the ACE removal from the ACL returns $False. This can be due to the wrong descriptor being provided, or the descriptor already not being on the ACL.
 
 ## RELATED LINKS
 

--- a/unit/test/Remove-VSTeamAccessControlEntry.Tests.ps1
+++ b/unit/test/Remove-VSTeamAccessControlEntry.Tests.ps1
@@ -113,7 +113,7 @@ $securityNamespace =
       [VSTeamVersions]::Core = '5.1'
 
       Context 'Remove-VSTeamAccessControlEntry by SecurityNamespaceId' {
-         Mock Invoke-RestMethod { return $true }
+         Mock Invoke-RestMethod { return $true } -Verifiable
 
          Remove-VSTeamAccessControlEntry -SecurityNamespaceId 2e9eb7ed-3c0a-47d4-87c1-0ffdd275fd87 -Descriptor "vssgp.Uy0xLTktMTU1MTM3NDI0NS0yMTkxNDc4NTk1LTU1MDM1MzIxOC0yNDM3MjM2NDgzLTQyMjkyNzUyNDktMC0wLTAtOC04" -Token xyz
 
@@ -121,9 +121,8 @@ $securityNamespace =
             Assert-MockCalled Invoke-RestMethod -Exactly 1 -ParameterFilter {
                $Uri -like "https://dev.azure.com/test/_apis/accesscontrolentries/2e9eb7ed-3c0a-47d4-87c1-0ffdd275fd87*" -and
                $Uri -like "*api-version=$([VSTeamVersions]::Core)*" -and
-               $Uri -like "*Microsoft.TeamFoundation.Identity;S-1*" -and
                $Uri -like "*?token=xyz*" -and
-               $Uri -like "*&descriptors=abc*" -and
+               $Uri -like "*&descriptors=Microsoft.TeamFoundation.Identity;S-1*" -and
                $ContentType -eq "application/json" -and
                $Method -eq "Delete"
             }
@@ -132,40 +131,38 @@ $securityNamespace =
 
       Context 'Remove-VSTeamAccessControlEntry by SecurityNamespace' {
          Mock Get-VSTeamSecurityNamespace { return $securityNamespace }
-         Mock Invoke-RestMethod { return $true }
+         Mock Invoke-RestMethod { return $true } -Verifiable
 
          $securityNamespace = Get-VSTeamSecurityNamespace -Id "2e9eb7ed-3c0a-47d4-87c1-0ffdd275fd87"
          Remove-VSTeamAccessControlEntry -SecurityNamespace $securityNamespace -Descriptor "vssgp.Uy0xLTktMTU1MTM3NDI0NS0yMTkxNDc4NTk1LTU1MDM1MzIxOC0yNDM3MjM2NDgzLTQyMjkyNzUyNDktMC0wLTAtOC04" -Token xyz 
 
          It 'Should have a properly constructed URL' {
             Assert-MockCalled Invoke-RestMethod -Exactly 1 -ParameterFilter {
-                $Uri -like "https://dev.azure.com/test/_apis/accesscontrolentries/2e9eb7ed-3c0a-47d4-87c1-0ffdd275fd87*" -and
-                $Uri -like "*api-version=$([VSTeamVersions]::Core)*" -and
-                $Uri -like "*Microsoft.TeamFoundation.Identity;S-1*" -and
-                $Uri -like "*?token=xyz*" -and
-                $Uri -like "*&descriptors=abc*" -and
-                $ContentType -eq "application/json" -and
-                $Method -eq "Delete"
+               $Uri -like "https://dev.azure.com/test/_apis/accesscontrolentries/2e9eb7ed-3c0a-47d4-87c1-0ffdd275fd87*" -and
+               $Uri -like "*api-version=$([VSTeamVersions]::Core)*" -and
+               $Uri -like "*?token=xyz*" -and
+               $Uri -like "*&descriptors=Microsoft.TeamFoundation.Identity;S-1*" -and
+               $ContentType -eq "application/json" -and
+               $Method -eq "Delete"
             }
          }
       }
 
       Context 'Remove-VSTeamAccessControlEntry by SecurityNamespace (pipeline)' {
          Mock Get-VSTeamSecurityNamespace { return $securityNamespace }
-         Mock Invoke-RestMethod { return $true }
+         Mock Invoke-RestMethod { return $true } -Verifiable
 
          Get-VSTeamSecurityNamespace -Id "2e9eb7ed-3c0a-47d4-87c1-0ffdd275fd87" | `
          Remove-VSTeamAccessControlEntry -SecurityNamespace $_ -Descriptor "vssgp.Uy0xLTktMTU1MTM3NDI0NS0yMTkxNDc4NTk1LTU1MDM1MzIxOC0yNDM3MjM2NDgzLTQyMjkyNzUyNDktMC0wLTAtOC04" -Token xyz 
 
          It 'Should have a properly constructed URL' {
             Assert-MockCalled Invoke-RestMethod -Exactly 1 -ParameterFilter {
-                $Uri -like "https://dev.azure.com/test/_apis/accesscontrolentries/2e9eb7ed-3c0a-47d4-87c1-0ffdd275fd87*" -and
-                $Uri -like "*api-version=$([VSTeamVersions]::Core)*" -and
-                $Uri -like "*Microsoft.TeamFoundation.Identity;S-1*" -and
-                $Uri -like "*?token=xyz*" -and
-                $Uri -like "*&descriptors=abc*" -and
-                $ContentType -eq "application/json" -and
-                $Method -eq "Delete"
+               $Uri -like "https://dev.azure.com/test/_apis/accesscontrolentries/2e9eb7ed-3c0a-47d4-87c1-0ffdd275fd87*" -and
+               $Uri -like "*api-version=$([VSTeamVersions]::Core)*" -and
+               $Uri -like "*?token=xyz*" -and
+               $Uri -like "*&descriptors=Microsoft.TeamFoundation.Identity;S-1*" -and
+               $ContentType -eq "application/json" -and
+               $Method -eq "Delete"
             }
          }
       }

--- a/unit/test/Remove-VSTeamAccessControlEntry.Tests.ps1
+++ b/unit/test/Remove-VSTeamAccessControlEntry.Tests.ps1
@@ -9,103 +9,20 @@ InModuleScope VSTeam {
 $securityNamespace = 
 @"
 {
-    "DisplayName":  "Git Repositories",
-    "SeparatorValue":  "/",
-    "ElementLength":  -1,
-    "WritePermission":  8192,
-    "ReadPermission":  2,
-    "DataspaceCategory":  "Git",
-    "StructureValue":  "1",
-    "ExtensionType":  "Microsoft.TeamFoundation.Git.Server.Plugins.GitSecurityNamespaceExtension",
-    "IsRemotable":  true,
-    "UseTokenTranslator":  true,
-    "SystemBitMask":  0,
-    "Actions":  [
-                    {
-                        "DisplayName":  "Administer",
-                        "Name":  "Administer",
-                        "Bit":  1
-                    },
-                    {
-                        "DisplayName":  "Read",
-                        "Name":  "GenericRead",
-                        "Bit":  2
-                    },
-                    {
-                        "DisplayName":  "Contribute",
-                        "Name":  "GenericContribute",
-                        "Bit":  4
-                    },
-                    {
-                        "DisplayName":  "Force push (rewrite history, delete branches and tags)",
-                        "Name":  "ForcePush",
-                        "Bit":  8
-                    },
-                    {
-                        "DisplayName":  "Create branch",
-                        "Name":  "CreateBranch",
-                        "Bit":  16
-                    },
-                    {
-                        "DisplayName":  "Create tag",
-                        "Name":  "CreateTag",
-                        "Bit":  32
-                    },
-                    {
-                        "DisplayName":  "Manage notes",
-                        "Name":  "ManageNote",
-                        "Bit":  64
-                    },
-                    {
-                        "DisplayName":  "Bypass policies when pushing",
-                        "Name":  "PolicyExempt",
-                        "Bit":  128
-                    },
-                    {
-                        "DisplayName":  "Create repository",
-                        "Name":  "CreateRepository",
-                        "Bit":  256
-                    },
-                    {
-                        "DisplayName":  "Delete repository",
-                        "Name":  "DeleteRepository",
-                        "Bit":  512
-                    },
-                    {
-                        "DisplayName":  "Rename repository",
-                        "Name":  "RenameRepository",
-                        "Bit":  1024
-                    },
-                    {
-                        "DisplayName":  "Edit policies",
-                        "Name":  "EditPolicies",
-                        "Bit":  2048
-                    },
-                    {
-                        "DisplayName":  "Remove others\u0027 locks",
-                        "Name":  "RemoveOthersLocks",
-                        "Bit":  4096
-                    },
-                    {
-                        "DisplayName":  "Manage permissions",
-                        "Name":  "ManagePermissions",
-                        "Bit":  8192
-                    },
-                    {
-                        "DisplayName":  "Contribute to pull requests",
-                        "Name":  "PullRequestContribute",
-                        "Bit":  16384
-                    },
-                    {
-                        "DisplayName":  "Bypass policies when completing pull requests",
-                        "Name":  "PullRequestBypassPolicy",
-                        "Bit":  32768
-                    }
-                ],
-    "ID":  "2e9eb7ed-3c0a-47d4-87c1-0ffdd275fd87",
-    "ProjectName":  "",
-    "DisplayMode":  "------",
-    "Name":  "Git Repositories"
+    "namespaceId":  "2e9eb7ed-3c0a-47d4-87c1-0ffdd275fd87",
+    "name":  "Git Repositories",
+    "displayName":  "Git Repositories",
+    "separatorValue":  "/",
+    "elementLength":  -1,
+    "writePermission":  8192,
+    "readPermission":  2,
+    "dataspaceCategory":  "Git",
+    "actions":  "               ",
+    "structureValue":  1,
+    "extensionType":  "Microsoft.TeamFoundation.Git.Server.Plugins.GitSecurityNamespaceExtension",
+    "isRemotable":  true,
+    "useTokenTranslator":  true,
+    "systemBitMask":  0
 }
 "@ | ConvertFrom-Json
   

--- a/unit/test/Remove-VSTeamAccessControlEntry.Tests.ps1
+++ b/unit/test/Remove-VSTeamAccessControlEntry.Tests.ps1
@@ -91,6 +91,7 @@ $securityNamespace =
         {
             "DisplayName":  "Contribute to pull requests",
             "Name":  "PullRequestContribute",
+            "Bit":"16384"
         },
         {
             "DisplayName":  "Bypass policies when completing pull requests",

--- a/unit/test/Remove-VSTeamAccessControlEntry.Tests.ps1
+++ b/unit/test/Remove-VSTeamAccessControlEntry.Tests.ps1
@@ -137,7 +137,7 @@ InModuleScope VSTeam {
       Context 'Remove-VSTeamAccessControlEntry by SecurityNamespaceId' {
          Mock Invoke-RestMethod { return $true }
 
-         Remove-VSTeamAccessControlEntry -SecurityNamespaceId 2e9eb7ed-3c0a-47d4-87c1-0ffdd275fd87 -Descriptor abc -Token xyz
+         Remove-VSTeamAccessControlEntry -SecurityNamespaceId 2e9eb7ed-3c0a-47d4-87c1-0ffdd275fd87 -Descriptor "vssgp.Uy0xLTktMTU1MTM3NDI0NS0xODc2Mzk2MjA0LTIwNjc1NTI1ODctMzA2NDY5MTU3My0yNjkxODIxNjgzLTEtMjM0NjY4Mzk3Mi0yNDI0MDE0NjYzLTI5MzAxOTk4OTktMTU1MjUwNTM3MQ" -Token xyz
 
          It 'Should have a properly constructed URL' {
             Assert-MockCalled Invoke-RestMethod -Exactly 1 -ParameterFilter {
@@ -157,7 +157,7 @@ InModuleScope VSTeam {
          Mock Invoke-RestMethod { return $true }
 
          $securityNamespace = Get-VSTeamSecurityNamespace -Id "2e9eb7ed-3c0a-47d4-87c1-0ffdd275fd87"
-         Remove-VSTeamAccessControlEntry -SecurityNamespace $securityNamespace -Descriptor abc -Token xyz 
+         Remove-VSTeamAccessControlEntry -SecurityNamespace $securityNamespace -Descriptor "vssgp.Uy0xLTktMTU1MTM3NDI0NS0xODc2Mzk2MjA0LTIwNjc1NTI1ODctMzA2NDY5MTU3My0yNjkxODIxNjgzLTEtMjM0NjY4Mzk3Mi0yNDI0MDE0NjYzLTI5MzAxOTk4OTktMTU1MjUwNTM3MQ" -Token xyz 
 
          It 'Should have a properly constructed URL' {
             Assert-MockCalled Invoke-RestMethod -Exactly 1 -ParameterFilter {
@@ -177,7 +177,7 @@ InModuleScope VSTeam {
          Mock Invoke-RestMethod { return $true }
 
          Get-VSTeamSecurityNamespace -Id "2e9eb7ed-3c0a-47d4-87c1-0ffdd275fd87" | `
-            Remove-VSTeamAccessControlEntry -Descriptor abc -Token xyz 
+            Remove-VSTeamAccessControlEntry -Descriptor "vssgp.Uy0xLTktMTU1MTM3NDI0NS0xODc2Mzk2MjA0LTIwNjc1NTI1ODctMzA2NDY5MTU3My0yNjkxODIxNjgzLTEtMjM0NjY4Mzk3Mi0yNDI0MDE0NjYzLTI5MzAxOTk4OTktMTU1MjUwNTM3MQ" -Token xyz 
 
          It 'Should have a properly constructed URL' {
             Assert-MockCalled Invoke-RestMethod -Exactly 1 -ParameterFilter {

--- a/unit/test/Remove-VSTeamAccessControlEntry.Tests.ps1
+++ b/unit/test/Remove-VSTeamAccessControlEntry.Tests.ps1
@@ -114,15 +114,15 @@ $securityNamespace =
 
       Context 'Remove-VSTeamAccessControlEntry by SecurityNamespaceId' {
          It 'Should have a properly constructed URL' {
-            Mock _callAPI { return $true } -Verifiable
+            Mock Invoke-RestMethod { return $true } -Verifiable
 
             Remove-VSTeamAccessControlEntry -SecurityNamespaceId 2e9eb7ed-3c0a-47d4-87c1-0ffdd275fd87 -Descriptor "vssgp.Uy0xLTktMTU1MTM3NDI0NS0yMTkxNDc4NTk1LTU1MDM1MzIxOC0yNDM3MjM2NDgzLTQyMjkyNzUyNDktMC0wLTAtOC04" -Token xyz
    
-            Assert-MockCalled _callAPI -Exactly -Scope It -Times 1 -ParameterFilter {
-               $Url -like "https://dev.azure.com/test/_apis/accesscontrolentries/2e9eb7ed-3c0a-47d4-87c1-0ffdd275fd87*" -and
-               $Url -like "*api-version=$([VSTeamVersions]::Core)*" -and
-               $Url -like "*?token=xyz*" -and
-               $Url -like "*&descriptors=Microsoft.TeamFoundation.Identity;S-1*" -and
+            Assert-MockCalled Invoke-RestMethod -ParameterFilter {
+               $Uri -like "https://dev.azure.com/test/_apis/accesscontrolentries/2e9eb7ed-3c0a-47d4-87c1-0ffdd275fd87*" -and
+               $Uri -like "*api-version=$([VSTeamVersions]::Core)*" -and
+               $Uri -like "*?token=xyz*" -and
+               $Uri -like "*&descriptors=Microsoft.TeamFoundation.Identity;S-1*" -and
                $ContentType -eq "application/json" -and
                $Method -eq "Delete"
             }
@@ -132,16 +132,16 @@ $securityNamespace =
       Context 'Remove-VSTeamAccessControlEntry by SecurityNamespace' {
          It 'Should have a properly constructed URL' {
             Mock Get-VSTeamSecurityNamespace { return $securityNamespace }
-            Mock _callAPI { return $true } -Verifiable
+            Mock Invoke-RestMethod { return $true } -Verifiable
    
             $securityNamespace = Get-VSTeamSecurityNamespace -Id "2e9eb7ed-3c0a-47d4-87c1-0ffdd275fd87"
             Remove-VSTeamAccessControlEntry -SecurityNamespace $securityNamespace -Descriptor "vssgp.Uy0xLTktMTU1MTM3NDI0NS0yMTkxNDc4NTk1LTU1MDM1MzIxOC0yNDM3MjM2NDgzLTQyMjkyNzUyNDktMC0wLTAtOC04" -Token xyz 
 
-            Assert-MockCalled _callAPI -Exactly -Scope It -Times 1 -ParameterFilter {
-               $Url -like "https://dev.azure.com/test/_apis/accesscontrolentries/2e9eb7ed-3c0a-47d4-87c1-0ffdd275fd87*" -and
-               $Url -like "*api-version=$([VSTeamVersions]::Core)*" -and
-               $Url -like "*?token=xyz*" -and
-               $Url -like "*&descriptors=Microsoft.TeamFoundation.Identity;S-1*" -and
+            Assert-MockCalled Invoke-RestMethod -ParameterFilter {
+               $Uri -like "https://dev.azure.com/test/_apis/accesscontrolentries/2e9eb7ed-3c0a-47d4-87c1-0ffdd275fd87*" -and
+               $Uri -like "*api-version=$([VSTeamVersions]::Core)*" -and
+               $Uri -like "*?token=xyz*" -and
+               $Uri -like "*&descriptors=Microsoft.TeamFoundation.Identity;S-1*" -and
                $ContentType -eq "application/json" -and
                $Method -eq "Delete"
             }

--- a/unit/test/Remove-VSTeamAccessControlEntry.Tests.ps1
+++ b/unit/test/Remove-VSTeamAccessControlEntry.Tests.ps1
@@ -6,7 +6,7 @@ InModuleScope VSTeam {
    # using the Set-VSTeamAccount function.
    [VSTeamVersions]::Account = 'https://dev.azure.com/test'
 
-   [VSTeamSecurityNamespace]$securityNamespace = 
+$securityNamespace = 
 @"
 {
     "DisplayName":  "Git Repositories",

--- a/unit/test/Remove-VSTeamAccessControlEntry.Tests.ps1
+++ b/unit/test/Remove-VSTeamAccessControlEntry.Tests.ps1
@@ -107,45 +107,32 @@ $securityNamespace =
 }
 "@ | ConvertFrom-Json
   
-   Describe 'AccessControlEntry VSTS' {
-      # You have to set the version or the api-version will not be Removed when
-      # [VSTeamVersions]::Core = ''
-      [VSTeamVersions]::Core = '5.1'
+    Describe 'AccessControlEntry VSTS'{
+        # You have to set the version or the api-version will not be Removed when
+        # [VSTeamVersions]::Core = ''
+        [VSTeamVersions]::Core = '5.1'
 
-      Context 'Remove-VSTeamAccessControlEntry by SecurityNamespaceId' {
-         It 'Should have a properly constructed URL' {
-            Mock Invoke-RestMethod { return $true } -Verifiable
+        Mock Invoke-RestMethod { return $true } -Verifiable
+        Mock Get-VSTeamSecurityNamespace { return $securityNamespace }
 
-            Remove-VSTeamAccessControlEntry -SecurityNamespaceId 2e9eb7ed-3c0a-47d4-87c1-0ffdd275fd87 -Descriptor "vssgp.Uy0xLTktMTU1MTM3NDI0NS0yMTkxNDc4NTk1LTU1MDM1MzIxOC0yNDM3MjM2NDgzLTQyMjkyNzUyNDktMC0wLTAtOC04" -Token xyz
-   
-            Assert-MockCalled Invoke-RestMethod -ParameterFilter {
-               $Uri -like "https://dev.azure.com/test/_apis/accesscontrolentries/2e9eb7ed-3c0a-47d4-87c1-0ffdd275fd87*" -and
-               $Uri -like "*api-version=$([VSTeamVersions]::Core)*" -and
-               $Uri -like "*?token=xyz*" -and
-               $Uri -like "*&descriptors=Microsoft.TeamFoundation.Identity;S-1*" -and
-               $ContentType -eq "application/json" -and
-               $Method -eq "Delete"
+        Context 'Remove-VSTeamAccessControlEntry by SecurityNamespaceId'{
+            It 'Should succeed with a properly formatted descriptor'{
+            Remove-VSTeamAccessControlEntry -SecurityNamespaceId 2e9eb7ed-3c0a-47d4-87c1-0ffdd275fd87 -Descriptor "vssgp.Uy0xLTktMTU1MTM3NDI0NS0yMTkxNDc4NTk1LTU1MDM1MzIxOC0yNDM3MjM2NDgzLTQyMjkyNzUyNDktMC0wLTAtOC04" -Token xyz | Should be $true
             }
-         }
-      }
-
-      Context 'Remove-VSTeamAccessControlEntry by SecurityNamespace' {
-         It 'Should have a properly constructed URL' {
-            Mock Get-VSTeamSecurityNamespace { return $securityNamespace }
-            Mock Invoke-RestMethod { return $true } -Verifiable
-   
-            $securityNamespace = Get-VSTeamSecurityNamespace -Id "2e9eb7ed-3c0a-47d4-87c1-0ffdd275fd87"
-            Remove-VSTeamAccessControlEntry -SecurityNamespace $securityNamespace -Descriptor "vssgp.Uy0xLTktMTU1MTM3NDI0NS0yMTkxNDc4NTk1LTU1MDM1MzIxOC0yNDM3MjM2NDgzLTQyMjkyNzUyNDktMC0wLTAtOC04" -Token xyz 
-
-            Assert-MockCalled Invoke-RestMethod -ParameterFilter {
-               $Uri -like "https://dev.azure.com/test/_apis/accesscontrolentries/2e9eb7ed-3c0a-47d4-87c1-0ffdd275fd87*" -and
-               $Uri -like "*api-version=$([VSTeamVersions]::Core)*" -and
-               $Uri -like "*?token=xyz*" -and
-               $Uri -like "*&descriptors=Microsoft.TeamFoundation.Identity;S-1*" -and
-               $ContentType -eq "application/json" -and
-               $Method -eq "Delete"
+            It 'Should fail with an improperly formatted descriptor'{
+            Remove-VSTeamAccessControlEntry -SecurityNamespaceId 2e9eb7ed-3c0a-47d4-87c1-0ffdd275fd87 -Descriptor "vssgp.NotARealDescriptor" -Token xyz | Should belike "Could not convert base64 string to string*"
             }
-         }
-      }
-   }
+        }
+
+        Context 'Remove-VSTeamAccessControlEntry by SecurityNamespace'{
+            It 'Should succeed with a properly formatted descriptor'{  
+                $securityNamespace = Get-VSTeamSecurityNamespace -Id "2e9eb7ed-3c0a-47d4-87c1-0ffdd275fd87"
+                Remove-VSTeamAccessControlEntry -SecurityNamespace $securityNamespace -Descriptor "vssgp.Uy0xLTktMTU1MTM3NDI0NS0yMTkxNDc4NTk1LTU1MDM1MzIxOC0yNDM3MjM2NDgzLTQyMjkyNzUyNDktMC0wLTAtOC04" -Token xyz | Should be $true
+            }
+            It 'Should succeed with a properly formatted descriptor'{  
+                $securityNamespace = Get-VSTeamSecurityNamespace -Id "2e9eb7ed-3c0a-47d4-87c1-0ffdd275fd87"
+                Remove-VSTeamAccessControlEntry -SecurityNamespace $securityNamespace -Descriptor "vssgp.NotARealDescriptor" -Token xyz | Should belike "Could not convert base64 string to string*"
+            }
+        }
+    }
 }

--- a/unit/test/Remove-VSTeamAccessControlEntry.Tests.ps1
+++ b/unit/test/Remove-VSTeamAccessControlEntry.Tests.ps1
@@ -113,12 +113,12 @@ $securityNamespace =
       [VSTeamVersions]::Core = '5.1'
 
       Context 'Remove-VSTeamAccessControlEntry by SecurityNamespaceId' {
-         Mock Invoke-RestMethod { return $true } -Verifiable
-
-         Remove-VSTeamAccessControlEntry -SecurityNamespaceId 2e9eb7ed-3c0a-47d4-87c1-0ffdd275fd87 -Descriptor "vssgp.Uy0xLTktMTU1MTM3NDI0NS0yMTkxNDc4NTk1LTU1MDM1MzIxOC0yNDM3MjM2NDgzLTQyMjkyNzUyNDktMC0wLTAtOC04" -Token xyz
-
          It 'Should have a properly constructed URL' {
-            Assert-MockCalled Invoke-RestMethod -Exactly 1 -ParameterFilter {
+            Mock Invoke-RestMethod { return $true } -Verifiable
+
+            Remove-VSTeamAccessControlEntry -SecurityNamespaceId 2e9eb7ed-3c0a-47d4-87c1-0ffdd275fd87 -Descriptor "vssgp.Uy0xLTktMTU1MTM3NDI0NS0yMTkxNDc4NTk1LTU1MDM1MzIxOC0yNDM3MjM2NDgzLTQyMjkyNzUyNDktMC0wLTAtOC04" -Token xyz
+   
+            Assert-MockCalled Invoke-RestMethod -Exactly -Scope It -Times 1 -ParameterFilter {
                $Uri -like "https://dev.azure.com/test/_apis/accesscontrolentries/2e9eb7ed-3c0a-47d4-87c1-0ffdd275fd87*" -and
                $Uri -like "*api-version=$([VSTeamVersions]::Core)*" -and
                $Uri -like "*?token=xyz*" -and
@@ -130,33 +130,14 @@ $securityNamespace =
       }
 
       Context 'Remove-VSTeamAccessControlEntry by SecurityNamespace' {
-         Mock Get-VSTeamSecurityNamespace { return $securityNamespace }
-         Mock Invoke-RestMethod { return $true } -Verifiable
-
-         $securityNamespace = Get-VSTeamSecurityNamespace -Id "2e9eb7ed-3c0a-47d4-87c1-0ffdd275fd87"
-         Remove-VSTeamAccessControlEntry -SecurityNamespace $securityNamespace -Descriptor "vssgp.Uy0xLTktMTU1MTM3NDI0NS0yMTkxNDc4NTk1LTU1MDM1MzIxOC0yNDM3MjM2NDgzLTQyMjkyNzUyNDktMC0wLTAtOC04" -Token xyz 
-
          It 'Should have a properly constructed URL' {
-            Assert-MockCalled Invoke-RestMethod -Exactly 1 -ParameterFilter {
-               $Uri -like "https://dev.azure.com/test/_apis/accesscontrolentries/2e9eb7ed-3c0a-47d4-87c1-0ffdd275fd87*" -and
-               $Uri -like "*api-version=$([VSTeamVersions]::Core)*" -and
-               $Uri -like "*?token=xyz*" -and
-               $Uri -like "*&descriptors=Microsoft.TeamFoundation.Identity;S-1*" -and
-               $ContentType -eq "application/json" -and
-               $Method -eq "Delete"
-            }
-         }
-      }
+            Mock Get-VSTeamSecurityNamespace { return $securityNamespace }
+            Mock Invoke-RestMethod { return $true } -Verifiable
+   
+            $securityNamespace = Get-VSTeamSecurityNamespace -Id "2e9eb7ed-3c0a-47d4-87c1-0ffdd275fd87"
+            Remove-VSTeamAccessControlEntry -SecurityNamespace $securityNamespace -Descriptor "vssgp.Uy0xLTktMTU1MTM3NDI0NS0yMTkxNDc4NTk1LTU1MDM1MzIxOC0yNDM3MjM2NDgzLTQyMjkyNzUyNDktMC0wLTAtOC04" -Token xyz 
 
-      Context 'Remove-VSTeamAccessControlEntry by SecurityNamespace (pipeline)' {
-         Mock Get-VSTeamSecurityNamespace { return $securityNamespace }
-         Mock Invoke-RestMethod { return $true } -Verifiable
-
-         Get-VSTeamSecurityNamespace -Id "2e9eb7ed-3c0a-47d4-87c1-0ffdd275fd87" | `
-         Remove-VSTeamAccessControlEntry -SecurityNamespace $_ -Descriptor "vssgp.Uy0xLTktMTU1MTM3NDI0NS0yMTkxNDc4NTk1LTU1MDM1MzIxOC0yNDM3MjM2NDgzLTQyMjkyNzUyNDktMC0wLTAtOC04" -Token xyz 
-
-         It 'Should have a properly constructed URL' {
-            Assert-MockCalled Invoke-RestMethod -Exactly 1 -ParameterFilter {
+            Assert-MockCalled Invoke-RestMethod -Exactly -Scope It -Times 1 -ParameterFilter {
                $Uri -like "https://dev.azure.com/test/_apis/accesscontrolentries/2e9eb7ed-3c0a-47d4-87c1-0ffdd275fd87*" -and
                $Uri -like "*api-version=$([VSTeamVersions]::Core)*" -and
                $Uri -like "*?token=xyz*" -and

--- a/unit/test/Remove-VSTeamAccessControlEntry.Tests.ps1
+++ b/unit/test/Remove-VSTeamAccessControlEntry.Tests.ps1
@@ -115,7 +115,7 @@ $securityNamespace =
       Context 'Remove-VSTeamAccessControlEntry by SecurityNamespaceId' {
          Mock Invoke-RestMethod { return $true }
 
-         Remove-VSTeamAccessControlEntry -SecurityNamespaceId 2e9eb7ed-3c0a-47d4-87c1-0ffdd275fd87 -Descriptor "vssgp.Uy0xLTktMTU1MTM3NDI0NS0xODc2Mzk2MjA0LTIwNjc1NTI1ODctMzA2NDY5MTU3My0yNjkxODIxNjgzLTEtMjM0NjY4Mzk3Mi0yNDI0MDE0NjYzLTI5MzAxOTk4OTktMTU1MjUwNTM3MQ" -Token xyz
+         Remove-VSTeamAccessControlEntry -SecurityNamespaceId 2e9eb7ed-3c0a-47d4-87c1-0ffdd275fd87 -Descriptor "vssgp.Uy0xLTktMTU1MTM3NDI0NS0yMTkxNDc4NTk1LTU1MDM1MzIxOC0yNDM3MjM2NDgzLTQyMjkyNzUyNDktMC0wLTAtOC04" -Token xyz
 
          It 'Should have a properly constructed URL' {
             Assert-MockCalled Invoke-RestMethod -Exactly 1 -ParameterFilter {
@@ -135,7 +135,7 @@ $securityNamespace =
          Mock Invoke-RestMethod { return $true }
 
          $securityNamespace = Get-VSTeamSecurityNamespace -Id "2e9eb7ed-3c0a-47d4-87c1-0ffdd275fd87"
-         Remove-VSTeamAccessControlEntry -SecurityNamespace $securityNamespace -Descriptor "vssgp.Uy0xLTktMTU1MTM3NDI0NS0xODc2Mzk2MjA0LTIwNjc1NTI1ODctMzA2NDY5MTU3My0yNjkxODIxNjgzLTEtMjM0NjY4Mzk3Mi0yNDI0MDE0NjYzLTI5MzAxOTk4OTktMTU1MjUwNTM3MQ" -Token xyz 
+         Remove-VSTeamAccessControlEntry -SecurityNamespace $securityNamespace -Descriptor "vssgp.Uy0xLTktMTU1MTM3NDI0NS0yMTkxNDc4NTk1LTU1MDM1MzIxOC0yNDM3MjM2NDgzLTQyMjkyNzUyNDktMC0wLTAtOC04" -Token xyz 
 
          It 'Should have a properly constructed URL' {
             Assert-MockCalled Invoke-RestMethod -Exactly 1 -ParameterFilter {
@@ -155,7 +155,7 @@ $securityNamespace =
          Mock Invoke-RestMethod { return $true }
 
          Get-VSTeamSecurityNamespace -Id "2e9eb7ed-3c0a-47d4-87c1-0ffdd275fd87" | `
-         Remove-VSTeamAccessControlEntry -SecurityNamespace $_ -Descriptor "vssgp.Uy0xLTktMTU1MTM3NDI0NS0xODc2Mzk2MjA0LTIwNjc1NTI1ODctMzA2NDY5MTU3My0yNjkxODIxNjgzLTEtMjM0NjY4Mzk3Mi0yNDI0MDE0NjYzLTI5MzAxOTk4OTktMTU1MjUwNTM3MQ" -Token xyz 
+         Remove-VSTeamAccessControlEntry -SecurityNamespace $_ -Descriptor "vssgp.Uy0xLTktMTU1MTM3NDI0NS0yMTkxNDc4NTk1LTU1MDM1MzIxOC0yNDM3MjM2NDgzLTQyMjkyNzUyNDktMC0wLTAtOC04" -Token xyz 
 
          It 'Should have a properly constructed URL' {
             Assert-MockCalled Invoke-RestMethod -Exactly 1 -ParameterFilter {

--- a/unit/test/Remove-VSTeamAccessControlEntry.Tests.ps1
+++ b/unit/test/Remove-VSTeamAccessControlEntry.Tests.ps1
@@ -114,15 +114,15 @@ $securityNamespace =
 
       Context 'Remove-VSTeamAccessControlEntry by SecurityNamespaceId' {
          It 'Should have a properly constructed URL' {
-            Mock Invoke-RestMethod { return $true } -Verifiable
+            Mock _callAPI { return $true } -Verifiable
 
             Remove-VSTeamAccessControlEntry -SecurityNamespaceId 2e9eb7ed-3c0a-47d4-87c1-0ffdd275fd87 -Descriptor "vssgp.Uy0xLTktMTU1MTM3NDI0NS0yMTkxNDc4NTk1LTU1MDM1MzIxOC0yNDM3MjM2NDgzLTQyMjkyNzUyNDktMC0wLTAtOC04" -Token xyz
    
-            Assert-MockCalled Invoke-RestMethod -Exactly -Scope It -Times 1 -ParameterFilter {
-               $Uri -like "https://dev.azure.com/test/_apis/accesscontrolentries/2e9eb7ed-3c0a-47d4-87c1-0ffdd275fd87*" -and
-               $Uri -like "*api-version=$([VSTeamVersions]::Core)*" -and
-               $Uri -like "*?token=xyz*" -and
-               $Uri -like "*&descriptors=Microsoft.TeamFoundation.Identity;S-1*" -and
+            Assert-MockCalled _callAPI -Exactly -Scope It -Times 1 -ParameterFilter {
+               $Url -like "https://dev.azure.com/test/_apis/accesscontrolentries/2e9eb7ed-3c0a-47d4-87c1-0ffdd275fd87*" -and
+               $Url -like "*api-version=$([VSTeamVersions]::Core)*" -and
+               $Url -like "*?token=xyz*" -and
+               $Url -like "*&descriptors=Microsoft.TeamFoundation.Identity;S-1*" -and
                $ContentType -eq "application/json" -and
                $Method -eq "Delete"
             }
@@ -132,16 +132,16 @@ $securityNamespace =
       Context 'Remove-VSTeamAccessControlEntry by SecurityNamespace' {
          It 'Should have a properly constructed URL' {
             Mock Get-VSTeamSecurityNamespace { return $securityNamespace }
-            Mock Invoke-RestMethod { return $true } -Verifiable
+            Mock _callAPI { return $true } -Verifiable
    
             $securityNamespace = Get-VSTeamSecurityNamespace -Id "2e9eb7ed-3c0a-47d4-87c1-0ffdd275fd87"
             Remove-VSTeamAccessControlEntry -SecurityNamespace $securityNamespace -Descriptor "vssgp.Uy0xLTktMTU1MTM3NDI0NS0yMTkxNDc4NTk1LTU1MDM1MzIxOC0yNDM3MjM2NDgzLTQyMjkyNzUyNDktMC0wLTAtOC04" -Token xyz 
 
-            Assert-MockCalled Invoke-RestMethod -Exactly -Scope It -Times 1 -ParameterFilter {
-               $Uri -like "https://dev.azure.com/test/_apis/accesscontrolentries/2e9eb7ed-3c0a-47d4-87c1-0ffdd275fd87*" -and
-               $Uri -like "*api-version=$([VSTeamVersions]::Core)*" -and
-               $Uri -like "*?token=xyz*" -and
-               $Uri -like "*&descriptors=Microsoft.TeamFoundation.Identity;S-1*" -and
+            Assert-MockCalled _callAPI -Exactly -Scope It -Times 1 -ParameterFilter {
+               $Url -like "https://dev.azure.com/test/_apis/accesscontrolentries/2e9eb7ed-3c0a-47d4-87c1-0ffdd275fd87*" -and
+               $Url -like "*api-version=$([VSTeamVersions]::Core)*" -and
+               $Url -like "*?token=xyz*" -and
+               $Url -like "*&descriptors=Microsoft.TeamFoundation.Identity;S-1*" -and
                $ContentType -eq "application/json" -and
                $Method -eq "Delete"
             }

--- a/unit/test/Remove-VSTeamAccessControlEntry.Tests.ps1
+++ b/unit/test/Remove-VSTeamAccessControlEntry.Tests.ps1
@@ -6,7 +6,7 @@ InModuleScope VSTeam {
    # using the Set-VSTeamAccount function.
    [VSTeamVersions]::Account = 'https://dev.azure.com/test'
 
-   $securityNamespace = 
+   [VSTeamSecurityNamespace]$securityNamespace = 
 @"
 {
     "DisplayName":  "Git Repositories",
@@ -102,35 +102,15 @@ InModuleScope VSTeam {
                         "Bit":  32768
                     }
                 ],
-    "_internalObj":  [
-                         {
-                             "namespaceId":  "2e9eb7ed-3c0a-47d4-87c1-0ffdd275fd87",
-                             "name":  "Git Repositories",
-                             "displayName":  "Git Repositories",
-                             "separatorValue":  "/",
-                             "elementLength":  -1,
-                             "writePermission":  8192,
-                             "readPermission":  2,
-                             "dataspaceCategory":  "Git",
-                             "actions":  "               ",
-                             "structureValue":  1,
-                             "extensionType":  "Microsoft.TeamFoundation.Git.Server.Plugins.GitSecurityNamespaceExtension",
-                             "isRemotable":  true,
-                             "useTokenTranslator":  true,
-                             "systemBitMask":  0
-                         }
-                     ],
     "ID":  "2e9eb7ed-3c0a-47d4-87c1-0ffdd275fd87",
     "ProjectName":  "",
     "DisplayMode":  "------",
     "Name":  "Git Repositories"
 }
 "@ | ConvertFrom-Json
-
-   $securityNamespaceObject = [VSTeamSecurityNamespace]::new($securityNamespace)
   
    Describe 'AccessControlEntry VSTS' {
-      # You have to set the version or the api-version will not be Removeed when
+      # You have to set the version or the api-version will not be Removed when
       # [VSTeamVersions]::Core = ''
       [VSTeamVersions]::Core = '5.1'
 
@@ -153,7 +133,7 @@ InModuleScope VSTeam {
       }
 
       Context 'Remove-VSTeamAccessControlEntry by SecurityNamespace' {
-         Mock Get-VSTeamSecurityNamespace { return $securityNamespaceObject }
+         Mock Get-VSTeamSecurityNamespace { return $securityNamespace }
          Mock Invoke-RestMethod { return $true }
 
          $securityNamespace = Get-VSTeamSecurityNamespace -Id "2e9eb7ed-3c0a-47d4-87c1-0ffdd275fd87"
@@ -173,7 +153,7 @@ InModuleScope VSTeam {
       }
 
       Context 'Remove-VSTeamAccessControlEntry by SecurityNamespace (pipeline)' {
-         Mock Get-VSTeamSecurityNamespace { return $securityNamespaceObject }
+         Mock Get-VSTeamSecurityNamespace { return $securityNamespace }
          Mock Invoke-RestMethod { return $true }
 
          Get-VSTeamSecurityNamespace -Id "2e9eb7ed-3c0a-47d4-87c1-0ffdd275fd87" | `

--- a/unit/test/Remove-VSTeamAccessControlEntry.Tests.ps1
+++ b/unit/test/Remove-VSTeamAccessControlEntry.Tests.ps1
@@ -1,5 +1,5 @@
 Set-StrictMode -Version Latest
-Import-module .\Downloads\vsteam-master\bin\VSTeam.psd1
+
 InModuleScope VSTeam {
 
    # Set the account to use for testing. A normal user would do this

--- a/unit/test/Remove-VSTeamAccessControlEntry.Tests.ps1
+++ b/unit/test/Remove-VSTeamAccessControlEntry.Tests.ps1
@@ -1,5 +1,5 @@
 Set-StrictMode -Version Latest
-
+Import-module .\Downloads\vsteam-master\bin\VSTeam.psd1
 InModuleScope VSTeam {
 
    # Set the account to use for testing. A normal user would do this
@@ -17,7 +17,87 @@ $securityNamespace =
     "writePermission":  8192,
     "readPermission":  2,
     "dataspaceCategory":  "Git",
-    "actions":  "               ",
+    "actions":  [
+        {
+            "DisplayName":  "Administer",
+            "Name":  "Administer",
+            "Bit":  1
+        },
+        {
+            "DisplayName":  "Read",
+            "Name":  "GenericRead",
+            "Bit":  2
+        },
+        {
+            "DisplayName":  "Contribute",
+            "Name":  "GenericContribute",
+            "Bit":  4
+        },
+        {
+            "DisplayName":  "Force push (rewrite history, delete branches and tags)",
+            "Name":  "ForcePush",
+            "Bit":  8
+        },
+        {
+            "DisplayName":  "Create branch",
+            "Name":  "CreateBranch",
+            "Bit":  16
+        },
+        {
+            "DisplayName":  "Create tag",
+            "Name":  "CreateTag",
+            "Bit":  32
+        },
+        {
+            "DisplayName":  "Manage notes",
+            "Name":  "ManageNote",
+            "Bit":  64
+        },
+        {
+            "DisplayName":  "Bypass policies when pushing",
+            "Name":  "PolicyExempt",
+            "Bit":  128
+        },
+        {
+            "DisplayName":  "Create repository",
+            "Name":  "CreateRepository",
+            "Bit":  256
+        },
+        {
+            "DisplayName":  "Delete repository",
+            "Name":  "DeleteRepository",
+            "Bit":  512
+        },
+        {
+            "DisplayName":  "Rename repository",
+            "Name":  "RenameRepository",
+            "Bit":  1024
+        },
+        {
+            "DisplayName":  "Edit policies",
+            "Name":  "EditPolicies",
+            "Bit":  2048
+        },
+        {
+            "DisplayName":  "Remove others\u0027 locks",
+            "Name":  "RemoveOthersLocks",
+            "Bit":  4096
+        },
+        {
+            "DisplayName":  "Manage permissions",
+            "Name":  "ManagePermissions",
+            "Bit":  8192
+        },
+        {
+            "DisplayName":  "Contribute to pull requests",
+            "Name":  "PullRequestContribute",
+        },
+        {
+            "DisplayName":  "Bypass policies when completing pull requests",
+            "Name":  "PullRequestBypassPolicy",
+            "Bit":  32768
+        }
+    ],
     "structureValue":  1,
     "extensionType":  "Microsoft.TeamFoundation.Git.Server.Plugins.GitSecurityNamespaceExtension",
     "isRemotable":  true,
@@ -74,7 +154,7 @@ $securityNamespace =
          Mock Invoke-RestMethod { return $true }
 
          Get-VSTeamSecurityNamespace -Id "2e9eb7ed-3c0a-47d4-87c1-0ffdd275fd87" | `
-            Remove-VSTeamAccessControlEntry -Descriptor "vssgp.Uy0xLTktMTU1MTM3NDI0NS0xODc2Mzk2MjA0LTIwNjc1NTI1ODctMzA2NDY5MTU3My0yNjkxODIxNjgzLTEtMjM0NjY4Mzk3Mi0yNDI0MDE0NjYzLTI5MzAxOTk4OTktMTU1MjUwNTM3MQ" -Token xyz 
+         Remove-VSTeamAccessControlEntry -SecurityNamespace $_ -Descriptor "vssgp.Uy0xLTktMTU1MTM3NDI0NS0xODc2Mzk2MjA0LTIwNjc1NTI1ODctMzA2NDY5MTU3My0yNjkxODIxNjgzLTEtMjM0NjY4Mzk3Mi0yNDI0MDE0NjYzLTI5MzAxOTk4OTktMTU1MjUwNTM3MQ" -Token xyz 
 
          It 'Should have a properly constructed URL' {
             Assert-MockCalled Invoke-RestMethod -Exactly 1 -ParameterFilter {

--- a/unit/test/Remove-VSTeamAccessControlEntry.Tests.ps1
+++ b/unit/test/Remove-VSTeamAccessControlEntry.Tests.ps1
@@ -1,0 +1,195 @@
+Set-StrictMode -Version Latest
+
+InModuleScope VSTeam {
+
+   # Set the account to use for testing. A normal user would do this
+   # using the Set-VSTeamAccount function.
+   [VSTeamVersions]::Account = 'https://dev.azure.com/test'
+
+   $securityNamespace = 
+@"
+{
+    "DisplayName":  "Git Repositories",
+    "SeparatorValue":  "/",
+    "ElementLength":  -1,
+    "WritePermission":  8192,
+    "ReadPermission":  2,
+    "DataspaceCategory":  "Git",
+    "StructureValue":  "1",
+    "ExtensionType":  "Microsoft.TeamFoundation.Git.Server.Plugins.GitSecurityNamespaceExtension",
+    "IsRemotable":  true,
+    "UseTokenTranslator":  true,
+    "SystemBitMask":  0,
+    "Actions":  [
+                    {
+                        "DisplayName":  "Administer",
+                        "Name":  "Administer",
+                        "Bit":  1
+                    },
+                    {
+                        "DisplayName":  "Read",
+                        "Name":  "GenericRead",
+                        "Bit":  2
+                    },
+                    {
+                        "DisplayName":  "Contribute",
+                        "Name":  "GenericContribute",
+                        "Bit":  4
+                    },
+                    {
+                        "DisplayName":  "Force push (rewrite history, delete branches and tags)",
+                        "Name":  "ForcePush",
+                        "Bit":  8
+                    },
+                    {
+                        "DisplayName":  "Create branch",
+                        "Name":  "CreateBranch",
+                        "Bit":  16
+                    },
+                    {
+                        "DisplayName":  "Create tag",
+                        "Name":  "CreateTag",
+                        "Bit":  32
+                    },
+                    {
+                        "DisplayName":  "Manage notes",
+                        "Name":  "ManageNote",
+                        "Bit":  64
+                    },
+                    {
+                        "DisplayName":  "Bypass policies when pushing",
+                        "Name":  "PolicyExempt",
+                        "Bit":  128
+                    },
+                    {
+                        "DisplayName":  "Create repository",
+                        "Name":  "CreateRepository",
+                        "Bit":  256
+                    },
+                    {
+                        "DisplayName":  "Delete repository",
+                        "Name":  "DeleteRepository",
+                        "Bit":  512
+                    },
+                    {
+                        "DisplayName":  "Rename repository",
+                        "Name":  "RenameRepository",
+                        "Bit":  1024
+                    },
+                    {
+                        "DisplayName":  "Edit policies",
+                        "Name":  "EditPolicies",
+                        "Bit":  2048
+                    },
+                    {
+                        "DisplayName":  "Remove others\u0027 locks",
+                        "Name":  "RemoveOthersLocks",
+                        "Bit":  4096
+                    },
+                    {
+                        "DisplayName":  "Manage permissions",
+                        "Name":  "ManagePermissions",
+                        "Bit":  8192
+                    },
+                    {
+                        "DisplayName":  "Contribute to pull requests",
+                        "Name":  "PullRequestContribute",
+                        "Bit":  16384
+                    },
+                    {
+                        "DisplayName":  "Bypass policies when completing pull requests",
+                        "Name":  "PullRequestBypassPolicy",
+                        "Bit":  32768
+                    }
+                ],
+    "_internalObj":  [
+                         {
+                             "namespaceId":  "2e9eb7ed-3c0a-47d4-87c1-0ffdd275fd87",
+                             "name":  "Git Repositories",
+                             "displayName":  "Git Repositories",
+                             "separatorValue":  "/",
+                             "elementLength":  -1,
+                             "writePermission":  8192,
+                             "readPermission":  2,
+                             "dataspaceCategory":  "Git",
+                             "actions":  "               ",
+                             "structureValue":  1,
+                             "extensionType":  "Microsoft.TeamFoundation.Git.Server.Plugins.GitSecurityNamespaceExtension",
+                             "isRemotable":  true,
+                             "useTokenTranslator":  true,
+                             "systemBitMask":  0
+                         }
+                     ],
+    "ID":  "2e9eb7ed-3c0a-47d4-87c1-0ffdd275fd87",
+    "ProjectName":  "",
+    "DisplayMode":  "------",
+    "Name":  "Git Repositories"
+}
+"@ | ConvertFrom-Json
+
+   $securityNamespaceObject = [VSTeamSecurityNamespace]::new($securityNamespace)
+  
+   Describe 'AccessControlEntry VSTS' {
+      # You have to set the version or the api-version will not be Removeed when
+      # [VSTeamVersions]::Core = ''
+      [VSTeamVersions]::Core = '5.1'
+
+      Context 'Remove-VSTeamAccessControlEntry by SecurityNamespaceId' {
+         Mock Invoke-RestMethod { return $true }
+
+         Remove-VSTeamAccessControlEntry -SecurityNamespaceId 2e9eb7ed-3c0a-47d4-87c1-0ffdd275fd87 -Descriptor abc -Token xyz
+
+         It 'Should have a properly constructed URL' {
+            Assert-MockCalled Invoke-RestMethod -Exactly 1 -ParameterFilter {
+               $Uri -like "https://dev.azure.com/test/_apis/accesscontrolentries/2e9eb7ed-3c0a-47d4-87c1-0ffdd275fd87*" -and
+               $Uri -like "*api-version=$([VSTeamVersions]::Core)*" -and
+               $Uri -like "*Microsoft.TeamFoundation.Identity;S-1*" -and
+               $Uri -like "*?token=xyz*" -and
+               $Uri -like "*&descriptors=abc*" -and
+               $ContentType -eq "application/json" -and
+               $Method -eq "Delete"
+            }
+         }
+      }
+
+      Context 'Remove-VSTeamAccessControlEntry by SecurityNamespace' {
+         Mock Get-VSTeamSecurityNamespace { return $securityNamespaceObject }
+         Mock Invoke-RestMethod { return $true }
+
+         $securityNamespace = Get-VSTeamSecurityNamespace -Id "2e9eb7ed-3c0a-47d4-87c1-0ffdd275fd87"
+         Remove-VSTeamAccessControlEntry -SecurityNamespace $securityNamespace -Descriptor abc -Token xyz 
+
+         It 'Should have a properly constructed URL' {
+            Assert-MockCalled Invoke-RestMethod -Exactly 1 -ParameterFilter {
+                $Uri -like "https://dev.azure.com/test/_apis/accesscontrolentries/2e9eb7ed-3c0a-47d4-87c1-0ffdd275fd87*" -and
+                $Uri -like "*api-version=$([VSTeamVersions]::Core)*" -and
+                $Uri -like "*Microsoft.TeamFoundation.Identity;S-1*" -and
+                $Uri -like "*?token=xyz*" -and
+                $Uri -like "*&descriptors=abc*" -and
+                $ContentType -eq "application/json" -and
+                $Method -eq "Delete"
+            }
+         }
+      }
+
+      Context 'Remove-VSTeamAccessControlEntry by SecurityNamespace (pipeline)' {
+         Mock Get-VSTeamSecurityNamespace { return $securityNamespaceObject }
+         Mock Invoke-RestMethod { return $true }
+
+         Get-VSTeamSecurityNamespace -Id "2e9eb7ed-3c0a-47d4-87c1-0ffdd275fd87" | `
+            Remove-VSTeamAccessControlEntry -Descriptor abc -Token xyz 
+
+         It 'Should have a properly constructed URL' {
+            Assert-MockCalled Invoke-RestMethod -Exactly 1 -ParameterFilter {
+                $Uri -like "https://dev.azure.com/test/_apis/accesscontrolentries/2e9eb7ed-3c0a-47d4-87c1-0ffdd275fd87*" -and
+                $Uri -like "*api-version=$([VSTeamVersions]::Core)*" -and
+                $Uri -like "*Microsoft.TeamFoundation.Identity;S-1*" -and
+                $Uri -like "*?token=xyz*" -and
+                $Uri -like "*&descriptors=abc*" -and
+                $ContentType -eq "application/json" -and
+                $Method -eq "Delete"
+            }
+         }
+      }
+   }
+}


### PR DESCRIPTION
# PR Summary

This pull request adds the Remove-VSTeamAccessControlEntry function. This function removes one or more specified descriptors from an ACL inside the specified security namespace. This function accepts pipeline input for the namespace ID, or a properly constructed VSTeamSecurityNamespace object from which it can extract the namespace ID. Help and Unit tests are included.

## PR Checklist

- [Complete] [Write Help](https://github.com/DarqueWarrior/vsteam/blob/master/.github/CONTRIBUTING.md#write-help)
- [Complete] [Write Unit Test](https://github.com/DarqueWarrior/vsteam/blob/master/.github/CONTRIBUTING.md#write-unit-test)
- [Complete] [Update VSTeam.psd1](https://github.com/DarqueWarrior/vsteam/blob/master/.github/CONTRIBUTING.md#add-a-format-file)
- [Complete] [Update CHANGELOG.md](https://github.com/DarqueWarrior/vsteam/blob/master/.github/CONTRIBUTING.md#add-a-format-file)
