### PR TITLE
Force install of VSTeam Module

### DIFF
--- a/build/integrationTests.yml
+++ b/build/integrationTests.yml
@@ -61,7 +61,7 @@ jobs:
                   $pwd = ConvertTo-SecureString "$(PKG_PAT)" -AsPlainText -Force
                   $creds = New-Object PSCredential($e, $pwd)
 
-                  Install-Module -Name VSTeam -Repository $n -Credential $creds -MaximumVersion $b -MinimumVersion $b -Scope CurrentUser -Verbose
+                  Install-Module -Name VSTeam -Repository $n -Credential $creds -MaximumVersion $b -MinimumVersion $b -Force -Scope CurrentUser -Verbose
                 workingDirectory: '$(Pipeline.Workspace)/Test'
 
             - task: PowerShell@2


### PR DESCRIPTION
# PR Summary

Force install of VSTeam Module.
I've seen that it failed on the `Install VSTeam Module` step recently (The build that is currently listed on the "Build" badge on the README is failing on this)

Fixes #248

## PR Checklist

- [ ] [Write Help](https://github.com/DarqueWarrior/vsteam/blob/master/.github/CONTRIBUTING.md#write-help)
- [ ] [Write Unit Test](https://github.com/DarqueWarrior/vsteam/blob/master/.github/CONTRIBUTING.md#write-unit-test)
- [ ] [Update CHANGELOG.md](https://github.com/DarqueWarrior/vsteam/blob/master/.github/CONTRIBUTING.md#add-a-format-file)

(not necessary)