### PR TITLE
Pass variables cross stage

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -188,6 +188,13 @@ stages:
               publishVstsFeed: 'vsteam'
               allowPackageConflicts: true
 
+          - template: ./templates/persist-variable.yml
+            parameters:
+              variableName: 'PACKAGE_VERSION'
+
+          - publish: $(Pipeline.Workspace)/variables
+            artifact: variables
+
 - stage: Testing
   displayName: Testing stage
   dependsOn: Package
@@ -255,6 +262,13 @@ stages:
       runOnce:
         deploy:
           steps:
+          - download: current
+            artifact: variables
+
+          - template: ./templates/read-variable.yml
+            parameters:
+               variableName: 'PACKAGE_VERSION'
+
           - task: NuGetToolInstaller@0
             displayName: 'Install NuGet 5.2.0'
             inputs:

--- a/templates/persist-variable.yml
+++ b/templates/persist-variable.yml
@@ -1,0 +1,18 @@
+parameters:
+  variableName: ''
+
+steps:
+- bash: |
+    echo "Variable 'variableName' found with value '$VARIABLE_NAME'"
+    if [ -z "$VARIABLE_NAME" ]; then
+      echo "##vso[task.logissue type=error;]Missing template parameter \"variableName\""
+      echo "##vso[task.complete result=Failed;]"
+    fi
+  env:
+    VARIABLE_NAME: ${{ parameters.variableName }}
+  displayName: Check for required parameters in YAML template
+- powershell: |
+   mkdir -p $(Pipeline.Workspace)/variables
+   echo "$(${{ parameters.variableName }})" > $(Pipeline.Workspace)/variables/${{ parameters.variableName }}.variable
+   echo "Variable written to '$(Pipeline.Workspace)/variables/${{ parameters.variableName }}.variable'"
+  displayName: 'Persist ''${{ parameters.variableName }}'' variable'

--- a/templates/read-variable.yml
+++ b/templates/read-variable.yml
@@ -1,0 +1,20 @@
+parameters:
+  variableName: ''
+
+steps:
+- bash: |
+    echo "Variable 'variableName' found with value '$VARIABLE_NAME'"
+    if [ -z "$VARIABLE_NAME" ]; then
+      echo "##vso[task.logissue type=error;]Missing template parameter \"variableName\""
+      echo "##vso[task.complete result=Failed;]"
+    fi
+  env:
+    VARIABLE_NAME: ${{ parameters.variableName }}
+  displayName: Check for required parameters in YAML template
+- bash: |
+   echo "Reading file '$(Pipeline.Workspace)/variables/${{ parameters.variableName }}.variable'"
+   cat $(Pipeline.Workspace)/variables/${{ parameters.variableName }}.variable
+   READ_VAR=$(cat $(Pipeline.Workspace)/variables/${{ parameters.variableName }}.variable)
+   echo "Read value '$READ_VAR'"
+   echo "##vso[task.setvariable variable=${{ parameters.variableName }};]$READ_VAR"
+  displayName: 'Reading ''${{ parameters.variableName }}'' variable'


### PR DESCRIPTION
# PR Summary

Pass variables across stages in Azure DevOps pipeline so tat `PACKAGE_VERSION` is available in other stages as well.

This is required to fix the current GitHub releases.

Follow-up for #253 to fix broken GitHub releases.
