### PR TITLE
Adds IncludeCommits switch to Get-VSTeamPullRequest

### DIFF
--- a/.docs/Get-VSTeamPullRequest.md
+++ b/.docs/Get-VSTeamPullRequest.md
@@ -54,6 +54,14 @@ PS C:\> Get-VSTeamPullRequest -Id 123
 
 This command gets the pull request with an Id of 123.
 
+### -------------------------- EXAMPLE 6 --------------------------
+
+```PowerShell
+PS C:\> Get-VSTeamPullRequest -Id 123 -RepositoryId "93BBA613-2729-4158-9217-751E952AB4AF" -IncludeCommits
+```
+
+This command gets the pull request with an Id of 123 and includes the commits that are part of the pull request.
+
 ## PARAMETERS
 
 ### -ProjectName
@@ -80,7 +88,7 @@ Specifies the pull request by ID.
 Type: String
 Aliases: PullRequestId
 Accept pipeline input: true (ByPropertyName)
-Parameter Sets: ById
+Parameter Sets: ById, IncludeCommits
 ```
 
 ### -RepositoryId
@@ -89,7 +97,7 @@ The repository ID of the pull request's target branch.
 
 ```yaml
 Type: Guid
-Parameter Sets: SearchCriteriaWithStatus, SearchCriteriaWithAll
+Parameter Sets: SearchCriteriaWithStatus, SearchCriteriaWithAll, ById, IncludeCommits
 ```
 
 ### -SourceRepositoryId
@@ -157,6 +165,15 @@ The number of pull requests to ignore. For example, to retrieve results 101-150,
 ```yaml
 Type: Int32
 Parameter Sets: SearchCriteriaWithStatus, SearchCriteriaWithAll
+```
+
+### -IncludeCommits
+
+If set, includes the commits that are part of the pull request. Requires the RepositoryId to be set.
+
+```yaml
+Type: Switch
+Parameter Sets: IncludeCommits
 ```
 
 ## INPUTS

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,10 @@ Merged [Pull Request](https://github.com/DarqueWarrior/vsteam/pull/317) from [Br
 
 - Adds a new function Stop-VSTeamBuild which allows cancelling a build using the build id.
 
+Merged [Pull Request](https://github.com/DarqueWarrior/vsteam/pull/333) from [Daniel Sturm](https://github.com/danstur) which included the following:
+
+- Adds -IncludeCommits switch to Get-VSTeamPullRequest.
+
 ## 6.4.8
 
 You can now tab complete Area and Resource of Invoke-VSTeamRequest.

--- a/Source/Public/Get-VSTeamPullRequest.ps1
+++ b/Source/Public/Get-VSTeamPullRequest.ps1
@@ -3,10 +3,13 @@ function Get-VSTeamPullRequest {
    param (
       [Alias('PullRequestId')]
       [Parameter(ParameterSetName = "ById")]
+      [Parameter(ParameterSetName = "IncludeCommits")]
       [string] $Id,
-
+      
       [Parameter(ParameterSetName = "SearchCriteriaWithStatus")]
       [Parameter(ParameterSetName = "SearchCriteriaWithAll")]
+      [Parameter(ParameterSetName = "ById")]
+      [Parameter(ParameterSetName = "IncludeCommits", Mandatory)]
       [Guid] $RepositoryId,
 
       [Parameter(ParameterSetName = "SearchCriteriaWithAll")]
@@ -30,6 +33,9 @@ function Get-VSTeamPullRequest {
       [Parameter(ParameterSetName = "SearchCriteriaWithAll")]
       [switch] $All,
 
+      [Parameter(ParameterSetName = "IncludeCommits")]
+      [switch] $IncludeCommits,
+
       [Parameter(ParameterSetName = "SearchCriteriaWithAll")]
       [Parameter(ParameterSetName = "SearchCriteriaWithStatus")]
       [int] $Top,
@@ -47,7 +53,13 @@ function Get-VSTeamPullRequest {
    process {
       try {
          if ($Id) {
-            if ($ProjectName) {
+            if ($RepositoryId) {
+               $queryString = @{
+                  'includeCommits' = $IncludeCommits
+               }
+               $resp = _callAPI -Id "$RepositoryId/pullRequests/$Id" -Area git -Resource repositories -Version $(_getApiVersion Git) -QueryString $queryString 
+            }
+            elseif ($ProjectName) {
                $resp = _callAPI -ProjectName $ProjectName -Area git -Resource pullRequests -Version $(_getApiVersion Git) -Id $Id
             }
             else {

--- a/Source/en-US/VSTeam-Help.xml
+++ b/Source/en-US/VSTeam-Help.xml
@@ -13783,6 +13783,70 @@ ID Title          Status
           </dev:type>
           <dev:defaultValue>None</dev:defaultValue>
         </command:parameter>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="false" position="named" aliases="none">
+          <maml:name>RepositoryId</maml:name>
+          <maml:Description>
+            <maml:para>The repository ID of the pull request's target branch.</maml:para>
+          </maml:Description>
+          <command:parameterValue required="true" variableLength="false">Guid</command:parameterValue>
+          <dev:type>
+            <maml:name>Guid</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+      </command:syntaxItem>
+      <command:syntaxItem>
+        <maml:name>Get-VSTeamPullRequest</maml:name>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="true (ByPropertyName)" position="0" aliases="none">
+          <maml:name>ProjectName</maml:name>
+          <maml:Description>
+            <maml:para>Specifies the team project for which this function operates.</maml:para>
+            <maml:para>You can tab complete from a list of available projects.</maml:para>
+            <maml:para>You can use Set-VSTeamDefaultProject to set a default project so you do not have to pass the ProjectName with each call.</maml:para>
+          </maml:Description>
+          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="true (ByPropertyName)" position="named" aliases="PullRequestId">
+          <maml:name>Id</maml:name>
+          <maml:Description>
+            <maml:para>Specifies the pull request by ID.</maml:para>
+          </maml:Description>
+          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="false" position="named" aliases="none">
+          <maml:name>RepositoryId</maml:name>
+          <maml:Description>
+            <maml:para>The repository ID of the pull request's target branch.</maml:para>
+          </maml:Description>
+          <command:parameterValue required="true" variableLength="false">Guid</command:parameterValue>
+          <dev:type>
+            <maml:name>Guid</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="false" position="named" aliases="none">
+          <maml:name>IncludeCommits</maml:name>
+          <maml:Description>
+            <maml:para>If set, includes the commits that are part of the pull request. Requires the RepositoryId to be set.</maml:para>
+          </maml:Description>
+          <dev:type>
+            <maml:name>SwitchParameter</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>False</dev:defaultValue>
+        </command:parameter>
       </command:syntaxItem>
       <command:syntaxItem>
         <maml:name>Get-VSTeamPullRequest</maml:name>
@@ -14119,6 +14183,18 @@ ID Title          Status
         </dev:type>
         <dev:defaultValue>None</dev:defaultValue>
       </command:parameter>
+      <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="false" position="named" aliases="none">
+        <maml:name>IncludeCommits</maml:name>
+        <maml:Description>
+          <maml:para>If set, includes the commits that are part of the pull request. Requires the RepositoryId to be set.</maml:para>
+        </maml:Description>
+        <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+        <dev:type>
+          <maml:name>SwitchParameter</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>False</dev:defaultValue>
+      </command:parameter>
     </command:parameters>
     <command:inputTypes />
     <command:returnValues />
@@ -14161,6 +14237,13 @@ ID Title          Status
         <dev:code>PS C:\&gt; Get-VSTeamPullRequest -Id 123</dev:code>
         <dev:remarks>
           <maml:para>This command gets the pull request with an Id of 123.</maml:para>
+        </dev:remarks>
+      </command:example>
+      <command:example>
+        <maml:title>-------------------------- EXAMPLE 6 --------------------------</maml:title>
+        <dev:code>PS C:\&gt; Get-VSTeamPullRequest -Id 123 -RepositoryId "93BBA613-2729-4158-9217-751E952AB4AF" -IncludeCommits</dev:code>
+        <dev:remarks>
+          <maml:para>This command gets the pull request with an Id of 123 and includes the commits that are part of the pull request.</maml:para>
         </dev:remarks>
       </command:example>
     </command:examples>

--- a/docs/Get-VSTeamPullRequest.md
+++ b/docs/Get-VSTeamPullRequest.md
@@ -55,6 +55,14 @@ PS C:\> Get-VSTeamPullRequest -Id 123
 
 This command gets the pull request with an Id of 123.
 
+### -------------------------- EXAMPLE 6 --------------------------
+
+```PowerShell
+PS C:\> Get-VSTeamPullRequest -Id 123 -RepositoryId "93BBA613-2729-4158-9217-751E952AB4AF" -IncludeCommits
+```
+
+This command gets the pull request with an Id of 123 and includes the commits that are part of the pull request.
+
 ## PARAMETERS
 
 ### -ProjectName
@@ -81,7 +89,7 @@ Specifies the pull request by ID.
 Type: String
 Aliases: PullRequestId
 Accept pipeline input: true (ByPropertyName)
-Parameter Sets: ById
+Parameter Sets: ById, IncludeCommits
 ```
 
 ### -RepositoryId
@@ -90,7 +98,7 @@ The repository ID of the pull request's target branch.
 
 ```yaml
 Type: Guid
-Parameter Sets: SearchCriteriaWithStatus, SearchCriteriaWithAll
+Parameter Sets: SearchCriteriaWithStatus, SearchCriteriaWithAll, ById, IncludeCommits
 ```
 
 ### -SourceRepositoryId
@@ -158,6 +166,15 @@ The number of pull requests to ignore. For example, to retrieve results 101-150,
 ```yaml
 Type: Int32
 Parameter Sets: SearchCriteriaWithStatus, SearchCriteriaWithAll
+```
+
+### -IncludeCommits
+
+If set, includes the commits that are part of the pull request. Requires the RepositoryId to be set.
+
+```yaml
+Type: Switch
+Parameter Sets: IncludeCommits
 ```
 
 ## INPUTS

--- a/unit/test/Get-VSTeamPullRequest.Tests.ps1
+++ b/unit/test/Get-VSTeamPullRequest.Tests.ps1
@@ -203,6 +203,16 @@ Describe 'VSTeamPullRequest' {
 
          $pr.reviewStatus | Should -Be "Rejected"
       }
+
+      It 'with RepositoryId and IncludeCommits' {
+         Get-VSTeamPullRequest -Id 101 -RepositoryId "93BBA613-2729-4158-9217-751E952AB4AF" -IncludeCommits
+         Should -Invoke Invoke-RestMethod -Exactly -Scope It -Times 1 -ParameterFilter {
+            $Uri -like "*test/_apis/git/repositories*" -and
+            $Uri -like "*includeCommits=True" -and
+            $Uri -like "*api-version=$(_getApiVersion Git)*" -and
+            $Uri -like "*pullRequests/101*"
+         }
+      }
    }
 }
 


### PR DESCRIPTION
# PR Summary

Currently Get-VsTeamPullRequest does not offer a way to get the commits of a specific pull request. Here's a simple implementation that works fine for me with Azure DevOps Server (on-premise). 

## Open Questions

- Not sure if simply adding `RepositoryId` to the ById parameter set is the best approach.
- Do I need a types file for the git commit ref? ([msdn](https://docs.microsoft.com/en-us/rest/api/azure/devops/git/pull%20requests/get%20pull%20request?view=azure-devops-server-rest-5.0#gitcommitref))
- Since the pull request ID is only known after I create this, I guess I should update the changelog and rebase afterwards? :-) 
- Trying to run the Script Analyzer results in:
```
Invoke-ScriptAnalyzer: C:\dev\OpenSource\vsteam\Build-Module.ps1:149:9
Line |
 149 |     $r = Invoke-ScriptAnalyzer -Path $output -Recurse
     |          ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     | Object reference not set to an instance of an object.
```
(Windows 10 x64, PowerShell 7.0). So I couldn't run the analyzer to see if I violated any rules - given the minimal changes I hope not.

## PR Checklist

- [x] [Write Help](https://github.com/DarqueWarrior/vsteam/blob/master/.github/CONTRIBUTING.md#write-help)
- [x] [Write Unit Test](https://github.com/DarqueWarrior/vsteam/blob/master/.github/CONTRIBUTING.md#write-unit-test)
- [x] [Update CHANGELOG.md](https://github.com/DarqueWarrior/vsteam/blob/master/.github/CONTRIBUTING.md#update-changelogmd)
