### PR TITLE
Update order on installing Pester from Build-Module.  

### DIFF
--- a/Build-Module.ps1
+++ b/Build-Module.ps1
@@ -113,7 +113,7 @@ if ($runTests.IsPresent) {
    }
 
    # This loads [PesterConfiguration] into scope
-   Import-Module Pester
+   Import-Module Pester -MinimumVersion 5.0.0
 
    $pesterArgs = [PesterConfiguration]::Default
    $pesterArgs.Run.Path = '.\unit'

--- a/Build-Module.ps1
+++ b/Build-Module.ps1
@@ -107,13 +107,13 @@ if ($ipmo.IsPresent -or $runTests.IsPresent) {
 
 # run the unit tests with Pester
 if ($runTests.IsPresent) {
-   # This loads [PesterConfiguration] into scope
-   Import-Module Pester
-
    if ($null -eq $(Get-Module -ListAvailable Pester | Where-Object Version -like '5.*')) {
       Write-Output "Installing Pester 5"
       Install-Module -Name Pester -Repository PSGallery -Force -AllowPrerelease -MinimumVersion '5.0.0-rc9' -Scope CurrentUser -AllowClobber -SkipPublisherCheck
    }
+
+   # This loads [PesterConfiguration] into scope
+   Import-Module Pester
 
    $pesterArgs = [PesterConfiguration]::Default
    $pesterArgs.Run.Path = '.\unit'


### PR DESCRIPTION

# PR Summary

Build-Module.ps1 has code to install Pester 5 if it is not present.  That code exists after the import of the Pester module happens.

If no version of the Pester module is present, the script would error before installing.

If any version earlier than 5.0.0.x of the Pester module was available, it would be loaded before the install was attempted and then error when attemping to access the static property of `[PesterConfiguration]::Default`.

This PR changes the order to

* Check for a version of Pester 5.*
* If there is no Pester 5 installed, then install Pester 5 from the PowerShell Gallery
* Import Pester with a minimum version of 5.0.0

## PR Checklist

- [⛔] [Write Help](https://github.com/DarqueWarrior/vsteam/blob/master/.github/CONTRIBUTING.md#write-help)
- [⛔] [Write Unit Test](https://github.com/DarqueWarrior/vsteam/blob/master/.github/CONTRIBUTING.md#write-unit-test)
- [⛔] [Update CHANGELOG.md](https://github.com/DarqueWarrior/vsteam/blob/master/.github/CONTRIBUTING.md#update-changelogmd)

Didn't update the changelog as this PR doesn't impact module functionality, just the new dev/build machine experience.
