### PR TITLE
Fixed a bug in Test-VSTeamYamlPipeline

### DIFF
--- a/.docs/gen-help.ps1
+++ b/.docs/gen-help.ps1
@@ -19,6 +19,6 @@ if(-not (Get-Module platyPS -ListAvailable)) {
    Install-Module platyPS -Scope CurrentUser -Force
 }
 
-$helpOutput = New-ExternalHelp ..\docs -OutputPath ..\Source\en-US -AlphabeticParamsOrder -Force | Out-String
+$helpOutput = New-ExternalHelp ..\docs -OutputPath ..\Source\en-US -Force | Out-String
 
 Write-Verbose $helpOutput

--- a/.docs/gen-help.ps1
+++ b/.docs/gen-help.ps1
@@ -19,6 +19,6 @@ if(-not (Get-Module platyPS -ListAvailable)) {
    Install-Module platyPS -Scope CurrentUser -Force
 }
 
-$helpOutput = New-ExternalHelp ..\docs -OutputPath ..\Source\en-US -Force | Out-String
+$helpOutput = New-ExternalHelp ..\docs -OutputPath ..\Source\en-US -AlphabeticParamsOrder -Force | Out-String
 
 Write-Verbose $helpOutput

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 7.1.1
+
+Fixed bug in Test-VSTeamYamlPipeline by adding a Pipelines version value.
+
 ## 7.1.0
 
 Added:

--- a/Source/Classes/Versions.cs
+++ b/Source/Classes/Versions.cs
@@ -7,7 +7,7 @@ namespace vsteam_lib
       Build, Release, Core, Git, DistributedTask, DistributedTaskReleased,
       VariableGroups, Tfvc, Packaging, MemberEntitlementManagement,
       ExtensionsManagement, ServiceEndpoints, Graph, TaskGroups, Policy,
-      Processes, Version, HierarchyQuery
+      Processes, Version, HierarchyQuery, Pipelines
    }
 
    public static class Versions
@@ -36,6 +36,9 @@ namespace vsteam_lib
                break;
             case APIs.DistributedTaskReleased:
                DistributedTaskReleased = version;
+               break;
+            case APIs.Pipelines:
+               Pipelines = version;
                break;
             case APIs.VariableGroups:
                VariableGroups = version;
@@ -88,6 +91,8 @@ namespace vsteam_lib
                return DistributedTask;
             case APIs.DistributedTaskReleased:
                return DistributedTaskReleased;
+            case APIs.Pipelines:
+               return Pipelines;
             case APIs.VariableGroups:
                return VariableGroups;
             case APIs.Tfvc:
@@ -133,6 +138,7 @@ namespace vsteam_lib
       public static string Release { get; set; } = "3.0-preview";
       public static string DistributedTask { get; set; } = "3.0-preview";
       public static string DistributedTaskReleased { get; set; } = "";
+      public static string Pipelines { get; set; } = "";
       public static string VariableGroups { get; set; } = "";
       public static string TaskGroups { get; set; } = "3.0-preview";
       public static string Tfvc { get; set; } = "3.0";

--- a/Source/Private/common.ps1
+++ b/Source/Private/common.ps1
@@ -177,7 +177,7 @@ function _getApiVersion {
          'DistributedTaskReleased', 'VariableGroups', 'Tfvc',
          'Packaging', 'MemberEntitlementManagement',
          'ExtensionsManagement', 'ServiceEndpoints', 'Graph',
-         'TaskGroups', 'Policy', 'Processes', 'HierarchyQuery')]
+         'TaskGroups', 'Policy', 'Processes', 'HierarchyQuery', 'Pipelines')]
       [string] $Service,
 
       [parameter(ParameterSetName = 'Target')]

--- a/Source/Public/Get-VSTeamAPIVersion.ps1
+++ b/Source/Public/Get-VSTeamAPIVersion.ps1
@@ -1,9 +1,14 @@
 function Get-VSTeamAPIVersion {
-   [CmdletBinding(HelpUri='https://methodsandpractices.github.io/vsteam-docs/docs/modules/vsteam/commands/Get-VSTeamAPIVersion')]
+   [CmdletBinding(HelpUri = 'https://methodsandpractices.github.io/vsteam-docs/docs/modules/vsteam/commands/Get-VSTeamAPIVersion')]
    [OutputType([System.Collections.Hashtable])]
    param(
       [Parameter(Mandatory = $false, Position = 0)]
-      [ValidateSet('Build', 'Release', 'Core', 'Git', 'DistributedTask', 'DistributedTaskReleased', 'VariableGroups', 'Tfvc', 'Packaging', 'MemberEntitlementManagement', 'ExtensionsManagement', 'ServiceEndpoints', 'Graph', 'TaskGroups', 'Policy', 'Processes', 'HierarchyQuery')]
+      [ValidateSet('Build', 'Release', 'Core', 'Git', 'DistributedTask',
+                   'DistributedTaskReleased', 'VariableGroups', 'Tfvc',
+                   'Packaging', 'MemberEntitlementManagement',
+                   'ExtensionsManagement', 'ServiceEndpoints', 'Graph',
+                   'TaskGroups', 'Policy', 'Processes', 'HierarchyQuery',
+                   'Pipelines')]
       [string] $Service
    )
 
@@ -30,6 +35,7 @@ function Get-VSTeamAPIVersion {
          Policy                      = $(_getApiVersion Policy)
          Processes                   = $(_getApiVersion Processes)
          HierarchyQuery              = $(_getApiVersion HierarchyQuery)
+         Pipelines                   = $(_getApiVersion Pipelines)
       }
    }
 }

--- a/Source/Public/Set-VSTeamAPIVersion.ps1
+++ b/Source/Public/Set-VSTeamAPIVersion.ps1
@@ -13,7 +13,8 @@ function Set-VSTeamAPIVersion {
                    'DistributedTaskReleased', 'VariableGroups', 'Tfvc',
                    'Packaging', 'MemberEntitlementManagement',
                    'ExtensionsManagement', 'ServiceEndpoints', 'Graph',
-                   'TaskGroups', 'Policy', 'HierarchyQuery')]
+                   'TaskGroups', 'Policy', 'Processes', 'HierarchyQuery',
+                   'Pipelines')]
       [string] $Service,
 
       [parameter(ParameterSetName = 'Service', Mandatory = $true, Position = 1)]
@@ -37,6 +38,7 @@ function Set-VSTeamAPIVersion {
                [vsteam_lib.Versions]::Release = '5.0'
                [vsteam_lib.Versions]::DistributedTask = '5.0-preview'
                [vsteam_lib.Versions]::DistributedTaskReleased = ''
+               [vsteam_lib.Versions]::Pipelines = ''
                [vsteam_lib.Versions]::HierarchyQuery = '5.0-preview'
                [vsteam_lib.Versions]::VariableGroups = '5.0-preview'
                [vsteam_lib.Versions]::Tfvc = '5.0'
@@ -57,6 +59,7 @@ function Set-VSTeamAPIVersion {
                [vsteam_lib.Versions]::Release = '5.1'
                [vsteam_lib.Versions]::DistributedTask = '5.1-preview'
                [vsteam_lib.Versions]::DistributedTaskReleased = ''
+               [vsteam_lib.Versions]::Pipelines = '5.1-preview'
                [vsteam_lib.Versions]::HierarchyQuery = '5.1-preview'
                [vsteam_lib.Versions]::VariableGroups = '5.1-preview'
                [vsteam_lib.Versions]::Tfvc = '5.1'
@@ -77,6 +80,7 @@ function Set-VSTeamAPIVersion {
                [vsteam_lib.Versions]::Release = '4.0-preview'
                [vsteam_lib.Versions]::DistributedTask = '4.0-preview'
                [vsteam_lib.Versions]::DistributedTaskReleased = ''
+               [vsteam_lib.Versions]::Pipelines = ''
                [vsteam_lib.Versions]::HierarchyQuery = ''
                [vsteam_lib.Versions]::VariableGroups = '4.0-preview'
                [vsteam_lib.Versions]::Tfvc = '4.0'
@@ -97,6 +101,7 @@ function Set-VSTeamAPIVersion {
                [vsteam_lib.Versions]::Release = '4.1-preview'
                [vsteam_lib.Versions]::DistributedTask = '4.1-preview'
                [vsteam_lib.Versions]::DistributedTaskReleased = ''
+               [vsteam_lib.Versions]::Pipelines = ''
                [vsteam_lib.Versions]::HierarchyQuery = ''
                [vsteam_lib.Versions]::VariableGroups = '4.1-preview'
                [vsteam_lib.Versions]::Tfvc = '4.1'
@@ -117,6 +122,7 @@ function Set-VSTeamAPIVersion {
                [vsteam_lib.Versions]::Release = '3.0-preview'
                [vsteam_lib.Versions]::DistributedTask = '3.0-preview'
                [vsteam_lib.Versions]::DistributedTaskReleased = ''
+               [vsteam_lib.Versions]::Pipelines = ''
                [vsteam_lib.Versions]::HierarchyQuery = ''
                [vsteam_lib.Versions]::VariableGroups = '' # Was introduced in Update 1
                [vsteam_lib.Versions]::TaskGroups = '3.0-preview'
@@ -137,6 +143,7 @@ function Set-VSTeamAPIVersion {
                [vsteam_lib.Versions]::Release = '3.1-preview'
                [vsteam_lib.Versions]::DistributedTask = '3.1-preview'
                [vsteam_lib.Versions]::DistributedTaskReleased = ''
+               [vsteam_lib.Versions]::Pipelines = ''
                [vsteam_lib.Versions]::HierarchyQuery = ''
                [vsteam_lib.Versions]::VariableGroups = '3.1-preview' # Resource of DistributedTask area
                [vsteam_lib.Versions]::TaskGroups = '3.1-preview' # Resource of DistributedTask area
@@ -158,6 +165,7 @@ function Set-VSTeamAPIVersion {
                [vsteam_lib.Versions]::Release = '3.2-preview'
                [vsteam_lib.Versions]::DistributedTask = '3.2-preview'
                [vsteam_lib.Versions]::DistributedTaskReleased = ''
+               [vsteam_lib.Versions]::Pipelines = ''
                [vsteam_lib.Versions]::HierarchyQuery = ''
                [vsteam_lib.Versions]::VariableGroups = '3.2-preview' # Resource of DistributedTask area
                [vsteam_lib.Versions]::TaskGroups = '3.2-preview' # Resource of DistributedTask area
@@ -179,6 +187,7 @@ function Set-VSTeamAPIVersion {
                [vsteam_lib.Versions]::Release = '5.1'
                [vsteam_lib.Versions]::DistributedTask = '6.0-preview'
                [vsteam_lib.Versions]::DistributedTaskReleased = '5.1'
+               [vsteam_lib.Versions]::Pipelines = '5.1-preview'
                [vsteam_lib.Versions]::HierarchyQuery = '5.1-preview'
                [vsteam_lib.Versions]::VariableGroups = '5.1-preview.1'
                [vsteam_lib.Versions]::TaskGroups = '6.0-preview'
@@ -238,6 +247,10 @@ function Set-VSTeamAPIVersion {
    # Get-VSTeamOption -area 'distributedtask' -resource 'messages'
    # Get-VSTeamOption -area 'distributedtask' -resource 'jobrequests'
    Write-Verbose "DistributedTaskReleased: $([vsteam_lib.Versions]::DistributedTaskReleased)"
+
+   # Testing pipelines
+   #  Get-VSTeamOption -area 'pipelines' -resource 'runs'
+   Write-Verbose "Pipelines: $([vsteam_lib.Versions]::Pipelines)"
 
    # Get-VSTeamOption -area 'Contribution' -resource 'HierarchyQuery'
    Write-Verbose "HierarchyQuery: $([vsteam_lib.Versions]::HierarchyQuery)"

--- a/Source/Public/Test-VSTeamYamlPipeline.ps1
+++ b/Source/Public/Test-VSTeamYamlPipeline.ps1
@@ -35,7 +35,7 @@ function Test-VSTeamYamlPipeline {
             -Area pipelines `
             -id "$PipelineId/runs" `
             -Body ($body | ConvertTo-Json -Compress -Depth 100) `
-            -Version $(_getApiVersion Build)
+            -Version $(_getApiVersion Pipelines)
       }
       catch {
          if ($PSItem -match 'PipelineValidationException') {

--- a/Source/VSTeam.psd1
+++ b/Source/VSTeam.psd1
@@ -12,7 +12,7 @@
    RootModule           = 'VSTeam.psm1'
 
    # Version number of this module.
-   ModuleVersion        = '7.1.0'
+   ModuleVersion        = '7.1.1'
 
    # Supported PSEditions
    CompatiblePSEditions = @('Core', 'Desktop')

--- a/Tests/function/tests/Test-VSTeamYamlPipeline.Tests.ps1
+++ b/Tests/function/tests/Test-VSTeamYamlPipeline.Tests.ps1
@@ -3,7 +3,7 @@ Set-StrictMode -Version Latest
 Describe 'VSTeamYamlPipeline' {
    BeforeAll {
       . "$PSScriptRoot\_testInitialize.ps1" $PSCommandPath
-      
+
       $testYamlPath = "$sampleFiles\azure-pipelines.test.yml"
       Mock _getInstance { return 'https://dev.azure.com/test' }
       Mock Invoke-RestMethod { Open-SampleFile 'pipelineDefYamlResult.json' }
@@ -16,7 +16,7 @@ Describe 'VSTeamYamlPipeline' {
 
          Should -Invoke Invoke-RestMethod -Exactly -Scope It -Times 1 -ParameterFilter {
             $Uri -like "*https://dev.azure.com/test/project/_apis/pipelines/24/runs*" -and
-            $Uri -like "*api-version=$(_getApiVersion Build)*" -and
+            $Uri -like "*api-version=$(_getApiVersion Pipelines)*" -and
             $Body -like '*"PreviewRun":*true*' -and
             $Body -notlike '*YamlOverride*'
          }
@@ -27,7 +27,7 @@ Describe 'VSTeamYamlPipeline' {
 
          Should -Invoke Invoke-RestMethod -Exactly -Scope It -Times 1 -ParameterFilter {
             $Uri -like "*https://dev.azure.com/test/project/_apis/pipelines/24/runs*" -and
-            $Uri -like "*api-version=$(_getApiVersion Build)*" -and
+            $Uri -like "*api-version=$(_getApiVersion Pipelines)*" -and
             $Body -like '*"PreviewRun":*true*' -and
             $Body -like '*YamlOverride*'
          }
@@ -40,12 +40,12 @@ Describe 'VSTeamYamlPipeline' {
 
          Should -Invoke Invoke-RestMethod -Exactly -Scope It -Times 1 -ParameterFilter {
             $Uri -like "*https://dev.azure.com/test/project/_apis/pipelines/24/runs*" -and
-            $Uri -like "*api-version=$(_getApiVersion Build)*" -and
+            $Uri -like "*api-version=$(_getApiVersion Pipelines)*" -and
             $Body -like '*"PreviewRun":*true*' -and
             $Body -like '*YamlOverride*'
          }
       }
-      
+
       It 'Should create Yaml result' {
          $yamlResult = Test-VSTeamYamlPipeline -projectName project -PipelineId 24 -FilePath $testYamlPath
 

--- a/Tests/library/VersionsTests.cs
+++ b/Tests/library/VersionsTests.cs
@@ -15,6 +15,7 @@ namespace vsteam_lib.Test
       [DataRow("GitV1", APIs.Git)]
       [DataRow("DistributedTaskV1", APIs.DistributedTask)]
       [DataRow("DistributedTaskReleasedV1", APIs.DistributedTaskReleased)]
+      [DataRow("Pipelines", APIs.Pipelines)]
       [DataRow("VariableGroupsV1", APIs.VariableGroups)]
       [DataRow("TfvcV1", APIs.Tfvc)]
       [DataRow("PackagingV1", APIs.Packaging)]


### PR DESCRIPTION
# PR Summary

Test-VSTeamYamlPipeline needed a preview version to be passed. it used to reuse the Build version value. Now it has its own Pipelines version.

## PR Checklist

- [ ] [Write Help](https://github.com/DarqueWarrior/vsteam/blob/master/.github/CONTRIBUTING.md#write-help)
- [ ] [Write Unit Test](https://github.com/DarqueWarrior/vsteam/blob/master/.github/CONTRIBUTING.md#write-unit-test)
- [x] [Update CHANGELOG.md](https://github.com/DarqueWarrior/vsteam/blob/master/.github/CONTRIBUTING.md#update-changelogmd)
