### PR TITLE
Fix for #148

### DIFF
--- a/Source/Private/applyTypes.ps1
+++ b/Source/Private/applyTypes.ps1
@@ -95,7 +95,7 @@ function _applyTypesToBuild {
 function _applyArtifactTypes {
    $item.PSObject.TypeNames.Insert(0, "Team.Build.Artifact")
 
-   if ($item.PSObject.Properties.Match('resource').count -gt 0 -and $null -ne $item.resource) {
+   if ($item.PSObject.Properties.Match('resource').count -gt 0 -and $null -ne $item.resource -and $item.resource.PSObject.Properties.Match('propeties').count -gt 0) {
       $item.resource.PSObject.TypeNames.Insert(0, 'Team.Build.Artifact.Resource')
       $item.resource.properties.PSObject.TypeNames.Insert(0, 'Team.Build.Artifact.Resource.Properties')
    }


### PR DESCRIPTION
This fixes a bug in `Get-VSTeamBuildArtifact` where an error is returned because the API returns an extra record along with the list of artifacts that is called 'build.sourcelabel' and contains a URL but no "properties" object.

This PR stops the error by excluding any build artifact records returned by the API that don't contain a "properties" object from getting the build artifact specific type names applied. The result is still returned to the user however.

Alternatively if we think it would be better to exclude this result entirely, then it could instead be filtered out in the `Get-VSTeamBuildArtifact` function.

# PR Summary

<!-- summarize your PR between here and the checklist -->

## PR Checklist

- [ ] [Write Help](https://github.com/DarqueWarrior/vsteam/blob/master/.github/CONTRIBUTING.md#write-help)
- [ ] [Write Unit Test](https://github.com/DarqueWarrior/vsteam/blob/master/.github/CONTRIBUTING.md#write-unit-test)
- [ ] [Update CHANGELOG.md](https://github.com/DarqueWarrior/vsteam/blob/master/.github/CONTRIBUTING.md#add-a-format-file)
