### PR TITLE
Fixing Default API Version for Build API in TFS 2018

### DIFF
--- a/Source/Classes/VSTeamVersions.ps1
+++ b/Source/Classes/VSTeamVersions.ps1
@@ -2,7 +2,7 @@ class VSTeamVersions {
    static [string] $Account = $env:TEAM_ACCT
    static [string] $DefaultProject = $env:TEAM_PROJECT
    static [string] $Version = $(If ($env:TEAM_VERSION) { $env:TEAM_VERSION } Else { "TFS2017" })
-   static [string] $Build = '3.0'
+   static [string] $Build = '3.2'
    static [string] $Release = '3.0-preview'
    static [string] $Core = '3.0'
    static [string] $Git = '3.0'


### PR DESCRIPTION
Adjusting default API version for the Build API in TFS 2018 as documented in the issue #78.

The default version is changed from 3.0 to 3.2.

This has never been adjusted.