### PR TITLE
Update VSTeamJobRequest.ps1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 6.4.3
+
+Merged [Pull Request](https://github.com/DarqueWarrior/vsteam/pull/229) from [Asif Mithawala](https://github.com/asifma) which included the following:
+
+Added additional property checks in VSTeamJobRequest
+
 ## 6.4.2
 
 Merged [Pull Request](https://github.com/DarqueWarrior/vsteam/pull/226) from [Asif Mithawala](https://github.com/asifma) which included the following:

--- a/Source/Classes/VSTeamJobRequest.ps1
+++ b/Source/Classes/VSTeamJobRequest.ps1
@@ -1,43 +1,51 @@
 class VSTeamJobRequest : VSTeamLeaf {
    [datetime] $QueueTime
-   [datetime] $AssignTime
-   [datetime] $StartTime
+   [nullable[datetime]] $AssignTime
+   [nullable[datetime]] $StartTime
    [nullable[datetime]] $FinishTime
    [timespan] $Duration
    [string] $Type
    [string] $Result
    [string[]] $Demands
    [string] $Pipeline
-   
    VSTeamJobRequest (
       [object]$obj
    ) : base($obj.owner.name, $obj.requestId, $null) {
-
       $this.Type = $obj.planType
-      if ($obj.PSobject.Properties.Name -contains "result") {
-         $this.Result = $obj.result
+      if ($obj.PSobject.Properties.Name -notcontains "result" -and $obj.PSobject.Properties.Name -notcontains "assignTime") {
+         $this.Result = 'queued'
+      }
+      elseif ($obj.PSobject.Properties.Name -notcontains "result" -and $obj.PSobject.Properties.Name -contains "assignTime") {
+         $this.Result = 'running'
       }
       else {
-         $this.Result = 'running' 
-      }
+        $this.Result = $obj.result
+      } 
       $this.Demands = $obj.demands
       $this.QueueTime = $obj.queueTime
-      $this.AssignTime = $obj.assignTime
-      $this.StartTime = $obj.receiveTime
+      if ($obj.PSobject.Properties.Name -contains "assignTime") {
+         $this.AssignTime = $obj.assignTime
+      }
+      else {
+         $this.AssignTime = $null
+      }
+      if ($obj.PSobject.Properties.Name -contains "receiveTime") {
+         $this.StartTime = $obj.receiveTime
+      }
+      else {
+         $this.StartTime = $null
+      }
       if ($obj.PSobject.Properties.Name -contains "finishTime") {
          $this.FinishTime = $obj.finishTime
       }
       else {
-         $this.FinishTime = $null 
+         $this.FinishTime = $null
       }
       $this.Pipeline = $obj.definition.name
-
-      if ($null -ne $this.FinishTime) {
+      if ($null -ne $this.FinishTime -and $null -ne $this.StartTime) {
          $this.Duration = $this.FinishTime - $this.StartTime
       }
-
       $this._internalObj = $obj
-
       $this.AddTypeName('Team.JobRequest')
    }
 }

--- a/Source/VSTeam.psd1
+++ b/Source/VSTeam.psd1
@@ -12,7 +12,7 @@
    RootModule        = 'VSTeam.psm1'
 
    # Version number of this module.
-   ModuleVersion     = '6.4.2'
+   ModuleVersion     = '6.4.3'
 
    # Supported PSEditions
    # CompatiblePSEditions = @()


### PR DESCRIPTION
# PR Summary

Hi, I made a pull request a while ago #226 . I noticed similar errors for jobs that are "Queued".

Items that are "Queued" does not have properties: assignTime, receiveTime and result
I also added a statement to decide if job is currently "Queued", "running" or $obj.result if property exist.

Without this fix you don't get jobs that are currently "Queued" (you can try it yourself). 
Jobs can be queued when all Agents in a pool are busy e.g.
It's critical for me to know how many jobs are currently "Queued" for my Agent Auto-scaling automation.

Hope this fix will be merged soon :)

Best,
Asif Mithawala.

## PR Checklist
