### PR TITLE
Commands to work with states available for WorkItem types

### DIFF
--- a/.docs/Add-VSTeamWorkItemState.md
+++ b/.docs/Add-VSTeamWorkItemState.md
@@ -24,10 +24,9 @@ Order Name      Category   Color  Customization Hidden
 4     Postponed InProgress 0000ff custom
 ```
 
-This adds a state "postponed", shown in blue, as a custom state to the "Bug" WorkItem type in the "scrum2" process-template in the"in-progress" category. By default "Committed" is at position 3 in the list of states, as an "in-progress" state, and "Done" is at position 4 as a "completed" state, the new state is inserted between them, shifting "Done", and any state(s) below it, down by one position.
+This adds a state "postponed", shown in blue, as a custom state to the "Bug" WorkItem type in the "scrum2" process-template in the "in-progress" category. By default "Committed" is at position 3 in the list of states, as an "in-progress" state, and "Done" is at position 4 as a "completed" state, the new state is inserted between them, shifting "Done", and any state(s) below it, down by one position.
 
 ## PARAMETERS
-
 
 ### -Color
 
@@ -63,7 +62,7 @@ Accept wildcard characters: False
 
 ### -Order
 
-Positions the new state in the selection list. The first position in the list is 1, and if no order is specified the new state will be added at the end of the list.
+Positions the new state in the selection list.  Items must flow in the order, Proposed, In Progress, Resolved, Completed. so it is not possible to create an item in the "Proposed" category with a high number or in the "Completed" category with a low one. The first position in the list is 1, and if no order is specified the new state will be added at the end of its category
 
 ```yaml
 Type: Int32
@@ -79,7 +78,7 @@ Accept wildcard characters: False
 
 ### -StateCategory
 
-Each state fits into one of five categories: Proposed, InProgress, Resolved, Completed, or Removed. If no category is given the new state is considered to be a form of "in progress".
+Each state fits into one of five categories: Proposed, InProgress, Resolved, Completed, or Removed. If no category is given the new state is assumed to be a form of "in progress".
 
 ```yaml
 Type: String

--- a/.docs/Add-VSTeamWorkItemState.md
+++ b/.docs/Add-VSTeamWorkItemState.md
@@ -1,0 +1,142 @@
+<!-- #include "./common/header.md" -->
+
+# Add-VSTeamWorkItemState
+
+## SYNOPSIS
+
+<!-- #include "./synopsis/Add-VSTeamWorkItemState.md" -->
+
+## SYNTAX
+
+## Description
+
+Each WorkItem type in each process template has a set of possible states.  Items may have system-defined states and/or custom (user-defined) states. This command adds custom states. Note that unlike system states, custom ones can only be removed not hidden.
+
+## EXAMPLES
+
+### Example 1
+
+```powershell
+Add-VSTeamWorkItemState -WorkItemType Bug -Color Blue -Name Postponed -ProcessTemplate Scrum2 -Force
+
+Order Name      Category   Color  Customization Hidden
+----- ----      --------   -----  ------------- ------
+4     Postponed InProgress 0000ff custom
+```
+
+This adds a state "postponed", shown in blue, as a custom state to the "Bug" WorkItem type in the "scrum2" process-template in the"in-progress" category. By default "Committed" is at position 3 in the list of states, as an "in-progress" state, and "Done" is at position 4 as a "completed" state, the new state is inserted between them, shifting "Done", and any state(s) below it, down by one position.
+
+## PARAMETERS
+
+
+### -Color
+
+The color for the state either as a name, or as a hex RGB value like "ff0000" for Red. Color names should tab complete.
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Name
+
+Name for the new state.
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: True
+Position: 1
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Order
+
+Positions the new state in the selection list. The first position in the list is 1, and if no order is specified the new state will be added at the end of the list.
+
+```yaml
+Type: Int32
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -ProcessTemplate
+
+Specifies the process template where the WorkItem Type to be modified is found; by default this will be the template for the current project. Note that although some WorkItem types like "bug" or "task" are found in multiple templates, a change to the available states only applies to one template, and the built-in process templates cannot be modified. Values for this parameter should tab-complete.
+
+
+```yaml
+Type: String
+Parameter Sets: Process
+```
+### -StateCategory
+
+Each state fits into one of five categories: Proposed, InProgress, Resolved, Completed, or Removed. If no category is given the new state is considered to be a form of "in progress".
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+Accepted values: Proposed, InProgress, Resolved, Completed, Removed
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -WorkItemType
+
+The name of the WorkItem type whose state list is to be extended. Values for this parameter should tab-complete with types in the current project's process-template; types found only in other templates may need to be entered manually. 
+
+
+```yaml
+Type: String
+Parameter Sets: ByType
+```
+<!-- #include "./params/confirm.md" -->
+
+<!-- #include "./params/Force.md" -->
+
+<!-- #include "./params/whatif.md" -->
+
+## INPUTS
+
+### System.String
+
+## OUTPUTS
+
+### System.Object
+
+## NOTES
+
+<!-- #include "./common/prerequisites.md" -->
+
+## RELATED LINKS
+
+<!-- #include "./common/related.md" -->
+[Get-VsteamWorkItemState](Get-VsteamWorkItemState.md)
+
+[Hide-VsteamWorkItemState](Hide-VsteamWorkItemState.md)
+
+[Show-VsteamWorkItemState](Show-VsteamWorkItemState.md)
+
+[Remove-VsteamWorkItemState](Remove-VsteamWorkItemState.md)

--- a/.docs/Add-VSTeamWorkItemState.md
+++ b/.docs/Add-VSTeamWorkItemState.md
@@ -77,15 +77,6 @@ Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
-### -ProcessTemplate
-
-Specifies the process template where the WorkItem Type to be modified is found; by default this will be the template for the current project. Note that although some WorkItem types like "bug" or "task" are found in multiple templates, a change to the available states only applies to one template, and the built-in process templates cannot be modified. Values for this parameter should tab-complete.
-
-
-```yaml
-Type: String
-Parameter Sets: Process
-```
 ### -StateCategory
 
 Each state fits into one of five categories: Proposed, InProgress, Resolved, Completed, or Removed. If no category is given the new state is considered to be a form of "in progress".
@@ -103,28 +94,16 @@ Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
-### -WorkItemType
+<!-- #include "./params/forcegroup.md" -->
 
-The name of the WorkItem type whose state list is to be extended. Values for this parameter should tab-complete with types in the current project's process-template; types found only in other templates may need to be entered manually.
+<!-- #include "./params/processTemplate.md" -->
 
-
-```yaml
-Type: String
-Parameter Sets: ByType
-```
-<!-- #include "./params/confirm.md" -->
-
-<!-- #include "./params/Force.md" -->
-
-<!-- #include "./params/whatif.md" -->
+<!-- #include "./params/workItemType.md" -->
 
 ## INPUTS
 
-### System.String
-
 ## OUTPUTS
 
-### System.Object
 
 ## NOTES
 

--- a/.docs/Add-VSTeamWorkItemState.md
+++ b/.docs/Add-VSTeamWorkItemState.md
@@ -105,7 +105,7 @@ Accept wildcard characters: False
 
 ### -WorkItemType
 
-The name of the WorkItem type whose state list is to be extended. Values for this parameter should tab-complete with types in the current project's process-template; types found only in other templates may need to be entered manually. 
+The name of the WorkItem type whose state list is to be extended. Values for this parameter should tab-complete with types in the current project's process-template; types found only in other templates may need to be entered manually.
 
 
 ```yaml
@@ -128,11 +128,8 @@ Parameter Sets: ByType
 
 ## NOTES
 
-<!-- #include "./common/prerequisites.md" -->
-
 ## RELATED LINKS
 
-<!-- #include "./common/related.md" -->
 [Get-VsteamWorkItemState](Get-VsteamWorkItemState.md)
 
 [Hide-VsteamWorkItemState](Hide-VsteamWorkItemState.md)

--- a/.docs/Add-VSTeamWorkItemType.md
+++ b/.docs/Add-VSTeamWorkItemType.md
@@ -24,6 +24,10 @@ Modifies the custom process "Scrum5", creating a user-defined work item type "Ch
 
 ## PARAMETERS
 
+<!-- #include "./params/forcegroup.md" -->
+
+<!-- #include "./params/processTemplate.md" -->
+
 ### -Color
 
 Sets the the icon color. The input value can be the name of a color name like "Red" or "Aqua" or a hex value for red, green and blue parts. Color names should tab complete.
@@ -35,22 +39,6 @@ Aliases:
 
 Required: False
 Position: 3
-Default value: None
-Accept pipeline input: False
-Accept wildcard characters: False
-```
-
-### -Confirm
-
-Prompts you for confirmation before running the cmdlet. (By default new types are added without confirmation)
-
-```yaml
-Type: SwitchParameter
-Parameter Sets: (All)
-Aliases: cf
-
-Required: False
-Position: Named
 Default value: None
 Accept pipeline input: False
 Accept wildcard characters: False
@@ -89,42 +77,9 @@ Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
-### -ProcessTemplate
-
-The process template to modify. Note that the built-in templates ("Scrum", "Agile" etc.) cannot be modified, only custom templates (derived from the built-in ones) can be changed.
-
-```yaml
-Type: Object
-Parameter Sets: (All)
-Aliases:
-
-Required: False
-Position: 0
-Default value: None
-Accept pipeline input: False
-Accept wildcard characters: False
-```
-
-### -WhatIf
-
-Shows what would happen if the cmdlet runs.
-The cmdlet is not run.
-
-```yaml
-Type: SwitchParameter
-Parameter Sets: (All)
-Aliases: wi
-
-Required: False
-Position: Named
-Default value: None
-Accept pipeline input: False
-Accept wildcard characters: False
-```
-
 ### -WorkItemType
 
-The name for the new work item type.
+The name for the new work item type. (Alias "Name")
 
 ```yaml
 Type: String
@@ -140,19 +95,12 @@ Accept wildcard characters: False
 
 ## INPUTS
 
-### System.String
-
 ## OUTPUTS
-
-### System.Object
 
 ## NOTES
 
-<!-- #include "./common/prerequisites.md" -->
-
 ## RELATED LINKS
 
-<!-- #include "./common/related.md" -->
 [Get-VSTeamWorkItemType](Get-VSTeamWorkItemType.md)
 
 [Set-VSTeamWorkItemType](Set-VSTeamWorkItemType.md)

--- a/.docs/Add-VSTeamWorkItemType.md
+++ b/.docs/Add-VSTeamWorkItemType.md
@@ -138,10 +138,6 @@ Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
-### CommonParameters
-
-This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](http://go.microsoft.com/fwlink/?LinkID=113216).
-
 ## INPUTS
 
 ### System.String

--- a/.docs/Add-VSTeamWorkItemType.md
+++ b/.docs/Add-VSTeamWorkItemType.md
@@ -10,17 +10,17 @@
 
 ## Description
 
-Adds a new work item type to a custom process. Note that the built-in Process templates (Scrum, Agile etc.) do not allow their work item types to be customized, this is only allowed for custom processes
+Adds a new WorkItem type to a custom process template. Note that the built-in process templates (Scrum, Agile etc.) do not allow their WorkItem types to be customized, this is only allowed for custom processes.
 
 ## EXAMPLES
 
 ### Example 1
 
 ```powershell
-Add-VSTeamWorkItemType  -ProcessTemplate Scrum5 -WorkItemType ChangeRequest  -Description "New Work item Type" -Color Red  -Icon icon_asterisk
+Add-VSTeamWorkItemType  -ProcessTemplate Scrum5 -WorkItemType ChangeRequest  -Description "New WorkItem Type" -Color Red  -Icon icon_asterisk
 ```
 
-Modifies the custom process "Scrum5", creating a user-defined work item type "ChangeRequest" with a red asterisk as its icon and some simple text in the description.
+Modifies the custom process "Scrum5", creating a user-defined WorkItem type "ChangeRequest" with a red asterisk as its icon and some simple text in the description.
 
 ## PARAMETERS
 
@@ -30,7 +30,7 @@ Modifies the custom process "Scrum5", creating a user-defined work item type "Ch
 
 ### -Color
 
-Sets the the icon color. The input value can be the name of a color name like "Red" or "Aqua" or a hex value for red, green and blue parts. Color names should tab complete.
+Sets the icon color. The input value can be the name of a color name like "Red" or "Aqua" or a hex value for red, green and blue parts. Color names should tab complete.
 
 ```yaml
 Type: Object
@@ -46,7 +46,7 @@ Accept wildcard characters: False
 
 ### -Description
 
-Long text description of the the work item type.
+Long text description of the WorkItem type.
 
 ```yaml
 Type: String
@@ -62,7 +62,7 @@ Accept wildcard characters: False
 
 ### -Icon
 
-One of the predefined icons for work item types. Possible values should tab complete and
+One of the predefined icons for WorkItem types. Possible values should tab complete and
 if the name omits the leading "Icon\_" it will be added automatically.
 
 ```yaml
@@ -79,7 +79,7 @@ Accept wildcard characters: False
 
 ### -WorkItemType
 
-The name for the new work item type. (Alias "Name")
+The name for the new WorkItem type. (Alias "Name")
 
 ```yaml
 Type: String

--- a/.docs/Add-VSTeamWorkItemType.md
+++ b/.docs/Add-VSTeamWorkItemType.md
@@ -1,0 +1,164 @@
+<!-- #include "./common/header.md" -->
+
+# Add-VSTeamWorkItemType
+
+## SYNOPSIS
+
+<!-- #include "./synopsis/Add-VSTeamWorkItemType.md" -->
+
+## SYNTAX
+
+## Description
+
+Adds a new work item type to a custom process. Note that the built-in Process templates (Scrum, Agile etc.) do not allow their work item types to be customized, this is only allowed for custom processes
+
+## EXAMPLES
+
+### Example 1
+
+```powershell
+Add-VSTeamWorkItemType  -ProcessTemplate Scrum5 -WorkItemType ChangeRequest  -Description "New Work item Type" -Color Red  -Icon icon_asterisk
+```
+
+Modifies the custom process "Scrum5", creating a user-defined work item type "ChangeRequest" with a red asterisk as its icon and some simple text in the description.
+
+## PARAMETERS
+
+### -Color
+
+Sets the the icon color. The input value can be the name of a color name like "Red" or "Aqua" or a hex value for red, green and blue parts. Color names should tab complete.
+
+```yaml
+Type: Object
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: 3
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Confirm
+
+Prompts you for confirmation before running the cmdlet. (By default new types are added without confirmation)
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: (All)
+Aliases: cf
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Description
+
+Long text description of the the work item type.
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: 2
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Icon
+
+One of the predefined icons for work item types. Possible values should tab complete and
+if the name omits the leading "Icon\_" it will be added automatically.
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: 4
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -ProcessTemplate
+
+The process template to modify. Note that the built-in templates ("Scrum", "Agile" etc.) cannot be modified, only custom templates (derived from the built-in ones) can be changed.
+
+```yaml
+Type: Object
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: 0
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -WhatIf
+
+Shows what would happen if the cmdlet runs.
+The cmdlet is not run.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: (All)
+Aliases: wi
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -WorkItemType
+
+The name for the new work item type.
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases: Name
+
+Required: True
+Position: 1
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### CommonParameters
+
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](http://go.microsoft.com/fwlink/?LinkID=113216).
+
+## INPUTS
+
+### System.String
+
+## OUTPUTS
+
+### System.Object
+
+## NOTES
+
+<!-- #include "./common/prerequisites.md" -->
+
+## RELATED LINKS
+
+<!-- #include "./common/related.md" -->
+[Get-VSTeamWorkItemType](Get-VSTeamWorkItemType.md)
+
+[Set-VSTeamWorkItemType](Set-VSTeamWorkItemType.md)
+
+[Remove-VSTeamWorkItemType](Remove-VSTeamWorkItemType.md)

--- a/.docs/Get-VSTeamProcess.md
+++ b/.docs/Get-VSTeamProcess.md
@@ -42,6 +42,20 @@ This will return an process templates with names containing scrum,
 in other words, the default "Scrum" template and custom ones with
 names like "Custom Scrum", "Scrum for Contoso" will all be returned.
 
+### Example 4
+
+```powershell
+Get-VSTeamProcess  -ExpandProjects | where Projects -Contains "MyProject"
+
+Name  Enabled Default Description
+----  ------- ------- -----------
+Scrum True    False   This template is for teams who follow the Scrum framework.
+```
+
+This gets the projects associated with each process template,
+and filters the list down to the one which contains a particular project,
+the "Scrum" template in this example.
+
 ## PARAMETERS
 
 <!-- #include "./params/ProcessName.md" -->
@@ -55,6 +69,19 @@ Type: String
 Parameter Sets: ByID
 Aliases: ProcessID
 ```
+
+### ExpandProjects
+
+Gets the projects associated with the process, and sets the the .Projects property of the Process item to be a list of project-names.
+
+```yaml
+Type: SwitchParameter
+Required: false
+Position: Named
+Accept pipeline input: false
+Parameter Sets: (All)
+```
+
 
 ## INPUTS
 

--- a/.docs/Get-VSTeamProcess.md
+++ b/.docs/Get-VSTeamProcess.md
@@ -38,7 +38,7 @@ This will return the Process Templates only showing their name
 Get-VSTeamProcess *scrum*
 ```
 
-This will return an process templates with names containing scrum,
+This will return all process templates with names containing "scrum",
 in other words, the default "Scrum" template and custom ones with
 names like "Custom Scrum", "Scrum for Contoso" will all be returned.
 
@@ -52,9 +52,8 @@ Name  Enabled Default Description
 Scrum True    False   This template is for teams who follow the Scrum framework.
 ```
 
-This gets the projects associated with each process template,
-and filters the list down to the one which contains a particular project,
-the "Scrum" template in this example.
+This gets the processes with their associated projects and filters the list
+to the one which contains a particular project, the "Scrum" template in this example.
 
 ## PARAMETERS
 
@@ -72,7 +71,7 @@ Aliases: ProcessID
 
 ### ExpandProjects
 
-Gets the projects associated with the process, and sets the the .Projects property of the Process item to be a list of project-names.
+Gets the projects associated with the process, and sets the .Projects property of the Process item to be a list of project-names.
 
 ```yaml
 Type: SwitchParameter
@@ -81,7 +80,6 @@ Position: Named
 Accept pipeline input: false
 Parameter Sets: (All)
 ```
-
 
 ## INPUTS
 

--- a/.docs/Get-VSTeamWorkItemIconList.md
+++ b/.docs/Get-VSTeamWorkItemIconList.md
@@ -1,0 +1,28 @@
+<!-- #include "./common/header.md" -->
+
+# Get-VSTeamWorkItemIconList
+
+## SYNOPSIS
+<!-- #include "./synopsis/Get-VSTeamWorkItemIconList.md" -->
+
+## SYNTAX
+
+## DESCRIPTION
+
+<!-- #include "./synopsis/Get-VSTeamWorkItemIconList.md" -->
+
+## PARAMETERS
+
+### CommonParameters
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](http://go.microsoft.com/fwlink/?LinkID=113216).
+
+## INPUTS
+
+### None
+
+## OUTPUTS
+
+### System.Object
+## NOTES
+
+## RELATED LINKS

--- a/.docs/Get-VSTeamWorkItemIconList.md
+++ b/.docs/Get-VSTeamWorkItemIconList.md
@@ -13,8 +13,6 @@
 
 ## PARAMETERS
 
-### CommonParameters
-This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](http://go.microsoft.com/fwlink/?LinkID=113216).
 
 ## INPUTS
 

--- a/.docs/Get-VSTeamWorkItemState.md
+++ b/.docs/Get-VSTeamWorkItemState.md
@@ -10,8 +10,7 @@
 
 ## Description
 
-Each WorkItem type in each process template has a set of possible states, each belongs to a category which represents a stage in the item's lifecycle (Proposed, In-Progress, Completed, Resolved, Removed) and each has a color. Items may have system-defined states and/or custom (user-defined) states. Get-VSTeamWorkItemState lists the available states.
-
+Each WorkItem type in each process template has a set of possible states, each of which belongs to a category which represents a stage in the item's lifecycle (Proposed, In-Progress, Completed, Resolved, Removed) and each has a color. Items may have system-defined states and/or custom (user-defined) states. Get-VSTeamWorkItemState lists the available states.
 
 ## EXAMPLES
 
@@ -29,7 +28,7 @@ Order Name      Category   Color  Customization Hidden
 5     Removed   Removed    ffffff system
 ```
 
-This lists the states for the built in WorkItem type "bug" in the current project.
+This lists the states for the built in WorkItem type "Bug" in the current project.
 Notice that the states all have a customization of system; these states can be hidden but not removed.
 
 ### Example 2
@@ -63,7 +62,7 @@ Scrum           Bug              2 Approved  b2b2b2
 ...
 ```
 
-This pipeline gets all the process-templates in the first command; in the second it gets the "bug" WorkItem type in each one, and in the third it gets the states available for all the different versions of bug. It sorts the results to group the srates together - and finally formats the results as a table.
+This pipeline gets all the process-templates in the first command; in the second it gets the "Bug" WorkItem type in each one, and in the third it gets the states available for all the different versions of Bug. It sorts the results to group the states together - and finally formats the results as a table. (Only the first few rows are shown to save space.)
 This shows that in the default "Agile" and "CMMI" templates bugs have a state of "Active" but do not have "Approved", but the reverse is true in the "Scrum" template.
 
 
@@ -71,7 +70,7 @@ This shows that in the default "Agile" and "CMMI" templates bugs have a state of
 
 ### -ProcessTemplate
 
-The Process holding the WorkItem types of interest.
+The process holding the WorkItem types of interest.
 
 ```yaml
 Type: String

--- a/.docs/Get-VSTeamWorkItemState.md
+++ b/.docs/Get-VSTeamWorkItemState.md
@@ -1,0 +1,111 @@
+<!-- #include "./common/header.md" -->
+
+# Get-VsteamWorkItemState
+
+## SYNOPSIS
+
+<!-- #include "./synopsis/Get-VsteamWorkItemState.md" -->
+
+## SYNTAX
+
+## Description
+
+Each WorkItem type in each process template has a set of possible states, each belongs to a category which represents a stage in the item's lifecycle (Proposed, In-Progress, Completed, Resolved, Removed) and each has a color. Items may have system-defined states and/or custom (user-defined) states. Get-VsteamWorkItemState lists the available states.
+
+
+## EXAMPLES
+
+### Example 1
+
+```powershell
+Get-VsteamWorkItemState  -WorkItemType Bug
+
+Order Name      Category   Color  Customization Hidden
+----- ----      --------   -----  ------------- ------
+1     New       Proposed   b2b2b2 system
+2     Approved  Proposed   b2b2b2 system
+3     Committed InProgress 007acc system
+4     Done      Completed  339933 system
+5     Removed   Removed    ffffff system
+```
+
+This lists the states for the built in WorkItem type "bug" in the current project.
+Notice that the states all have a customization of system; these states can be hidden but not removed.
+
+### Example 2
+
+```powershell
+Get-VsteamWorkItemState -ProcessTemplate Scrum4 -WorkItemType 'Update'
+
+
+Order Name      Category   Color  Customization Hidden
+----- ----      --------   -----  ------------- ------
+1     New       Proposed   b2b2b2 custom
+2     Committed InProgress 007acc custom
+3     Done      Completed  339933 custom
+4     Failed    Removed    ff0000 custom
+```
+
+This lists the states for the custom WorkItem type "update" in the custom process "Scrum4".
+Notice that the states all have a customization of custom; these states can be removed but not hidden.
+
+### Example 3
+
+```powershell
+Get-VSTeamProcess | Get-VSTeamWorkItemType -WorkItemType bug | Get-VsteamWorkItemState | Sort-object name,processtemplate|  Format-table ProcessTemplate,WorkItemType,Order,name,Color -AutoSize
+
+
+ProcessTemplate WorkItemType order name      color
+--------------- ------------ ----- ----      -----
+Agile           Bug              2 Active    007acc
+CMMI            Bug              2 Active    007acc
+Scrum           Bug              2 Approved  b2b2b2
+...
+```
+
+This pipeline gets all the process-templates in the first command; in the second it gets the "bug" WorkItem type in each one, and in the third it gets the states available for all the different versions of bug. It sorts the results to group the srates together - and finally formats the results as a table.
+This shows that in the default "Agile" and "CMMI" templates bugs have a state of "Active" but do not have "Approved", but the reverse is true in the "Scrum" template.
+
+
+## PARAMETERS
+
+### -ProcessTemplate
+
+The Process holding the WorkItem types of interest.
+
+```yaml
+Type: String
+Parameter Sets: Process
+```
+
+### WorkItemType
+
+The type of work item to retrieve.
+
+```yaml
+Type: String
+Parameter Sets: ByType
+```
+
+## INPUTS
+
+### System.String
+
+## OUTPUTS
+
+### System.Object
+
+## NOTES
+
+<!-- #include "./common/prerequisites.md" -->
+
+## RELATED LINKS
+
+<!-- #include "./common/related.md" -->
+[Add-VsteamWorkItemState](Add-VsteamWorkItemState.md)
+
+[Hide-VsteamWorkItemState](Hide-VsteamWorkItemState.md)
+
+[Show-VsteamWorkItemState](Show-VsteamWorkItemState.md)
+
+[Remove-VsteamWorkItemState](Remove-VsteamWorkItemState.md)

--- a/.docs/Get-VSTeamWorkItemState.md
+++ b/.docs/Get-VSTeamWorkItemState.md
@@ -80,7 +80,7 @@ Parameter Sets: Process
 
 ### WorkItemType
 
-The type of work item to retrieve.
+The WorkItem type whose states should be retrieved.
 
 ```yaml
 Type: String
@@ -89,11 +89,7 @@ Parameter Sets: ByType
 
 ## INPUTS
 
-### System.String
-
 ## OUTPUTS
-
-### System.Object
 
 ## NOTES
 

--- a/.docs/Get-VSTeamWorkItemState.md
+++ b/.docs/Get-VSTeamWorkItemState.md
@@ -1,16 +1,16 @@
 <!-- #include "./common/header.md" -->
 
-# Get-VsteamWorkItemState
+# Get-VSTeamWorkItemState
 
 ## SYNOPSIS
 
-<!-- #include "./synopsis/Get-VsteamWorkItemState.md" -->
+<!-- #include "./synopsis/Get-VSTeamWorkItemState.md" -->
 
 ## SYNTAX
 
 ## Description
 
-Each WorkItem type in each process template has a set of possible states, each belongs to a category which represents a stage in the item's lifecycle (Proposed, In-Progress, Completed, Resolved, Removed) and each has a color. Items may have system-defined states and/or custom (user-defined) states. Get-VsteamWorkItemState lists the available states.
+Each WorkItem type in each process template has a set of possible states, each belongs to a category which represents a stage in the item's lifecycle (Proposed, In-Progress, Completed, Resolved, Removed) and each has a color. Items may have system-defined states and/or custom (user-defined) states. Get-VSTeamWorkItemState lists the available states.
 
 
 ## EXAMPLES
@@ -18,7 +18,7 @@ Each WorkItem type in each process template has a set of possible states, each b
 ### Example 1
 
 ```powershell
-Get-VsteamWorkItemState  -WorkItemType Bug
+Get-VSTeamWorkItemState  -WorkItemType Bug
 
 Order Name      Category   Color  Customization Hidden
 ----- ----      --------   -----  ------------- ------
@@ -35,7 +35,7 @@ Notice that the states all have a customization of system; these states can be h
 ### Example 2
 
 ```powershell
-Get-VsteamWorkItemState -ProcessTemplate Scrum4 -WorkItemType 'Update'
+Get-VSTeamWorkItemState -ProcessTemplate Scrum4 -WorkItemType 'Update'
 
 
 Order Name      Category   Color  Customization Hidden
@@ -52,7 +52,7 @@ Notice that the states all have a customization of custom; these states can be r
 ### Example 3
 
 ```powershell
-Get-VSTeamProcess | Get-VSTeamWorkItemType -WorkItemType bug | Get-VsteamWorkItemState | Sort-object name,processtemplate|  Format-table ProcessTemplate,WorkItemType,Order,name,Color -AutoSize
+Get-VSTeamProcess | Get-VSTeamWorkItemType -WorkItemType bug | Get-VSTeamWorkItemState | Sort-object name,processtemplate|  Format-table ProcessTemplate,WorkItemType,Order,name,Color -AutoSize
 
 
 ProcessTemplate WorkItemType order name      color
@@ -97,15 +97,14 @@ Parameter Sets: ByType
 
 ## NOTES
 
-<!-- #include "./common/prerequisites.md" -->
-
 ## RELATED LINKS
 
-<!-- #include "./common/related.md" -->
-[Add-VsteamWorkItemState](Add-VsteamWorkItemState.md)
+[Get-VSTeamWorkItemType](Get-VSTeamWorkItemType.md)
 
-[Hide-VsteamWorkItemState](Hide-VsteamWorkItemState.md)
+[Add-VSTeamWorkItemState](Add-VSTeamWorkItemState.md)
 
-[Show-VsteamWorkItemState](Show-VsteamWorkItemState.md)
+[Hide-VSTeamWorkItemState](Hide-VSTeamWorkItemState.md)
 
-[Remove-VsteamWorkItemState](Remove-VsteamWorkItemState.md)
+[Show-VSTeamWorkItemState](Show-VSTeamWorkItemState.md)
+
+[Remove-VSTeamWorkItemState](Remove-VSTeamWorkItemState.md)

--- a/.docs/Get-VSTeamWorkItemType.md
+++ b/.docs/Get-VSTeamWorkItemType.md
@@ -20,9 +20,46 @@
 Get-VSTeamWorkItemType -ProjectName test -WorkItemType 'Code Review Response'
 ```
 
-This command gets a single work item type.
+This command gets a single work item type from the named project.
+
+### Example 2
+
+```powershell
+Get-VSTeamWorkItemType -ProcessTemplate Basic
+```
+
+This command gets a list of the WorkItems available to projects which use the 'Basic' Template
+
+### Example 3
+
+```powershell
+Get-VSTeamProcess scr* | Get-VSTeamWorkItemType -WorkItemType pro* | Format-Table name,processTemplate
+
+name                 ProcessTemplate
+----                 ---------------
+Product Backlog Item Scrum
+Product Backlog Item Scrum2
+Product Backlog Item Scrum4
+```
+
+The first command in the pipeline gets the process templates with names which match SCR*, in this example 
+these are "Scrum", "Scrum2" and "Scrum4". The command second finds WorkItem-Types in those processes 
+which match "pro*", (each process has a "Product Backlog item" work item type) and the third command 
+shows a table of Type-name and the process-template which has that type.
+
 
 ## PARAMETERS
+
+<!-- #include "./params/projectName.md" -->
+
+### -ProcessTemplate
+
+The Process holding the WorkItems of interest.
+
+```yaml
+Type: String
+Parameter Sets: Process
+```
 
 ### WorkItemType
 
@@ -32,8 +69,6 @@ The type of work item to retrieve.
 Type: String
 Parameter Sets: ByType
 ```
-
-<!-- #include "./params/projectName.md" -->
 
 ## INPUTS
 
@@ -54,3 +89,8 @@ This causes issues with the ConvertFrom-Json CmdLet.  Therefore, all "": are rep
 ## RELATED LINKS
 
 <!-- #include "./common/related.md" -->
+[Add-VSTeamWorkItemType](Get-VSTeamWorkItemType.md)
+
+[Set-VSTeamWorkItemType](Set-VSTeamWorkItemType.md)
+
+[Remove-VSTeamWorkItemType](Remove-VSTeamWorkItemType.md)

--- a/.docs/Get-VSTeamWorkItemType.md
+++ b/.docs/Get-VSTeamWorkItemType.md
@@ -28,7 +28,7 @@ This command gets a single WorkItem type from the named project.
 Get-VSTeamWorkItemType -ProcessTemplate Basic
 ```
 
-This command gets a list of the WorkItems available to projects which use the 'Basic' Template
+This command gets a list of the WorkItems available to projects which use the 'Basic' Template.
 
 ### Example 3
 
@@ -42,9 +42,9 @@ Product Backlog Item Scrum2
 Product Backlog Item Scrum4
 ```
 
-The first command in the pipeline gets the process templates with names which match SCR*, in this example 
-these are "Scrum", "Scrum2" and "Scrum4". The command second finds WorkItem-Types in those processes 
-which match "pro*", (each process has a "Product Backlog item" WorkItem type) and the third command 
+The first command in the pipeline gets the process templates with names which match SCR*, in this example
+these are "Scrum", "Scrum2" and "Scrum4". The second command  finds WorkItem-Types in those processes
+which match "pro*", (each process has a "Product Backlog item" WorkItem type) and the third command
 shows a table of Type-name and the process-template which has that type.
 
 
@@ -52,7 +52,7 @@ shows a table of Type-name and the process-template which has that type.
 
 ### -Expand
 
-If specified the WorkItems returned will have behavior and/or layout and/or state information attached.
+If specified, the WorkItem type information returned will have behavior, layout and/or state information attached, depending on the value of the parameter.
 
 ```yaml
 Type: String[]
@@ -60,7 +60,7 @@ Parameter Sets: Process
 Accepted values: 'behaviors','layout','states'
 ```
 
-### --NotHidden
+### -NotHidden
 
 Excludes WorkItem Types which are marked as hidden.
 
@@ -76,7 +76,7 @@ Parameter Sets: (All)
 
 ### -ProcessTemplate
 
-The Process holding the WorkItem types of interest. 
+The Process template holding the WorkItem type(s) of interest.
 Note that if ProcessTemplate is specified it is still possible to provide a ProjectName parameter, but it will be ignored.
 
 ```yaml
@@ -85,8 +85,7 @@ Parameter Sets: Process
 ```
 
 ### WorkItemType
-
-The type of WorkItem type whose details should be retrieved (wild cards are supported).
+The WorkItem type whose details should be retrieved (wild cards are supported).
 
 ```yaml
 Type: String
@@ -112,7 +111,7 @@ This causes issues with the ConvertFrom-Json CmdLet.  Therefore, all "": are rep
 ## RELATED LINKS
 
 <!-- #include "./common/related.md" -->
-[Add-VSTeamWorkItemType](Get-VSTeamWorkItemType.md)
+[Add-VSTeamWorkItemType](Add-VSTeamWorkItemType.md)
 
 [Set-VSTeamWorkItemType](Set-VSTeamWorkItemType.md)
 

--- a/.docs/Get-VSTeamWorkItemType.md
+++ b/.docs/Get-VSTeamWorkItemType.md
@@ -106,11 +106,9 @@ The JSON returned has empty named items i.e.
 "": "To Do"
 This causes issues with the ConvertFrom-Json CmdLet.  Therefore, all "": are replaced with "_end":
 
-<!-- #include "./common/prerequisites.md" -->
 
 ## RELATED LINKS
 
-<!-- #include "./common/related.md" -->
 [Add-VSTeamWorkItemType](Add-VSTeamWorkItemType.md)
 
 [Set-VSTeamWorkItemType](Set-VSTeamWorkItemType.md)

--- a/.docs/Get-VSTeamWorkItemType.md
+++ b/.docs/Get-VSTeamWorkItemType.md
@@ -28,7 +28,7 @@ This command gets a single WorkItem type from the named project.
 Get-VSTeamWorkItemType -ProcessTemplate Basic
 ```
 
-This command gets a list of the WorkItems available to projects which use the 'Basic' Template.
+This command gets a list of the WorkItem types available to projects which use the 'Basic' Template.
 
 ### Example 3
 
@@ -43,9 +43,9 @@ Product Backlog Item Scrum4
 ```
 
 The first command in the pipeline gets the process templates with names which match SCR*, in this example
-these are "Scrum", "Scrum2" and "Scrum4". The second command  finds WorkItem-Types in those processes
+these are "Scrum", "Scrum2" and "Scrum4". The second command finds WorkItem types in those processes
 which match "pro*", (each process has a "Product Backlog item" WorkItem type) and the third command
-shows a table of Type-name and the process-template which has that type.
+shows a table of type-name and the process-template which has that type.
 
 
 ## PARAMETERS

--- a/.docs/Get-VSTeamWorkItemType.md
+++ b/.docs/Get-VSTeamWorkItemType.md
@@ -54,7 +54,7 @@ shows a table of Type-name and the process-template which has that type.
 
 ### -ProcessTemplate
 
-The Process holding the WorkItems of interest.
+The Process holding the WorkItem types of interest.
 
 ```yaml
 Type: String

--- a/.docs/Get-VSTeamWorkItemType.md
+++ b/.docs/Get-VSTeamWorkItemType.md
@@ -20,7 +20,7 @@
 Get-VSTeamWorkItemType -ProjectName test -WorkItemType 'Code Review Response'
 ```
 
-This command gets a single work item type from the named project.
+This command gets a single WorkItem type from the named project.
 
 ### Example 2
 
@@ -44,17 +44,40 @@ Product Backlog Item Scrum4
 
 The first command in the pipeline gets the process templates with names which match SCR*, in this example 
 these are "Scrum", "Scrum2" and "Scrum4". The command second finds WorkItem-Types in those processes 
-which match "pro*", (each process has a "Product Backlog item" work item type) and the third command 
+which match "pro*", (each process has a "Product Backlog item" WorkItem type) and the third command 
 shows a table of Type-name and the process-template which has that type.
 
 
 ## PARAMETERS
 
+### -Expand
+
+If specified the WorkItems returned will have behavior and/or layout and/or state information attached.
+
+```yaml
+Type: String[]
+Parameter Sets: Process
+Accepted values: 'behaviors','layout','states'
+```
+
+### --NotHidden
+
+Excludes WorkItem Types which are marked as hidden.
+
+```yaml
+Type: SwitchParameter
+Required: false
+Position: Named
+Accept pipeline input: false
+Parameter Sets: (All)
+```
+
 <!-- #include "./params/projectName.md" -->
 
 ### -ProcessTemplate
 
-The Process holding the WorkItems of interest.
+The Process holding the WorkItem types of interest. 
+Note that if ProcessTemplate is specified it is still possible to provide a ProjectName parameter, but it will be ignored.
 
 ```yaml
 Type: String
@@ -63,7 +86,7 @@ Parameter Sets: Process
 
 ### WorkItemType
 
-The type of work item to retrieve.
+The type of WorkItem type whose details should be retrieved (wild cards are supported).
 
 ```yaml
 Type: String

--- a/.docs/Hide-VSTeamWorkItemState.md
+++ b/.docs/Hide-VSTeamWorkItemState.md
@@ -74,18 +74,14 @@ Parameter Sets: Process
 
 ### -WorkItemType
 
-The name of the WorkItem type whose state list is to be modified. Values for this parameter should tab-complete with types in the current project's process-template; types found only in other templates may need to be entered manually. 
+The name of the WorkItem type whose state list is to be modified. Values for this parameter should tab-complete with types in the current project's process-template; types found only in other templates may need to be entered manually.
 
 
 ```yaml
 Type: String
 Parameter Sets: ByType
 ```
-<!-- #include "./params/confirm.md" -->
-
-<!-- #include "./params/Force.md" -->
-
-<!-- #include "./params/whatif.md" -->
+<!-- #include "./params/forcegroup.md" -->
 
 ## INPUTS
 
@@ -97,15 +93,12 @@ Parameter Sets: ByType
 
 ## NOTES
 
-<!-- #include "./common/prerequisites.md" -->
-
 ## RELATED LINKS
 
-<!-- #include "./common/related.md" -->
-[Add-VsteamWorkItemState](Add-VsteamWorkItemState.md)
+[Add-VSTeamWorkItemState](Add-VSTeamWorkItemState.md)
 
-[Get-VsteamWorkItemState](Get-VsteamWorkItemState.md)
+[Get-VSTeamWorkItemState](Get-VSTeamWorkItemState.md)
 
-[Show-VsteamWorkItemState](Show-VsteamWorkItemState.md)
+[Show-VSTeamWorkItemState](Show-VSTeamWorkItemState.md)
 
-[Remove-VsteamWorkItemState](Remove-VsteamWorkItemState.md)
+[Remove-VSTeamWorkItemState](Remove-VSTeamWorkItemState.md)

--- a/.docs/Hide-VSTeamWorkItemState.md
+++ b/.docs/Hide-VSTeamWorkItemState.md
@@ -10,7 +10,7 @@
 
 ## Description
 
-Each WorkItem type in each process template has a set of possible states.  Items may have system-defined states and/or custom (user-defined) states. System states cannot be removed, but this command can hide them. Note that although some WorkItem types like "Bug" or "Ttask" are found in multiple templates, a change to the available states only applies to one template, and only custom templates can be modified, the built-in ones cannot.
+Each WorkItem type in each process template has a set of possible states.  Items may have system-defined states and/or custom (user-defined) states. System states cannot be removed, but this command can hide them. Note that although some WorkItem types like "Bug" or "Task" are found in multiple templates, a change to the available states only applies to one template, and only custom templates can be modified, the built-in ones cannot.
 
 ## EXAMPLES
 
@@ -27,7 +27,7 @@ WARNING: An error occurred: Response status code does not indicate success: 403 
 WARNING: VS402356: You do not have the permissions required to perform the attempted operation on this process.
 ```
 
-In this example the user has tried to hide the state "Approved" for bugs in the current project's template. -Force has not been specified and the confirmation prompt says that the process template to be modified is "Scrum". This is a built-in template, therefore WorkItem types and their states are read-only. The user continues and an error occurs (the full error is not shown) because changing the system process is forbidden.
+In this example the user has tried to hide the state "Approved" for Bugs in the current project's template. -Force has not been specified and the confirmation prompt says that the process template to be modified is "Scrum". This is a built-in template, therefore WorkItem types and their states are read-only. The user continues and an error occurs (the full error is not shown) because changing the system process is forbidden.
 
 ### Example 2
 
@@ -39,7 +39,7 @@ Order Name     Category Color  Customization Hidden
 6     Approved Proposed b2b2b2 inherited     True
 ```
 
-This version hides the state "Approved" for bugs in the custom template named "Scrum2". -Force has specified to skip the confirmation, and the command returns the modified state. Notice that the customization column changes from "system" to "inherited" when a state is hidden.
+This version hides the state "Approved" for Bugs in the custom template named "Scrum2". -Force has specified to skip the confirmation, and the command returns the modified state. Notice that the customization column changes from "system" to "inherited" when a state is hidden.
 
 If the state is already hidden a warning message will appear and the state will not be changed.
 

--- a/.docs/Hide-VSTeamWorkItemState.md
+++ b/.docs/Hide-VSTeamWorkItemState.md
@@ -10,7 +10,7 @@
 
 ## Description
 
-Each WorkItem type in each process template has a set of possible states.  Items may have system-defined states and/or custom (user-defined) states. System states cannot be removed, but this command can hide them.
+Each WorkItem type in each process template has a set of possible states.  Items may have system-defined states and/or custom (user-defined) states. System states cannot be removed, but this command can hide them. Note that although some WorkItem types like "Bug" or "Ttask" are found in multiple templates, a change to the available states only applies to one template, and only custom templates can be modified, the built-in ones cannot.
 
 ## EXAMPLES
 
@@ -61,35 +61,15 @@ Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
-### -ProcessTemplate
+<!-- #include "./params/processTemplate.md" -->
 
-Specifies the process template where the WorkItem Type to be modified is found; by default this will be the template for the current project. Note that although some WorkItem types like "bug" or "task" are found in multiple templates, a change to the available states only applies to one template, and the built-in process templates cannot be modified. Values for this parameter should tab-complete.
+<!-- #include "./params/workItemType.md" -->
 
-
-```yaml
-Type: String
-Parameter Sets: Process
-```
-
-
-### -WorkItemType
-
-The name of the WorkItem type whose state list is to be modified. Values for this parameter should tab-complete with types in the current project's process-template; types found only in other templates may need to be entered manually.
-
-
-```yaml
-Type: String
-Parameter Sets: ByType
-```
 <!-- #include "./params/forcegroup.md" -->
 
 ## INPUTS
 
-### System.String
-
 ## OUTPUTS
-
-### System.Object
 
 ## NOTES
 

--- a/.docs/Hide-VSTeamWorkItemState.md
+++ b/.docs/Hide-VSTeamWorkItemState.md
@@ -1,0 +1,111 @@
+<!-- #include "./common/header.md" -->
+
+# Hide-VSTeamWorkItemState
+
+## SYNOPSIS
+
+<!-- #include "./synopsis/Hide-VSTeamWorkItemState.md" -->
+
+## SYNTAX
+
+## Description
+
+Each WorkItem type in each process template has a set of possible states.  Items may have system-defined states and/or custom (user-defined) states. System states cannot be removed, but this command can hide them.
+
+## EXAMPLES
+
+### Example 1
+
+```PowerShell
+Hide-VSTeamWorkItemState -WorkItemType Bug -Name Approved
+
+Confirm
+Are you sure you want to perform this action?
+Performing the operation "Modify WorkItem type 'Bug' in process template 'Scrum'; hide state" on target "Approved".
+[Y] Yes [A] Yes to All [N] No [L] No to All [S] Suspend [?] Help (default is "Yes"): y
+WARNING: An error occurred: Response status code does not indicate success: 403 (Forbidden).
+WARNING: VS402356: You do not have the permissions required to perform the attempted operation on this process.
+```
+
+In this example the user has tried to hide the state "Approved" for bugs in the current project's template. -Force has not been specified and the confirmation prompt says that the process template to be modified is "Scrum". This is a built-in template, therefore WorkItem types and their states are read-only. The user continues and an error occurs (the full error is not shown) because changing the system process is forbidden.
+
+### Example 2
+
+```PowerShell
+Hide-VSTeamWorkItemState -WorkItemType Bug -Name Approved -ProcessTemplate Scrum2 -Force
+
+Order Name     Category Color  Customization Hidden
+----- ----     -------- -----  ------------- ------
+6     Approved Proposed b2b2b2 inherited     True
+```
+
+This version hides the state "Approved" for bugs in the custom template named "Scrum2". -Force has specified to skip the confirmation, and the command returns the modified state. Notice that the customization column changes from "system" to "inherited" when a state is hidden.
+
+If the state is already hidden a warning message will appear and the state will not be changed.
+
+## PARAMETERS
+
+### -Name
+
+The name of the state to be hidden.
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: True
+Position: 1
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -ProcessTemplate
+
+Specifies the process template where the WorkItem Type to be modified is found; by default this will be the template for the current project. Note that although some WorkItem types like "bug" or "task" are found in multiple templates, a change to the available states only applies to one template, and the built-in process templates cannot be modified. Values for this parameter should tab-complete.
+
+
+```yaml
+Type: String
+Parameter Sets: Process
+```
+
+
+### -WorkItemType
+
+The name of the WorkItem type whose state list is to be modified. Values for this parameter should tab-complete with types in the current project's process-template; types found only in other templates may need to be entered manually. 
+
+
+```yaml
+Type: String
+Parameter Sets: ByType
+```
+<!-- #include "./params/confirm.md" -->
+
+<!-- #include "./params/Force.md" -->
+
+<!-- #include "./params/whatif.md" -->
+
+## INPUTS
+
+### System.String
+
+## OUTPUTS
+
+### System.Object
+
+## NOTES
+
+<!-- #include "./common/prerequisites.md" -->
+
+## RELATED LINKS
+
+<!-- #include "./common/related.md" -->
+[Add-VsteamWorkItemState](Add-VsteamWorkItemState.md)
+
+[Get-VsteamWorkItemState](Get-VsteamWorkItemState.md)
+
+[Show-VsteamWorkItemState](Show-VsteamWorkItemState.md)
+
+[Remove-VsteamWorkItemState](Remove-VsteamWorkItemState.md)

--- a/.docs/Remove-VSTeamWorkItemType.md
+++ b/.docs/Remove-VSTeamWorkItemType.md
@@ -10,9 +10,9 @@
 
 ## Description
 
-Removes a custom work item type, or reverts an inherited work item type back to the built-in Type.
+Removes a custom WorkItem type or reverts an inherited WorkItem type back to the built-in Type.
 
-If the type is a system type (as all work item types in built-in Process templates are) then an error will be thrown.
+If the type is a system type (as all WorkItem types in built-in Process templates are) then an error will be thrown.
 
 ## EXAMPLES
 
@@ -22,16 +22,8 @@ If the type is a system type (as all work item types in built-in Process templat
 Remove-VSTeamWorkItemType -ProcessTemplate Scrum5 -WorkItemType ChangeRequest
 ```
 
-Remove-VSTeamWorkItemType -ProcessTemplate Scrum5 -WorkItemType ChangeRequest.
+Removes the custom WorkItem type named "ChangeRequest" from the custom process template named "Scrum5"
 
-### Example 2
-
-```powershell
-Set-VSTeamWorkItemType -ProcessTemplate Scrum5 -WorkItemType ChangeRequest -Icon icon_parachute -color Blue -Description "For requests from customers"
-```
-
-Modifies the custom process "Scrum5", changing a user-defined work item type "ChangeRequest" to use
-a blue parachute icon and update its description..
 ## PARAMETERS
 
 ### -Confirm
@@ -58,7 +50,7 @@ Accept wildcard characters: False
 
 ### -WorkItemType
 
-The name of the work item type to be removed or reverted. If the WorkItem type is a system type (for example if had been changed but has already been reverted), then an error will be thrown.
+The name of the WorkItem type to be removed or reverted. If the WorkItem type is a system type (for example if had been changed but has already been reverted), then an error will be thrown.
 
 The built-in system types cannot be deleted, but can be disabled with Set-VSTeamWorkItemType.
 

--- a/.docs/Remove-VSTeamWorkItemType.md
+++ b/.docs/Remove-VSTeamWorkItemType.md
@@ -10,7 +10,7 @@
 
 ## Description
 
-Removes a custom work item type, or reverts an inherited work item type back to the built-in Type. 
+Removes a custom work item type, or reverts an inherited work item type back to the built-in Type.
 
 If the type is a system type (as all work item types in built-in Process templates are) then an error will be thrown.
 
@@ -103,10 +103,6 @@ Default value: None
 Accept pipeline input: False
 Accept wildcard characters: False
 ```
-
-### CommonParameters
-
-This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](http://go.microsoft.com/fwlink/?LinkID=113216).
 
 ## INPUTS
 

--- a/.docs/Remove-VSTeamWorkItemType.md
+++ b/.docs/Remove-VSTeamWorkItemType.md
@@ -34,7 +34,6 @@ Modifies the custom process "Scrum5", changing a user-defined work item type "Ch
 a blue parachute icon and update its description..
 ## PARAMETERS
 
-
 ### -Confirm
 
 Prompts you for confirmation before running the cmdlet. Normally the command will prompt for confirmation and -Confirm is only needed if \$ConfirmPreference has been changed.
@@ -51,40 +50,11 @@ Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
-<!-- #include "./params/force.md" -->
+<!-- #include "./params/Force.md" -->
 
-### -ProcessTemplate
+<!-- #include "./params/whatif.md" -->
 
-The process template to modify. Note that the built-in templates ("Scrum", "Agile" etc.) cannot be modified, only custom templates (derived from the built-in ones) can be changed.
-
-```yaml
-Type: Object
-Parameter Sets: (All)
-Aliases:
-
-Required: False
-Position: 0
-Default value: None
-Accept pipeline input: False
-Accept wildcard characters: False
-```
-
-### -WhatIf
-
-Shows what would happen if the cmdlet runs.
-The cmdlet is not run.
-
-```yaml
-Type: SwitchParameter
-Parameter Sets: (All)
-Aliases: wi
-
-Required: False
-Position: Named
-Default value: None
-Accept pipeline input: False
-Accept wildcard characters: False
-```
+<!-- #include "./params/processTemplate.md" -->
 
 ### -WorkItemType
 
@@ -106,19 +76,12 @@ Accept wildcard characters: False
 
 ## INPUTS
 
-### System.String
-
 ## OUTPUTS
-
-### System.Object
 
 ## NOTES
 
-<!-- #include "./common/prerequisites.md" -->
-
 ## RELATED LINKS
 
-<!-- #include "./common/related.md" -->
 [Add-VSTeamWorkItemType](Add-VSTeamWorkItemType.md)
 
 [Get-VSTeamWorkItemType](Get-VSTeamWorkItemType.md)

--- a/.docs/Remove-VSTeamWorkItemType.md
+++ b/.docs/Remove-VSTeamWorkItemType.md
@@ -1,0 +1,130 @@
+<!-- #include "./common/header.md" -->
+
+# Remove-VSTeamWorkItemType
+
+## SYNOPSIS
+
+<!-- #include "./synopsis/Remove-VSTeamWorkItemType.md" -->
+
+## SYNTAX
+
+## Description
+
+Removes a custom work item type, or reverts an inherited work item type back to the built-in Type. 
+
+If the type is a system type (as all work item types in built-in Process templates are) then an error will be thrown.
+
+## EXAMPLES
+
+### Example 1
+
+```powershell
+Remove-VSTeamWorkItemType -ProcessTemplate Scrum5 -WorkItemType ChangeRequest
+```
+
+Remove-VSTeamWorkItemType -ProcessTemplate Scrum5 -WorkItemType ChangeRequest.
+
+### Example 2
+
+```powershell
+Set-VSTeamWorkItemType -ProcessTemplate Scrum5 -WorkItemType ChangeRequest -Icon icon_parachute -color Blue -Description "For requests from customers"
+```
+
+Modifies the custom process "Scrum5", changing a user-defined work item type "ChangeRequest" to use
+a blue parachute icon and update its description..
+## PARAMETERS
+
+
+### -Confirm
+
+Prompts you for confirmation before running the cmdlet. Normally the command will prompt for confirmation and -Confirm is only needed if \$ConfirmPreference has been changed.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: (All)
+Aliases: cf
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+<!-- #include "./params/force.md" -->
+
+### -ProcessTemplate
+
+The process template to modify. Note that the built-in templates ("Scrum", "Agile" etc.) cannot be modified, only custom templates (derived from the built-in ones) can be changed.
+
+```yaml
+Type: Object
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: 0
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -WhatIf
+
+Shows what would happen if the cmdlet runs.
+The cmdlet is not run.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: (All)
+Aliases: wi
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -WorkItemType
+
+The name of the work item type to be removed or reverted. If the WorkItem type is a system type (for example if had been changed but has already been reverted), then an error will be thrown.
+
+The built-in system types cannot be deleted, but can be disabled with Set-VSTeamWorkItemType.
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases: Name
+
+Required: True
+Position: 1
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### CommonParameters
+
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](http://go.microsoft.com/fwlink/?LinkID=113216).
+
+## INPUTS
+
+### System.String
+
+## OUTPUTS
+
+### System.Object
+
+## NOTES
+
+<!-- #include "./common/prerequisites.md" -->
+
+## RELATED LINKS
+
+<!-- #include "./common/related.md" -->
+[Add-VSTeamWorkItemType](Add-VSTeamWorkItemType.md)
+
+[Get-VSTeamWorkItemType](Get-VSTeamWorkItemType.md)
+
+[Set-VSTeamWorkItemType](Remove-VSTeamWorkItemType.md)

--- a/.docs/Remove-VsteamWorkItemState.md
+++ b/.docs/Remove-VsteamWorkItemState.md
@@ -10,7 +10,7 @@
 
 ## Description
 
-Each WorkItem type in each process template has a set of possible states.  Items may have system-defined states and/or custom (user-defined) states. This command removes custom states. Note that system states, cannot be removed but can be hidden.
+Each WorkItem type in each process template has a set of possible states.  Items may have system-defined states and/or custom (user-defined) states. This command removes custom states. Note that system states cannot be removed but can be hidden.
 
 ## EXAMPLES
 
@@ -31,10 +31,9 @@ This removes the state "Postponed" from the WorkItem type "Bug" in the template 
 
 ```PowerShell
 Get-VSTeamWorkItemState -WorkItemType Bug  -ProcessTemplate Scrum2 | Where-Object customizationType -eq "custom" | Remove-VSTeamWorkItemState -Force
-
 ```
 
-As an alternative to the first example, this removes any and all custom types from the WorkItem type "Bug" in the template named "Scrum2", and -Force is use to remove any prompt which might appear.
+As an alternative to the first example, this removes any and all custom types from the WorkItem type "Bug" in the template named "Scrum2", and -Force is used to suppress any prompt which might appear.
 
 ## PARAMETERS
 

--- a/.docs/Remove-VsteamWorkItemState.md
+++ b/.docs/Remove-VsteamWorkItemState.md
@@ -54,24 +54,10 @@ Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
-### -ProcessTemplate
+<!-- #include "./params/processTemplate.md" -->
 
-Specifies the process template where the WorkItem Type to be modified is found; by default this will be the template for the current project. Note that although some WorkItem types like "bug" or "task" are found in multiple templates, a change to the available states only applies to one template, and the built-in process templates cannot be modified. Values for this parameter should tab-complete.
+<!-- #include "./params/workItemType.md" -->
 
-```yaml
-Type: String
-Parameter Sets: Process
-```
-
-### -WorkItemType
-
-The name of the WorkItem type whose state list is to be modified. Values for this parameter should tab-complete with types in the current project's process-template; types found only in other templates may need to be entered manually.
-
-
-```yaml
-Type: String
-Parameter Sets: ByType
-```
 <!-- #include "./params/forcegroup.md" -->
 
 ## INPUTS

--- a/.docs/Remove-VsteamWorkItemState.md
+++ b/.docs/Remove-VsteamWorkItemState.md
@@ -63,41 +63,29 @@ Type: String
 Parameter Sets: Process
 ```
 
-
 ### -WorkItemType
 
-The name of the WorkItem type whose state list is to be modified. Values for this parameter should tab-complete with types in the current project's process-template; types found only in other templates may need to be entered manually. 
+The name of the WorkItem type whose state list is to be modified. Values for this parameter should tab-complete with types in the current project's process-template; types found only in other templates may need to be entered manually.
 
 
 ```yaml
 Type: String
 Parameter Sets: ByType
 ```
-<!-- #include "./params/confirm.md" -->
-
-<!-- #include "./params/Force.md" -->
-
-<!-- #include "./params/whatif.md" -->
+<!-- #include "./params/forcegroup.md" -->
 
 ## INPUTS
 
-### System.String
-
 ## OUTPUTS
-
-### System.Object
 
 ## NOTES
 
-<!-- #include "./common/prerequisites.md" -->
-
 ## RELATED LINKS
 
-<!-- #include "./common/related.md" -->
-[Add-VsteamWorkItemState](Add-VsteamWorkItemState.md)
+[Add-VSTeamWorkItemState](Add-VSTeamWorkItemState.md)
 
-[Get-VsteamWorkItemState](Get-VsteamWorkItemState.md)
+[Get-VSTeamWorkItemState](Get-VSTeamWorkItemState.md)
 
-[Hide-VsteamWorkItemState](Hide-VsteamWorkItemState.md)
+[Hide-VSTeamWorkItemState](Hide-VSTeamWorkItemState.md)
 
-[Show-VsteamWorkItemState](Show-VsteamWorkItemState.md)
+[Show-VSTeamWorkItemState](Show-VSTeamWorkItemState.md)

--- a/.docs/Remove-VsteamWorkItemState.md
+++ b/.docs/Remove-VsteamWorkItemState.md
@@ -1,0 +1,103 @@
+<!-- #include "./common/header.md" -->
+
+# Remove-VSTeamWorkItemState
+
+## SYNOPSIS
+
+<!-- #include "./synopsis/Remove-VSTeamWorkItemState.md" -->
+
+## SYNTAX
+
+## Description
+
+Each WorkItem type in each process template has a set of possible states.  Items may have system-defined states and/or custom (user-defined) states. This command removes custom states. Note that system states, cannot be removed but can be hidden.
+
+## EXAMPLES
+
+### Example 1
+
+```PowerShell
+ Remove-VSTeamWorkItemState -WorkItemType Bug  -Name postponed -ProcessTemplate Scrum2
+
+Confirm
+Are you sure you want to perform this action?
+Performing the operation "Modify WorkItem type 'Bug' in process template 'Scrum2'; delete state" on target "postponed".
+[Y] Yes [A] Yes to All [N] No [L] No to All [S] Suspend [?] Help (default is "Yes"): y
+```
+
+This removes the state "Postponed" from the WorkItem type "Bug" in the template named "Scrum2" - because -Force was not specified a confirmation prompt is shown.
+
+### Example 2
+
+```PowerShell
+Get-VSTeamWorkItemState -WorkItemType Bug  -ProcessTemplate Scrum2 | Where-Object customizationType -eq "custom" | Remove-VSTeamWorkItemState -Force
+
+```
+
+As an alternative to the first example, this removes any and all custom types from the WorkItem type "Bug" in the template named "Scrum2", and -Force is use to remove any prompt which might appear.
+
+## PARAMETERS
+
+### -Name
+
+The name of the state to be removed.
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: True
+Position: 1
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -ProcessTemplate
+
+Specifies the process template where the WorkItem Type to be modified is found; by default this will be the template for the current project. Note that although some WorkItem types like "bug" or "task" are found in multiple templates, a change to the available states only applies to one template, and the built-in process templates cannot be modified. Values for this parameter should tab-complete.
+
+```yaml
+Type: String
+Parameter Sets: Process
+```
+
+
+### -WorkItemType
+
+The name of the WorkItem type whose state list is to be modified. Values for this parameter should tab-complete with types in the current project's process-template; types found only in other templates may need to be entered manually. 
+
+
+```yaml
+Type: String
+Parameter Sets: ByType
+```
+<!-- #include "./params/confirm.md" -->
+
+<!-- #include "./params/Force.md" -->
+
+<!-- #include "./params/whatif.md" -->
+
+## INPUTS
+
+### System.String
+
+## OUTPUTS
+
+### System.Object
+
+## NOTES
+
+<!-- #include "./common/prerequisites.md" -->
+
+## RELATED LINKS
+
+<!-- #include "./common/related.md" -->
+[Add-VsteamWorkItemState](Add-VsteamWorkItemState.md)
+
+[Get-VsteamWorkItemState](Get-VsteamWorkItemState.md)
+
+[Hide-VsteamWorkItemState](Hide-VsteamWorkItemState.md)
+
+[Show-VsteamWorkItemState](Show-VsteamWorkItemState.md)

--- a/.docs/Set-VSTeamWorkItemType.md
+++ b/.docs/Set-VSTeamWorkItemType.md
@@ -183,10 +183,6 @@ Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
-### CommonParameters
-
-This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](http://go.microsoft.com/fwlink/?LinkID=113216).
-
 ## INPUTS
 
 ### System.String

--- a/.docs/Set-VSTeamWorkItemType.md
+++ b/.docs/Set-VSTeamWorkItemType.md
@@ -1,0 +1,209 @@
+<!-- #include "./common/header.md" -->
+
+# Set-VSTeamWorkItemType
+
+## SYNOPSIS
+
+<!-- #include "./synopsis/Set-VSTeamWorkItemType.md" -->
+
+## SYNTAX
+
+## Description
+
+Modifies an existing work item type in a custom process; where the work item type is a built-in type, like "Bug",
+the original item is preserved and a new inherited version is created.
+It is possible to change the Description, Icon, Icon Color, and to enable or disable the work item type
+
+## EXAMPLES
+
+### Example 1
+
+```powershell
+Set-VSTeamWorkItemType -ProcessTemplate Scrum5 -WorkItemType Impediment -Disabled
+```
+
+Modifies the custom process "Scrum5", disabling the built in work item type "Impediment".
+
+### Example 2
+
+```powershell
+Set-VSTeamWorkItemType -ProcessTemplate Scrum5 -WorkItemType ChangeRequest -Icon icon_parachute -color Blue -Description "For requests from customers"
+```
+
+Modifies the custom process "Scrum5", changing a user-defined work item type "ChangeRequest" to use
+a blue parachute icon and update its description..
+## PARAMETERS
+
+### -Color
+
+Changes the the icon color. The input value can be the name of a color name like "Red" or "Aqua" or
+a hex value for red, green and blue parts. Color names should tab complete.
+
+```yaml
+Type: Object
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: 3
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Confirm
+
+Prompts you for confirmation before running the cmdlet. Normally the command will prompt for confirmation and -Confirm is only needed if \$ConfirmPreference has been changed.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: (All)
+Aliases: cf
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Description
+
+Long text description of the the work item type.
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: 2
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Disabled
+
+If specified, disables the work item so that it can not be selected for new items.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: Hide
+Aliases:
+
+Required: True
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Enabled
+
+If specified, enables a work item which was previously disabled.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: Show
+Aliases:
+
+Required: True
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+<!-- #include "./params/force.md" -->
+
+### -Icon
+
+One of the predefined icons for work item types. Possible values should tab complete and
+if the name omits the leading "Icon\_" it will be added automatically.
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: 4
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -ProcessTemplate
+
+The process template to modify. Note that the built-in templates ("Scrum", "Agile" etc.) cannot be modified, only custom templates (derived from the built-in ones) can be changed.
+
+```yaml
+Type: Object
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: 0
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -WhatIf
+
+Shows what would happen if the cmdlet runs.
+The cmdlet is not run.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: (All)
+Aliases: wi
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -WorkItemType
+
+The name of the work item type to be modified.
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases: Name
+
+Required: True
+Position: 1
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### CommonParameters
+
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](http://go.microsoft.com/fwlink/?LinkID=113216).
+
+## INPUTS
+
+### System.String
+
+## OUTPUTS
+
+### System.Object
+
+## NOTES
+
+<!-- #include "./common/prerequisites.md" -->
+
+## RELATED LINKS
+
+<!-- #include "./common/related.md" -->
+[Add-VSTeamWorkItemType](Add-VSTeamWorkItemType.md)
+
+[Get-VSTeamWorkItemType](Get-VSTeamWorkItemType.md)
+
+[Remove-VSTeamWorkItemType](Remove-VSTeamWorkItemType.md)

--- a/.docs/Set-VSTeamWorkItemType.md
+++ b/.docs/Set-VSTeamWorkItemType.md
@@ -66,10 +66,17 @@ Default value: None
 Accept pipeline input: False
 Accept wildcard characters: False
 ```
+<!-- #include "./params/Force.md" -->
+
+<!-- #include "./params/whatif.md" -->
+
+<!-- #include "./params/processTemplate.md" -->
+
+<!-- #include "./params/workItemType.md" -->
 
 ### -Description
 
-Long text description of the the work item type.
+Long text description of the WorkItem type.
 
 ```yaml
 Type: String
@@ -85,7 +92,7 @@ Accept wildcard characters: False
 
 ### -Disabled
 
-If specified, disables the work item so that it can not be selected for new items.
+If specified, disables the WorkItem type so that it can not be selected for new items.
 
 ```yaml
 Type: SwitchParameter
@@ -101,7 +108,7 @@ Accept wildcard characters: False
 
 ### -Enabled
 
-If specified, enables a work item which was previously disabled.
+If specified, enables a WorkItem type which was previously disabled.
 
 ```yaml
 Type: SwitchParameter
@@ -114,8 +121,6 @@ Default value: None
 Accept pipeline input: False
 Accept wildcard characters: False
 ```
-
-<!-- #include "./params/force.md" -->
 
 ### -Icon
 
@@ -134,70 +139,14 @@ Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
-### -ProcessTemplate
-
-The process template to modify. Note that the built-in templates ("Scrum", "Agile" etc.) cannot be modified, only custom templates (derived from the built-in ones) can be changed.
-
-```yaml
-Type: Object
-Parameter Sets: (All)
-Aliases:
-
-Required: False
-Position: 0
-Default value: None
-Accept pipeline input: False
-Accept wildcard characters: False
-```
-
-### -WhatIf
-
-Shows what would happen if the cmdlet runs.
-The cmdlet is not run.
-
-```yaml
-Type: SwitchParameter
-Parameter Sets: (All)
-Aliases: wi
-
-Required: False
-Position: Named
-Default value: None
-Accept pipeline input: False
-Accept wildcard characters: False
-```
-
-### -WorkItemType
-
-The name of the work item type to be modified.
-
-```yaml
-Type: String
-Parameter Sets: (All)
-Aliases: Name
-
-Required: True
-Position: 1
-Default value: None
-Accept pipeline input: False
-Accept wildcard characters: False
-```
-
 ## INPUTS
-
-### System.String
 
 ## OUTPUTS
 
-### System.Object
-
 ## NOTES
-
-<!-- #include "./common/prerequisites.md" -->
 
 ## RELATED LINKS
 
-<!-- #include "./common/related.md" -->
 [Add-VSTeamWorkItemType](Add-VSTeamWorkItemType.md)
 
 [Get-VSTeamWorkItemType](Get-VSTeamWorkItemType.md)

--- a/.docs/Set-VSTeamWorkItemType.md
+++ b/.docs/Set-VSTeamWorkItemType.md
@@ -10,9 +10,9 @@
 
 ## Description
 
-Modifies an existing work item type in a custom process; where the work item type is a built-in type, like "Bug",
-the original item is preserved and a new inherited version is created.
-It is possible to change the Description, Icon, Icon Color, and to enable or disable the work item type
+Modifies an existing WorkItem type in a custom process; where the WorkItem type is a built-in type, like "Bug",
+the original item is preserved, and a new inherited version is created.
+It is possible to change the Description, Icon, Icon Color, and to enable or disable the WorkItem type
 
 ## EXAMPLES
 
@@ -22,7 +22,7 @@ It is possible to change the Description, Icon, Icon Color, and to enable or dis
 Set-VSTeamWorkItemType -ProcessTemplate Scrum5 -WorkItemType Impediment -Disabled
 ```
 
-Modifies the custom process "Scrum5", disabling the built in work item type "Impediment".
+Modifies the custom process "Scrum5", disabling the built-in WorkItem type "Impediment".
 
 ### Example 2
 
@@ -30,13 +30,14 @@ Modifies the custom process "Scrum5", disabling the built in work item type "Imp
 Set-VSTeamWorkItemType -ProcessTemplate Scrum5 -WorkItemType ChangeRequest -Icon icon_parachute -color Blue -Description "For requests from customers"
 ```
 
-Modifies the custom process "Scrum5", changing a user-defined work item type "ChangeRequest" to use
-a blue parachute icon and update its description..
+Modifies the custom process "Scrum5", changing a user-defined WorkItem type "ChangeRequest" to use
+a blue parachute icon and update its description.
+
 ## PARAMETERS
 
 ### -Color
 
-Changes the the icon color. The input value can be the name of a color name like "Red" or "Aqua" or
+Changes the  icon color. The input value can be the name of a color name like "Red" or "Aqua" or
 a hex value for red, green and blue parts. Color names should tab complete.
 
 ```yaml
@@ -92,7 +93,7 @@ Accept wildcard characters: False
 
 ### -Disabled
 
-If specified, disables the WorkItem type so that it can not be selected for new items.
+If specified, disables the WorkItem type so that it cannot be selected for new items.
 
 ```yaml
 Type: SwitchParameter
@@ -124,7 +125,7 @@ Accept wildcard characters: False
 
 ### -Icon
 
-One of the predefined icons for work item types. Possible values should tab complete and
+One of the predefined icons for WorkItem types. Possible values should tab complete and
 if the name omits the leading "Icon\_" it will be added automatically.
 
 ```yaml

--- a/.docs/Show-VSTeamWorkItemState.md
+++ b/.docs/Show-VSTeamWorkItemState.md
@@ -1,0 +1,92 @@
+<!-- #include "./common/header.md" -->
+
+# Show-VSTeamWorkItemState
+
+## SYNOPSIS
+
+<!-- #include "./synopsis/Show-VSTeamWorkItemState.md" -->
+
+## SYNTAX
+
+## Description
+
+Each WorkItem type in each process template has a set of possible states.  Items may have system-defined states and/or custom (user-defined) states. This command is used to un-hide system states which have previously been hidden
+
+## EXAMPLES
+
+### Example 1
+
+```PowerShell
+Show-VSTeamWorkItemState -WorkItemType Bug -Name Approved -ProcessTemplate Scrum2 -Force
+```
+
+
+This un-hides the "Approved" state for bug in the custom process template "Scrum2", without the confirmation prompt.
+If the state is not hidden a warning message will appear and the state will not be changed.
+
+## PARAMETERS
+
+### -Name
+
+The name of the state to be revealed.
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: True
+Position: 1
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -ProcessTemplate
+
+Specifies the process template where the WorkItem Type to be modified is found; by default this will be the template for the current project. Note that although some WorkItem types like "bug" or "task" are found in multiple templates, a change to the available states only applies to one template, and the built-in process templates cannot be modified. Values for this parameter should tab-complete.
+
+
+```yaml
+Type: String
+Parameter Sets: Process
+```
+
+
+### -WorkItemType
+
+The name of the WorkItem type whose state list is to be modified. Values for this parameter should tab-complete with types in the current project's process-template; types found only in other templates may need to be entered manually. 
+
+
+```yaml
+Type: String
+Parameter Sets: ByType
+```
+<!-- #include "./params/confirm.md" -->
+
+<!-- #include "./params/Force.md" -->
+
+<!-- #include "./params/whatif.md" -->
+
+## INPUTS
+
+### System.String
+
+## OUTPUTS
+
+### System.Object
+
+## NOTES
+
+<!-- #include "./common/prerequisites.md" -->
+
+## RELATED LINKS
+
+<!-- #include "./common/related.md" -->
+[Add-VsteamWorkItemState](Add-VsteamWorkItemState.md)
+
+[Get-VsteamWorkItemState](Get-VsteamWorkItemState.md)
+
+[Hide-VsteamWorkItemState](Hide-VsteamWorkItemState.md)
+
+[Remove-VsteamWorkItemState](Remove-VsteamWorkItemState.md)

--- a/.docs/Show-VSTeamWorkItemState.md
+++ b/.docs/Show-VSTeamWorkItemState.md
@@ -10,7 +10,8 @@
 
 ## Description
 
-Each WorkItem type in each process template has a set of possible states.  Items may have system-defined states and/or custom (user-defined) states. This command is used to un-hide system states which have previously been hidden
+Each WorkItem type in each process template has a set of possible states.  Items may have system-defined states and/or custom (user-defined) states. This command is used to un-hide system states which have previously been hidden.  Note that although some WorkItem types like "Bug" or "Ttask" are found in multiple templates, a change to the available states only applies to one template, and only custom templates can be modified, the built-in ones cannot.
+
 
 ## EXAMPLES
 
@@ -19,7 +20,6 @@ Each WorkItem type in each process template has a set of possible states.  Items
 ```PowerShell
 Show-VSTeamWorkItemState -WorkItemType Bug -Name Approved -ProcessTemplate Scrum2 -Force
 ```
-
 This un-hides the "Approved" state for bug in the custom process template "Scrum2", without the confirmation prompt.
 If the state is not hidden a warning message will appear and the state will not be changed.
 
@@ -41,36 +41,15 @@ Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
-### -ProcessTemplate
+<!-- #include "./params/forcegroup.md" -->
 
-Specifies the process template where the WorkItem Type to be modified is found; by default this will be the template for the current project. Note that although some WorkItem types like "bug" or "task" are found in multiple templates, a change to the available states only applies to one template, and the built-in process templates cannot be modified. Values for this parameter should tab-complete.
+<!-- #include "./params/processTemplate.md" -->
 
-```yaml
-Type: String
-Parameter Sets: Process
-```
-
-### -WorkItemType
-
-The name of the WorkItem type whose state list is to be modified. Values for this parameter should tab-complete with types in the current project's process-template; types found only in other templates may need to be entered manually.
-
-```yaml
-Type: String
-Parameter Sets: ByType
-```
-<!-- #include "./params/confirm.md" -->
-
-<!-- #include "./params/Force.md" -->
-
-<!-- #include "./params/whatif.md" -->
+<!-- #include "./params/workItemType.md" -->
 
 ## INPUTS
 
-### System.String
-
 ## OUTPUTS
-
-### System.Object
 
 ## NOTES
 

--- a/.docs/Show-VSTeamWorkItemState.md
+++ b/.docs/Show-VSTeamWorkItemState.md
@@ -10,7 +10,7 @@
 
 ## Description
 
-Each WorkItem type in each process template has a set of possible states.  Items may have system-defined states and/or custom (user-defined) states. This command is used to un-hide system states which have previously been hidden.  Note that although some WorkItem types like "Bug" or "Ttask" are found in multiple templates, a change to the available states only applies to one template, and only custom templates can be modified, the built-in ones cannot.
+Each WorkItem type in each process template has a set of possible states.  Items may have system-defined states and/or custom (user-defined) states. This command is used to un-hide system states which have previously been hidden.  Note that although some WorkItem types like "Bug" or "Task" are found in multiple templates, a change to the available states only applies to one template, and only custom templates can be modified, the built-in ones cannot.
 
 
 ## EXAMPLES
@@ -20,7 +20,7 @@ Each WorkItem type in each process template has a set of possible states.  Items
 ```PowerShell
 Show-VSTeamWorkItemState -WorkItemType Bug -Name Approved -ProcessTemplate Scrum2 -Force
 ```
-This un-hides the "Approved" state for bug in the custom process template "Scrum2", without the confirmation prompt.
+This un-hides the "Approved" state for Bugs in the custom process template "Scrum2", without the confirmation prompt.
 If the state is not hidden a warning message will appear and the state will not be changed.
 
 ## PARAMETERS

--- a/.docs/Show-VSTeamWorkItemState.md
+++ b/.docs/Show-VSTeamWorkItemState.md
@@ -20,7 +20,6 @@ Each WorkItem type in each process template has a set of possible states.  Items
 Show-VSTeamWorkItemState -WorkItemType Bug -Name Approved -ProcessTemplate Scrum2 -Force
 ```
 
-
 This un-hides the "Approved" state for bug in the custom process template "Scrum2", without the confirmation prompt.
 If the state is not hidden a warning message will appear and the state will not be changed.
 
@@ -46,17 +45,14 @@ Accept wildcard characters: False
 
 Specifies the process template where the WorkItem Type to be modified is found; by default this will be the template for the current project. Note that although some WorkItem types like "bug" or "task" are found in multiple templates, a change to the available states only applies to one template, and the built-in process templates cannot be modified. Values for this parameter should tab-complete.
 
-
 ```yaml
 Type: String
 Parameter Sets: Process
 ```
 
-
 ### -WorkItemType
 
-The name of the WorkItem type whose state list is to be modified. Values for this parameter should tab-complete with types in the current project's process-template; types found only in other templates may need to be entered manually. 
-
+The name of the WorkItem type whose state list is to be modified. Values for this parameter should tab-complete with types in the current project's process-template; types found only in other templates may need to be entered manually.
 
 ```yaml
 Type: String
@@ -78,15 +74,12 @@ Parameter Sets: ByType
 
 ## NOTES
 
-<!-- #include "./common/prerequisites.md" -->
-
 ## RELATED LINKS
 
-<!-- #include "./common/related.md" -->
-[Add-VsteamWorkItemState](Add-VsteamWorkItemState.md)
+[Add-VSTeamWorkItemState](Add-VSTeamWorkItemState.md)
 
-[Get-VsteamWorkItemState](Get-VsteamWorkItemState.md)
+[Get-VSTeamWorkItemState](Get-VSTeamWorkItemState.md)
 
-[Hide-VsteamWorkItemState](Hide-VsteamWorkItemState.md)
+[Hide-VSTeamWorkItemState](Hide-VSTeamWorkItemState.md)
 
-[Remove-VsteamWorkItemState](Remove-VsteamWorkItemState.md)
+[Remove-VSTeamWorkItemState](Remove-VSTeamWorkItemState.md)

--- a/.docs/Unlock-VSTeamWorkItemType.md
+++ b/.docs/Unlock-VSTeamWorkItemType.md
@@ -1,0 +1,68 @@
+<!-- #include "./common/header.md" -->
+
+# Unlock-VSTeamWorkItemType
+
+## SYNOPSIS
+
+<!-- #include "./synopsis/Unlock-VSTeamWorkItemType.md" -->
+
+## SYNTAX
+
+## Description
+
+Takes a WorkItem type and if its customation field implies a custom or inherited type simply returns it.
+If it is a (locked) system type, creates a inherted type based on it, and returns the new type, optionally expanding the layout/states or behaviors.
+
+## PARAMETERS
+
+### -Expand
+
+If specified, the WorkItem type information returned after unlocking will have behavior, layout and/or state information attached, depending on the value of the parameter.
+If not specified the WorkItemType returned after unlocking will be simply be the result of the API call to create an inherited item.
+Has no effect if the item is already unlocked
+
+```yaml
+Type: String[]
+Parameter Sets: Process
+Accepted values: 'behaviors','layout','states'
+```
+
+<!-- #include "./params/forcegroup.md" -->
+
+### -WorkItemType
+
+An object representing the WorkItemType which should be unlocked (and may already be)
+
+```yaml
+Type: Object
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: 0
+Default value: None
+Accept pipeline input: True
+Accept wildcard characters: False
+```
+
+
+## INPUTS
+
+### System.String
+
+## OUTPUTS
+
+### System.Object
+
+## NOTES
+
+<!-- #include "./common/prerequisites.md" -->
+
+## RELATED LINKS
+
+<!-- #include "./common/related.md" -->
+[Add-VSTeamWorkItemType](Add-VSTeamWorkItemType.md)
+
+[Get-VSTeamWorkItemType](Get-VSTeamWorkItemType.md)
+
+[Remove-VSTeamWorkItemType](Remove-VSTeamWorkItemType.md)

--- a/.docs/Unlock-VSTeamWorkItemType.md
+++ b/.docs/Unlock-VSTeamWorkItemType.md
@@ -19,7 +19,7 @@ If it is a (locked) system type, creates a inherted type based on it, and return
 
 If specified, the WorkItem type information returned after unlocking will have behavior, layout and/or state information attached, depending on the value of the parameter.
 If not specified the WorkItemType returned after unlocking will be simply be the result of the API call to create an inherited item.
-Has no effect if the item is already unlocked
+Has no effect if the item is already unlocked.
 
 ```yaml
 Type: String[]
@@ -45,7 +45,6 @@ Accept pipeline input: True
 Accept wildcard characters: False
 ```
 
-
 ## INPUTS
 
 ### System.String
@@ -56,11 +55,8 @@ Accept wildcard characters: False
 
 ## NOTES
 
-<!-- #include "./common/prerequisites.md" -->
-
 ## RELATED LINKS
 
-<!-- #include "./common/related.md" -->
 [Add-VSTeamWorkItemType](Add-VSTeamWorkItemType.md)
 
 [Get-VSTeamWorkItemType](Get-VSTeamWorkItemType.md)

--- a/.docs/Unlock-VSTeamWorkItemType.md
+++ b/.docs/Unlock-VSTeamWorkItemType.md
@@ -10,15 +10,15 @@
 
 ## Description
 
-Takes a WorkItem type and if its customation field implies a custom or inherited type simply returns it.
-If it is a (locked) system type, creates a inherted type based on it, and returns the new type, optionally expanding the layout/states or behaviors.
+Takes a WorkItem type and if its customization field implies a custom or inherited type, simply returns it.
+If it is a (locked) system type, creates a inherted type based on it, and returns the new type, optionally expanding the layout, states, or behaviors.
 
 ## PARAMETERS
 
 ### -Expand
 
 If specified, the WorkItem type information returned after unlocking will have behavior, layout and/or state information attached, depending on the value of the parameter.
-If not specified the WorkItemType returned after unlocking will be simply be the result of the API call to create an inherited item.
+If not specified, the WorkItemType returned after unlocking will be simply be the result of the API call to create an inherited item.
 Has no effect if the item is already unlocked.
 
 ```yaml
@@ -31,7 +31,7 @@ Accepted values: 'behaviors','layout','states'
 
 ### -WorkItemType
 
-An object representing the WorkItemType which should be unlocked (and may already be)
+An object representing the WorkItemType which should be unlocked (and may already be).
 
 ```yaml
 Type: Object

--- a/.docs/params/processTemplate.md
+++ b/.docs/params/processTemplate.md
@@ -1,0 +1,17 @@
+### -ProcessTemplate
+
+The process template where the desired change should occur.
+Note that the built-in templates ("Scrum", "Agile" etc.) cannot be modified, only custom templates (derived from the built-in ones) can be changed.
+
+
+```yaml
+Type: Object
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: True (ByPropertyName)
+Accept wildcard characters: False
+```

--- a/.docs/params/workItemType.md
+++ b/.docs/params/workItemType.md
@@ -1,6 +1,5 @@
 ### -WorkItemType
-
-The name of the work item type to be modified.
+The name of the WorkItem type to be modified.
 
 ```yaml
 Type: Object

--- a/.docs/params/workItemType.md
+++ b/.docs/params/workItemType.md
@@ -1,0 +1,15 @@
+### -WorkItemType
+
+The name of the work item type to be modified.
+
+```yaml
+Type: Object
+Parameter Sets: (All)
+Aliases:
+
+Required: True
+Position: 0
+Default value: None
+Accept pipeline input: True (ByPropertyName)
+Accept wildcard characters: False
+```

--- a/.docs/synopsis/Add-VSTeamWorkItemState.md
+++ b/.docs/synopsis/Add-VSTeamWorkItemState.md
@@ -1,0 +1,1 @@
+Adds a custom state for a WorkItem type in a custom process template

--- a/.docs/synopsis/Add-VSTeamWorkItemType.md
+++ b/.docs/synopsis/Add-VSTeamWorkItemType.md
@@ -1,0 +1,1 @@
+Adds a new work item type to a custom process template.

--- a/.docs/synopsis/Add-VSTeamWorkItemType.md
+++ b/.docs/synopsis/Add-VSTeamWorkItemType.md
@@ -1,1 +1,1 @@
-Adds a new work item type to a custom process template.
+Adds a new WorkItem type to a custom process template.

--- a/.docs/synopsis/Get-VSTeamWorkItemIconList.md
+++ b/.docs/synopsis/Get-VSTeamWorkItemIconList.md
@@ -1,0 +1,1 @@
+Returns a list of Icons which can be displayed for different WorkItem types in the web UI.

--- a/.docs/synopsis/Get-VSTeamWorkItemState.md
+++ b/.docs/synopsis/Get-VSTeamWorkItemState.md
@@ -1,0 +1,1 @@
+Lists possible states for a WorkItem type.

--- a/.docs/synopsis/Get-VSTeamWorkItemType.md
+++ b/.docs/synopsis/Get-VSTeamWorkItemType.md
@@ -1,1 +1,1 @@
-Gets a list of all Work Item Types or a single work item type.
+Gets a list of all WorkItem Types or a single WorkItem type.

--- a/.docs/synopsis/Hide-VSTeamWorkItemState.md
+++ b/.docs/synopsis/Hide-VSTeamWorkItemState.md
@@ -1,0 +1,1 @@
+Hides a system-defined state for a WorkItem type in a custom process template

--- a/.docs/synopsis/Remove-VSTeamWorkItemState.md
+++ b/.docs/synopsis/Remove-VSTeamWorkItemState.md
@@ -1,0 +1,1 @@
+Removes a custom state from a WorkItem type in a custom process

--- a/.docs/synopsis/Remove-VSTeamWorkItemType.md
+++ b/.docs/synopsis/Remove-VSTeamWorkItemType.md
@@ -1,1 +1,1 @@
-Removes a custom work item type from custom process template.
+Removes a custom WorkItem type from custom process template.

--- a/.docs/synopsis/Remove-VSTeamWorkItemType.md
+++ b/.docs/synopsis/Remove-VSTeamWorkItemType.md
@@ -1,0 +1,1 @@
+Removes a custom work item type from custom process template.

--- a/.docs/synopsis/Set-VSTeamWorkItemType.md
+++ b/.docs/synopsis/Set-VSTeamWorkItemType.md
@@ -1,0 +1,1 @@
+Modifies an existing work item type in a custom process template.

--- a/.docs/synopsis/Show-VSTeamWorkItemState.md
+++ b/.docs/synopsis/Show-VSTeamWorkItemState.md
@@ -1,0 +1,1 @@
+Un-hides a system-defined state for a WorkItem type in a custom process template

--- a/.docs/synopsis/Unlock-VSTeamWorkItemType.md
+++ b/.docs/synopsis/Unlock-VSTeamWorkItemType.md
@@ -1,0 +1,1 @@
+If a WorkItem Type has customization of "System" creates an inherited WorkItem type from it. Otherwise returns it unchanged.

--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,8 @@ Source/Public/vsteam.public.ps1
 Source/Private/vsteam.private.ps1
 Source/Classes/vsteam.classes.ps1
 /dist
+/Notes
+/ExtraScripts
 test-results.xml
 coverage.xml
 .editorconfig

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -4,6 +4,13 @@
    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
    "version": "0.2.0",
    "configurations": [
+
+   {
+      "name": ".NET Core Attach",
+      "type": "coreclr",
+      "request": "attach",
+      "processId": "${command:pickProcess}"
+   },
       {
          "name": "Start PowerShell",
          "type": "coreclr",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,31 @@
 # Changelog
 
+## J.H. O'Neill @ 3rd October 2020
+1.  To support tab completion for (e.g.) icon color  in `Add-VSTeamWorkItemType`:  **added class** `ColorCompleter` in file `Source\Classes\Completer\ColorCompleter.cs`. 
+    I can't find way to use the conventional `KnownColor` class in single new C# class which will build for both Windows PowerShell 5 and PowerShell Core, so I've worked round it by getting the static properties of `System.Drawing.Color`.
+2.  To support use of Hex Red/green/blue attributes for colors (e.g icon color): **added class** `ColorTransformToHexAttribute` in file `Source\Classes\Attribute\ColorTransformToHexAttribute.cs`. 
+    If the parameter is given an object of type `System.Drawing.Color`, it coverts it to "aabbcc" for hex r,g,b values. If the parameter is a string in form "#aabbcc", the transformer strips the hash, if it is a string which isn't in "aabbcc" form, it tries to convert to a color and from the color to its hex string e.g the user tab-completes to "Red" which becomes "ff0000" and if the user enters "randomtext" it converts to "000000"
+3.  To support (e.g.) Population of an icon cache: **added function** `Get-VSTeamWorkIconList` in file `Source\Public\Get-VSTeamWorkItemIconList`
+4.  To support icon completion and validation: **added class** `IconCache` in file `Source\Classes\Cache\IconCache.cs`. This largely copied from `ProjectCache`
+5.  To support icon completion (e.g. in in `Add-VSTeamWorkItemType): **added class** `IconCompleter` in file `Source\Classes\Completer\IconCompleter.cs`. This is based on `ProjectCompleter`
+6.  To support transformation of shortened icon-names from `name` to `icon_name` format and support the validation of icon names, (e.g. in in `Add-VSTeamWorkItemType): **added class** `IconTransformAttribute`in file `Source\Classes\Attribute\IconTransformAttribute.cs`. 
+7. To support project-independent operations on Process-templates (e.g Add-VsTeamWorkItemType), **changed class** `vsteam_lib.Versions`,  **added property** `DefaultProcess` property and corresponding environment variable `TEAM_PROCESS` - `process` is patterned after `project`.
+8.  **Changed function** `Set-VSTeamDefaultProject` 
+    * *Fixed* an apparant bug in where process level environment variable `TEAM_PROJECT` and `[vsteam_lib.Versions]::DefaultProject` were only set on Windows.
+    * *Updated*  to store current project's process in `TEAM_PROCESS` and `[vsteam_lib.Versions]::DefaultProcess`
+    * *Updated tests* `Set-VSTeamDefaultProject.Tests.ps1` and `Get-VSTeamAgent.Tests.ps1` to mock the additional API call used to look-up the project's template.  
+9.  To support changes to Process Templates themselves **changed class** `vsteam_lib.Process` **added property** `ReferenceName` 
+10. **Changed function** `Get-VSTeamWorkItemType`. 
+    * Fixed a BUG: Only WorkitemTypes for the current project are cached and for validation, so requesting a workitem from a different project will fail if that type is not in the current project. As a by product now support wildcards for selecting workitem types, entering an invalid name runs the command without any output instead of causing an error. 
+    * Added support for getting the workitem-types from a Process-template as well as from a project. When getting from a process-template, or from the default project whose template is know, add a property named `ProcessTemplate` to the objects so that piping into another function with that name as a `ValueFromPipelineByPropertyName` parameter can use it. 
+    * Added an alias property named `WorkItemType` as an alias for `Name`, also for `ValueFromPipelineByPropertyName` support
+    * Added a property named "hidden" when getting a list of workitem types for a project so picklists can remove hidden types.
+    * Fixed test which was breaking workitem-type sample data by converting it to JSON when it is known to fail to convert, it now just reads the text file and leaves the section at the comment `# This call returns JSON with "": which causes the ConvertFrom-Json to fail`  to do its thing!
+    * Added functional test for -Process Template option. 
+    * Added examples and parameter description to help. 
+11.  For WorkItemType operations, **added function** a private/helper `_getProcessTemplateUrl` in file `common.ps1` to get/set the urls of templates in a script level hash table (to reduce API calls to get ID from a name.) In a previous version I set a URL property on the processs object - this has been dropped. 
+12. **Added functions**  `Add-VSTeamWorkItemType`, `Set-VSTeamWorkItemType`, `Remove-VSTeamWorkItemType` with associated help and tests.
+
 ## 7.1.1
 
 Fixed bug in Test-VSTeamYamlPipeline by adding a Pipelines version value.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,7 +28,7 @@
     * Added functional test for -Process Template option.
     * Added examples and parameter description to help.
 1. For WorkItemType operations, **added function** a private/helper `_getProcessTemplateUrl` in file `common.ps1` to get/set the urls of templates in a script level hash table (to reduce API calls to get ID from a name.) In a previous version I set a URL property on the processs object - this has been dropped.
-1. **Added functions**  `Add-VSTeamWorkItemType`, `Set-VSTeamWorkItemType`, `Remove-VSTeamWorkItemType` with associated help and tests.
+1. **Added functions**  `Add-VSTeamWorkItemType`, `Set-VSTeamWorkItemType`, `Remove-VSTeamWorkItemType`, `Unlock-VSTeamWorkItemType` with associated help and tests.
 1. Ensured tests which mock Get-VSTeamProcess clear the process cache (otherwise the processes they return will not be used to validate the Process parameter during the test,)
 1. Ensured tests which call Set-VSTeamProject load and mock Get-VSTeamProcess.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@
 12.  For WorkItemType operations, **added function** a private/helper `_getProcessTemplateUrl` in file `common.ps1` to get/set the urls of templates in a script level hash table (to reduce API calls to get ID from a name.) In a previous version I set a URL property on the processs object - this has been dropped.
 13. **Added functions**  `Add-VSTeamWorkItemType`, `Set-VSTeamWorkItemType`, `Remove-VSTeamWorkItemType` with associated help and tests.
 14.  Ensured tests which mock Get-VSTeamProcess clear the process cache (otherwise the processes they return will not be used to validate the Process parameter during the test,)
+15.  Ensured tests which call Set-VSTeamProject load and mock Get-VSTeamProcess.
 
 ## 7.1.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,33 +1,34 @@
 # Changelog
 
 ## J.H. O'Neill @ 3rd October 2020
-1.  To support tab completion for (e.g.) icon color  in `Add-VSTeamWorkItemType`:  **added class** `ColorCompleter` in file `Source\Classes\Completer\ColorCompleter.cs`. 
+1.  To support tab completion for (e.g.) icon color  in `Add-VSTeamWorkItemType`:  **added class** `ColorCompleter` in file `Source\Classes\Completer\ColorCompleter.cs`.
     I can't find way to use the conventional `KnownColor` class in single new C# class which will build for both Windows PowerShell 5 and PowerShell Core, so I've worked round it by getting the static properties of `System.Drawing.Color`.
-2.  To support use of Hex Red/green/blue attributes for colors (e.g icon color): **added class** `ColorTransformToHexAttribute` in file `Source\Classes\Attribute\ColorTransformToHexAttribute.cs`. 
+2.  To support use of Hex Red/green/blue attributes for colors (e.g icon color): **added class** `ColorTransformToHexAttribute` in file `Source\Classes\Attribute\ColorTransformToHexAttribute.cs`.
     If the parameter is given an object of type `System.Drawing.Color`, it coverts it to "aabbcc" for hex r,g,b values. If the parameter is a string in form "#aabbcc", the transformer strips the hash, if it is a string which isn't in "aabbcc" form, it tries to convert to a color and from the color to its hex string e.g the user tab-completes to "Red" which becomes "ff0000" and if the user enters "randomtext" it converts to "000000"
 3.  To support (e.g.) Population of an icon cache: **added function** `Get-VSTeamWorkIconList` in file `Source\Public\Get-VSTeamWorkItemIconList`
 4.  To support icon completion and validation: **added class** `IconCache` in file `Source\Classes\Cache\IconCache.cs`. This largely copied from `ProjectCache`
 5.  To support icon completion (e.g. in in `Add-VSTeamWorkItemType): **added class** `IconCompleter` in file `Source\Classes\Completer\IconCompleter.cs`. This is based on `ProjectCompleter`
-6.  To support transformation of shortened icon-names from `name` to `icon_name` format and support the validation of icon names, (e.g. in in `Add-VSTeamWorkItemType): **added class** `IconTransformAttribute`in file `Source\Classes\Attribute\IconTransformAttribute.cs`. 
+6.  To support transformation of shortened icon-names from `name` to `icon_name` format and support the validation of icon names, (e.g. in in `Add-VSTeamWorkItemType): **added class** `IconTransformAttribute`in file `Source\Classes\Attribute\IconTransformAttribute.cs`.
 7. To support project-independent operations on Process-templates (e.g Add-VsTeamWorkItemType), **changed class** `vsteam_lib.Versions`,  **added property** `DefaultProcess` property and corresponding environment variable `TEAM_PROCESS` - `process` is patterned after `project`.
-8.  **Changed function** `Set-VSTeamDefaultProject` 
+8.  **Changed function** `Set-VSTeamDefaultProject`
     * *Fixed* an apparant bug in where process level environment variable `TEAM_PROJECT` and `[vsteam_lib.Versions]::DefaultProject` were only set on Windows.
     * *Updated*  to store current project's process in `TEAM_PROCESS` and `[vsteam_lib.Versions]::DefaultProcess`
-    * *Updated tests* `Set-VSTeamDefaultProject.Tests.ps1` and `Get-VSTeamAgent.Tests.ps1` to mock the additional API call used to look-up the project's template.  
-9.  To support changes to Process Templates themselves **changed class** `vsteam_lib.Process` **added property** `ReferenceName` 
-10. **Changed function** `Get-VSTeamWorkItemType`. 
-    * Fixed a BUG: Only WorkItemTypes for the current project are cached and for validation, so requesting a WorkItem from a different project will fail if that type is not in the current project. As a by product now support wildcards for selecting WorkItem types, entering an invalid name runs the command without any output instead of causing an error. 
-    * Added support for getting the WorkItem types from a Process-template as well as from a project. When getting from a process-template, or from the default project whose template is known, add a property named `ProcessTemplate` to the objects so that piping into another function with that name as a `ValueFromPipelineByPropertyName` parameter can use it. 
+    * *Updated tests* `Set-VSTeamDefaultProject.Tests.ps1` and `Get-VSTeamAgent.Tests.ps1` to mock the additional API call used to look-up the project's template.
+9.  To support changes to Process Templates themselves **changed class** `vsteam_lib.Process` **added property** `ReferenceName`, and to make it easier to find the template for a project **added property** projects.
+10. **Changed function** `Get-VSTeamProcess`, **add switch** `expandprojects`. If specified populates the newly add projects property in (9)
+11. **Changed function** `Get-VSTeamWorkItemType`.
+    * Fixed a BUG: Only WorkItemTypes for the current project are cached and for validation, so requesting a WorkItem from a different project will fail if that type is not in the current project. As a by product now support wildcards for selecting WorkItem types, entering an invalid name runs the command without any output instead of causing an error.
+    * Added support for getting the WorkItem types from a Process-template as well as from a project. When getting from a process-template, or from the default project whose template is known, add a property named `ProcessTemplate` to the objects so that piping into another function with that name as a `ValueFromPipelineByPropertyName` parameter can use it.
     * Added an alias property named `WorkItemType` as an alias for `Name`, also for `ValueFromPipelineByPropertyName` support
     * Added a property named "hidden" when getting a list of WorkItem types for a project so picklists can remove hidden types.
     * Added a switch parameter -NotHidden to return only visible WorkItem Types
     * Added an expand parameter to get state, behavior and/or layout information
     * Fixed test which was breaking WorkItem type sample data by converting it to JSON when it is known to fail to convert, it now just reads the text file and leaves the section at the comment `# This call returns JSON with "": which causes the ConvertFrom-Json to fail`  to do its thing!
-    * Added functional test for -Process Template option. 
-    * Added examples and parameter description to help. 
-11.  For WorkItemType operations, **added function** a private/helper `_getProcessTemplateUrl` in file `common.ps1` to get/set the urls of templates in a script level hash table (to reduce API calls to get ID from a name.) In a previous version I set a URL property on the processs object - this has been dropped. 
-12. **Added functions**  `Add-VSTeamWorkItemType`, `Set-VSTeamWorkItemType`, `Remove-VSTeamWorkItemType` with associated help and tests.
-13.  Ensured tests which mock Get-VSTeamProcess clear the process cache (otherwise the processes they return will not be used to validate the Process parameter during the test,)
+    * Added functional test for -Process Template option.
+    * Added examples and parameter description to help.
+12.  For WorkItemType operations, **added function** a private/helper `_getProcessTemplateUrl` in file `common.ps1` to get/set the urls of templates in a script level hash table (to reduce API calls to get ID from a name.) In a previous version I set a URL property on the processs object - this has been dropped.
+13. **Added functions**  `Add-VSTeamWorkItemType`, `Set-VSTeamWorkItemType`, `Remove-VSTeamWorkItemType` with associated help and tests.
+14.  Ensured tests which mock Get-VSTeamProcess clear the process cache (otherwise the processes they return will not be used to validate the Process parameter during the test,)
 
 ## 7.1.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,15 +16,18 @@
     * *Updated tests* `Set-VSTeamDefaultProject.Tests.ps1` and `Get-VSTeamAgent.Tests.ps1` to mock the additional API call used to look-up the project's template.  
 9.  To support changes to Process Templates themselves **changed class** `vsteam_lib.Process` **added property** `ReferenceName` 
 10. **Changed function** `Get-VSTeamWorkItemType`. 
-    * Fixed a BUG: Only WorkitemTypes for the current project are cached and for validation, so requesting a workitem from a different project will fail if that type is not in the current project. As a by product now support wildcards for selecting workitem types, entering an invalid name runs the command without any output instead of causing an error. 
-    * Added support for getting the workitem-types from a Process-template as well as from a project. When getting from a process-template, or from the default project whose template is know, add a property named `ProcessTemplate` to the objects so that piping into another function with that name as a `ValueFromPipelineByPropertyName` parameter can use it. 
+    * Fixed a BUG: Only WorkItemTypes for the current project are cached and for validation, so requesting a WorkItem from a different project will fail if that type is not in the current project. As a by product now support wildcards for selecting WorkItem types, entering an invalid name runs the command without any output instead of causing an error. 
+    * Added support for getting the WorkItem types from a Process-template as well as from a project. When getting from a process-template, or from the default project whose template is known, add a property named `ProcessTemplate` to the objects so that piping into another function with that name as a `ValueFromPipelineByPropertyName` parameter can use it. 
     * Added an alias property named `WorkItemType` as an alias for `Name`, also for `ValueFromPipelineByPropertyName` support
-    * Added a property named "hidden" when getting a list of workitem types for a project so picklists can remove hidden types.
-    * Fixed test which was breaking workitem-type sample data by converting it to JSON when it is known to fail to convert, it now just reads the text file and leaves the section at the comment `# This call returns JSON with "": which causes the ConvertFrom-Json to fail`  to do its thing!
+    * Added a property named "hidden" when getting a list of WorkItem types for a project so picklists can remove hidden types.
+    * Added a switch parameter -NotHidden to return only visible WorkItem Types
+    * Added an expand parameter to get state, behavior and/or layout information
+    * Fixed test which was breaking WorkItem type sample data by converting it to JSON when it is known to fail to convert, it now just reads the text file and leaves the section at the comment `# This call returns JSON with "": which causes the ConvertFrom-Json to fail`  to do its thing!
     * Added functional test for -Process Template option. 
     * Added examples and parameter description to help. 
 11.  For WorkItemType operations, **added function** a private/helper `_getProcessTemplateUrl` in file `common.ps1` to get/set the urls of templates in a script level hash table (to reduce API calls to get ID from a name.) In a previous version I set a URL property on the processs object - this has been dropped. 
 12. **Added functions**  `Add-VSTeamWorkItemType`, `Set-VSTeamWorkItemType`, `Remove-VSTeamWorkItemType` with associated help and tests.
+13.  Ensured tests which mock Get-VSTeamProcess clear the process cache (otherwise the processes they return will not be used to validate the Process parameter during the test,)
 
 ## 7.1.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@
 1. **Added functions**  `Add-VSTeamWorkItemType`, `Set-VSTeamWorkItemType`, `Remove-VSTeamWorkItemType`, `Unlock-VSTeamWorkItemType` with associated help and tests.
 1. Ensured tests which mock Get-VSTeamProcess clear the process cache (otherwise the processes they return will not be used to validate the Process parameter during the test,)
 1. Ensured tests which call Set-VSTeamProject load and mock Get-VSTeamProcess.
+1. Modified validator for process templates to allow multiple template names to be validated (where function can't support multiple names count should be validated.)
 
 ## 7.1.2
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,9 +20,10 @@
     * Fixed a BUG: Only WorkItemTypes for the current project are cached and for validation, so requesting a WorkItem from a different project will fail if that type is not in the current project. As a by product now support wildcards for selecting WorkItem types, entering an invalid name runs the command without any output instead of causing an error.
     * Added support for getting the WorkItem types from a Process-template as well as from a project. When getting from a process-template, or from the default project whose template is known, add a property named `ProcessTemplate` to the objects so that piping into another function with that name as a `ValueFromPipelineByPropertyName` parameter can use it.
     * Added an alias property named `WorkItemType` as an alias for `Name`, also for `ValueFromPipelineByPropertyName` support
-    * Added a property named "hidden" when getting a list of WorkItem types for a project so picklists can remove hidden types.
+    * Added a property named "hidden" when getting a list of WorkItem types for a project, so picklists can remove hidden types.
     * Added a switch parameter -NotHidden to return only visible WorkItem Types
     * Added an expand parameter to get state, behavior and/or layout information
+    * Now allow the workitemtype parameter to be a wildcard or multiple strings. (e.g. Get-VSTeamWorkItemType bug,feature)
     * Fixed test which was breaking WorkItem type sample data by converting it to JSON when it is known to fail to convert, it now just reads the text file and leaves the section at the comment `# This call returns JSON with "": which causes the ConvertFrom-Json to fail`  to do its thing!
     * Added functional test for -Process Template option.
     * Added examples and parameter description to help.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## J.H. O'Neill @ 6th October 2020
+1. Ensured cache is cleared in Set- and Remove- -VSTeamWorkItemType.Tests
+2.  To Support workitem *states*, Added 5 new functions each with its PS1 help and test. 
+   *  Get-VsteamWorkItemState
+   *  Add-VSTeamWorkItemState
+   *  Remove-VsteamWorkItemState
+   *  Hide-VsteamWorkItemState
+   *  Show-VsteamWorkItemState
+
+Each WorkItem type in each process template has a set of possible states e.g. "To Do", "In Progress" and "Done". Some are system states which cannot be removed but can be hidden (and shown). Other states are custom/user-added and can be removed (but not hidden). This provides tools for listing the states, hiding and showing system ones, and adding and removing user ones. 
+
+
 ## J.H. O'Neill @ 3rd October 2020
 1.  To support tab completion for (e.g.) icon color  in `Add-VSTeamWorkItemType`:  **added class** `ColorCompleter` in file `Source\Classes\Completer\ColorCompleter.cs`. 
     I can't find way to use the conventional `KnownColor` class in single new C# class which will build for both Windows PowerShell 5 and PowerShell Core, so I've worked round it by getting the static properties of `System.Drawing.Color`.

--- a/Source/Classes/Attribute/ColorTransformToHexAttribute.cs
+++ b/Source/Classes/Attribute/ColorTransformToHexAttribute.cs
@@ -1,0 +1,33 @@
+﻿using System.Diagnostics.CodeAnalysis;
+using System.Management.Automation;
+using System.Drawing;
+using System.Text.RegularExpressions;
+namespace vsteam_lib
+{
+   public class ColorTransformToHexAttribute : ArgumentTransformationAttribute {
+      [ExcludeFromCodeCoverage]
+      public override object Transform(EngineIntrinsics engineIntrinsics, object InputData) {
+         try {
+            if (InputData is string) {
+               string s = (string)InputData;
+               Regex sixHexDigits = new Regex(@"^#?([\da-f]{6})$",RegexOptions.IgnoreCase);
+               if (sixHexDigits.Match(s).Success ) {
+                  InputData = sixHexDigits.Replace(s,"$1");
+               }
+               else {
+                  InputData =  Color.FromName(s);
+               }                
+            }
+            if (InputData is Color) {
+               Color c = (Color)InputData;
+               InputData = (string.Format("{0:x2}{1:x2}{2:x2}",c.R, c.G, c.B) );
+            }
+         }
+         catch {
+            throw (new ParameterBindingException((InputData as string) + " could not be transformed into a color.") ); 
+         }
+
+         return (InputData);
+      }
+   }
+}

--- a/Source/Classes/Attribute/IconTransformAttribute.cs
+++ b/Source/Classes/Attribute/IconTransformAttribute.cs
@@ -1,0 +1,33 @@
+﻿using System.Diagnostics.CodeAnalysis;
+using System.Management.Automation;
+using System.Text.RegularExpressions;
+using System.Linq;
+namespace vsteam_lib
+{
+   public class IconTransformAttribute : ArgumentTransformationAttribute {
+      [ExcludeFromCodeCoverage]
+      public override object Transform(EngineIntrinsics engineIntrinsics, object InputData) {
+          
+            string s = (InputData as string).ToLower();
+            if (! string.IsNullOrEmpty(s))
+            {
+               Regex iconSomething = new Regex(@"^icon_\w+");
+               if (!iconSomething.IsMatch(s)) 
+               { 
+                  s = "icon_" + s;
+               }
+               var iconList = IconCache.GetCurrent(false);
+            
+               if (iconList.Count() > 1 && ! iconList.Contains(s) ) 
+               {
+                  throw (new ValidationMetadataException(s + " is not a valid icon name.") );
+               }
+               else
+               {
+                  return s;
+               }
+            }
+            return InputData;
+      }
+   }
+}

--- a/Source/Classes/Attribute/ProcessTemplateValidateAttribute.cs
+++ b/Source/Classes/Attribute/ProcessTemplateValidateAttribute.cs
@@ -1,9 +1,35 @@
-﻿using System.Collections.Generic;
-
+﻿using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
+using System.Management.Automation;
 namespace vsteam_lib
 {
    public class ProcessTemplateValidateAttribute : BaseValidateArgumentsAttribute
    {
       internal override IEnumerable<string> GetValues() => ProcessTemplateCache.GetCurrent();
+
+      protected override void Validate(object arguments, EngineIntrinsics engineIntrinsics)
+      {
+         if (string.IsNullOrEmpty(arguments?.ToString()))
+         {
+            return;
+         }
+
+         if (arguments is object[])
+         {
+            IEnumerable enumerable = arguments as IEnumerable;
+            foreach (var item in enumerable)
+            {
+                Validate(item,engineIntrinsics);
+            }
+            return;
+         }
+
+         var cache = ProcessTemplateCache.GetCurrent();
+         if (cache.Count() > 0 && cache.All(s => string.Compare(arguments.ToString(), s, true) != 0))
+         {
+            throw new ValidationMetadataException($"'{arguments}' is invalid");
+         }
+      }
    }
 }

--- a/Source/Classes/Cache/IconCache.cs
+++ b/Source/Classes/Cache/IconCache.cs
@@ -1,0 +1,34 @@
+﻿using System.Collections.Generic;
+using System.Management.Automation;
+
+namespace vsteam_lib
+{
+   /// <summary>
+   /// Cache project names to reduce the number of
+   /// rest APIs calls needed for parameter completion / validation 
+   /// </summary>
+   public static class IconCache
+   {
+      public static void Invalidate() => Cache.Invalidate();
+      internal static bool HasCacheExpired => Cache.HasCacheExpired;
+      internal static InternalCache Cache { get; } = new InternalCache("Get-VSTeamWorkItemIconList", "ID", false);
+      public static void Update(IEnumerable<string> list, int minutesToExpire = 240) => Cache.Update(list, minutesToExpire);
+
+      /// <summary>
+      /// There are times we need to force an update of the cache
+      /// even if it has not expired yet. This will be true when we
+      /// add a new project.
+      /// </summary>
+      /// <param name="forceUpdate"></param>
+      /// <returns></returns>
+      public static IEnumerable<string> GetCurrent(bool forceUpdate)
+      {
+         if (HasCacheExpired || forceUpdate)
+         {
+            Update(null);
+         }
+
+         return Cache.Values;
+      }
+   }
+}

--- a/Source/Classes/Cache/IconCache.cs
+++ b/Source/Classes/Cache/IconCache.cs
@@ -1,10 +1,9 @@
 ﻿using System.Collections.Generic;
-using System.Management.Automation;
 
 namespace vsteam_lib
 {
    /// <summary>
-   /// Cache project names to reduce the number of
+   /// Cache Icons for work items to reduce the number of
    /// rest APIs calls needed for parameter completion / validation 
    /// </summary>
    public static class IconCache
@@ -16,8 +15,7 @@ namespace vsteam_lib
 
       /// <summary>
       /// There are times we need to force an update of the cache
-      /// even if it has not expired yet. This will be true when we
-      /// add a new project.
+      /// even if it has not expired yet. 
       /// </summary>
       /// <param name="forceUpdate"></param>
       /// <returns></returns>

--- a/Source/Classes/Cache/InternalCache.cs
+++ b/Source/Classes/Cache/InternalCache.cs
@@ -46,9 +46,8 @@ namespace vsteam_lib
       internal void Update(IEnumerable<string> list, int minutesToExpire = 1)
       {
          this.MinutesToExpire = minutesToExpire;
-
-         // If a list is passed in use it. If not call Get-VSTeamProcess
-         if (null == list)
+         // If a list is passed in use it. If not, call the command we were given, provided we're logged on
+         if (null == list && !string.IsNullOrEmpty(Versions.Account))
          {
             if (this._requiresProject)
             {
@@ -77,7 +76,6 @@ namespace vsteam_lib
                                 .Invoke<string>();
             }
          }
-
          this.PreFill(list);
       }
 
@@ -91,9 +89,9 @@ namespace vsteam_lib
             {
                this.Values.Add(item);
             }
+            /// Only set the time stamp if a list was passed.
+            this._timeStamp = Math.Round(DateTime.UtcNow.TimeOfDay.TotalMinutes);
          }
-
-         this._timeStamp = Math.Round(DateTime.UtcNow.TimeOfDay.TotalMinutes);
       }
 
       internal IEnumerable<string> GetCurrent()

--- a/Source/Classes/Completer/ColorCompleter.cs
+++ b/Source/Classes/Completer/ColorCompleter.cs
@@ -1,0 +1,41 @@
+﻿using System.Management.Automation.Language;
+using System.Drawing;
+using System.Reflection;
+using System.Collections;
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+using System.Globalization;
+using System.Management.Automation;
+
+namespace vsteam_lib
+{
+    public class ColorCompleter  : IArgumentCompleter
+    {
+      [ExcludeFromCodeCoverage]
+      public ColorCompleter() : base() { }
+        public  IEnumerable<CompletionResult> CompleteArgument(string commandName, string parameterName, string wordToComplete, CommandAst commandAst, IDictionary fakeBoundParameters) 
+        {
+            var values = new List<CompletionResult>();
+            List<string> colorlist = new List<string>();
+            foreach (PropertyInfo p in typeof(Color).GetProperties() ) {
+                if (p.PropertyType == typeof(Color)) {
+                    colorlist.Add(p.Name);
+                }
+            }
+            SelectValues(wordToComplete, colorlist, values);
+            return values;
+        }
+        /// following module style.
+        protected static void SelectValues(string wordToComplete, IEnumerable<string> words, List<CompletionResult> values)
+        {
+             foreach (var word in words)
+            {
+                if (string.IsNullOrEmpty(wordToComplete) || word.StartsWith(wordToComplete, true, CultureInfo.InvariantCulture))
+                {
+                    // Only wrap in single quotes if they have a space. 
+                    values.Add(new CompletionResult(word.Contains(" ") ? $"'{word}'" : word));
+                }
+            }
+        }
+    }
+}

--- a/Source/Classes/Completer/IconCompleter.cs
+++ b/Source/Classes/Completer/IconCompleter.cs
@@ -1,0 +1,38 @@
+﻿using System.Collections;
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+using System.Management.Automation;
+using System.Management.Automation.Abstractions;
+using System.Management.Automation.Language;
+
+namespace vsteam_lib
+{
+   public class IconCompleter : BaseCompleter
+   {
+      /// <summary>
+      /// This constructor is used when running in a PowerShell session. It cannot be
+      /// loaded in a unit test.
+      /// </summary>
+      [ExcludeFromCodeCoverage]
+      public IconCompleter() : base() { }
+
+      /// <summary>
+      /// This constructor is used during unit testings
+      /// </summary>
+      /// <param name="powerShell">fake instance of IPowerShell used for testing</param>
+      public IconCompleter(IPowerShell powerShell) : base(powerShell) { }
+
+      public override IEnumerable<CompletionResult> CompleteArgument(string commandName,
+                                                                     string parameterName,
+                                                                     string wordToComplete,
+                                                                     CommandAst commandAst,
+                                                                     IDictionary fakeBoundParameters)
+      {
+         var values = new List<CompletionResult>();
+
+         SelectValues(wordToComplete, IconCache.GetCurrent(false), values);
+
+         return values;
+      }
+   }
+}

--- a/Source/Classes/Completer/WorkItemTypeCompleter.cs
+++ b/Source/Classes/Completer/WorkItemTypeCompleter.cs
@@ -1,21 +1,62 @@
 ﻿using System.Diagnostics.CodeAnalysis;
 using System.Management.Automation.Abstractions;
+using System.Collections;
+using System.Collections.Generic;
+using System.Management.Automation;
+using System.Management.Automation.Language;
 
 namespace vsteam_lib
 {
-   public class WorkItemTypeCompleter : BaseProjectCompleter
+   public class WorkItemTypeCompleter : BaseCompleter
    {
       /// <summary>
       /// This constructor is used when running in a PowerShell session. It cannot be
       /// loaded in a unit test.
       /// </summary>
       [ExcludeFromCodeCoverage]
-      public WorkItemTypeCompleter() : base("Get-VSTeamWorkItemType", "Name", false) { }
+      public WorkItemTypeCompleter() : base() { }
 
       /// <summary>
       /// This constructor is used during unit testings
       /// </summary>
       /// <param name="powerShell">fake instance of IPowerShell used for testing</param>
-      internal WorkItemTypeCompleter(IPowerShell powerShell) : base("Get-VSTeamWorkItemType", "Name", false, powerShell) { }
+      internal WorkItemTypeCompleter(IPowerShell powerShell) : base(powerShell) { }
+
+      public override IEnumerable<CompletionResult> CompleteArgument(string commandName,
+                                                                     string parameterName,
+                                                                     string wordToComplete,
+                                                                     CommandAst commandAst,
+                                                                     IDictionary fakeBoundParameters)
+      {
+         var values = new List<CompletionResult>();
+
+         // Can we use cached WorkItem types? Or has the user added
+         // -ProcessTemplate & given a template that isn't the default?
+         var ProcessTemplate  = fakeBoundParameters["ProcessTemplate"]?.ToString();
+         if (string.IsNullOrEmpty(ProcessTemplate) || ( ProcessTemplate == Versions.DefaultProcess) )
+         {
+            SelectValues(wordToComplete, WorkItemTypeCache.GetCurrent(), values);
+         }
+
+         else {
+            base._powerShell.Commands.Clear();
+            var wits = base._powerShell.AddCommand("Get-VsteamWorkItemType")
+                                         .AddParameter("ProcessTemplate", ProcessTemplate)
+                                         .AddCommand("Select-Object")
+                                         .AddParameter("ExpandProperty", "Name")
+                                         .AddCommand("Sort-Object")
+                                         .Invoke();
+            foreach (var w in wits)
+            {
+               string word = w.ToString();
+               if (string.IsNullOrEmpty(wordToComplete) || word.ToLower().StartsWith(wordToComplete.ToLower()))
+               {
+                  // Only wrap in single quotes if they have a space
+                  values.Add(new CompletionResult(word.Contains(" ") ? $"'{word}'" : word));
+               }
+            }
+         }
+         return values;
+      }
    }
 }

--- a/Source/Classes/Provider/Leaf.cs
+++ b/Source/Classes/Provider/Leaf.cs
@@ -24,6 +24,7 @@ namespace vsteam_lib.Provider
       public Leaf(PSObject obj, string name, string id, string projectName) : base(name)
       {
          Common.MoveProperties(this, obj);
+
          this.Id = id;
          this.InternalObject = obj;
          this.ProjectName = projectName;

--- a/Source/Classes/Provider/Leaf.cs
+++ b/Source/Classes/Provider/Leaf.cs
@@ -24,7 +24,6 @@ namespace vsteam_lib.Provider
       public Leaf(PSObject obj, string name, string id, string projectName) : base(name)
       {
          Common.MoveProperties(this, obj);
-
          this.Id = id;
          this.InternalObject = obj;
          this.ProjectName = projectName;

--- a/Source/Classes/Provider/Process.cs
+++ b/Source/Classes/Provider/Process.cs
@@ -1,4 +1,6 @@
-﻿using System.Management.Automation;
+﻿using System.Collections.Generic;
+using System.Linq;
+using System.Management.Automation;
 using System.Xml.Serialization;
 using vsteam_lib.Provider;
 
@@ -15,11 +17,13 @@ namespace vsteam_lib
       public string Type { get; set; }
       public string ProcessTemplate => this.Name;
       public string ParentProcessTypeId { get; set; }
-      public string[] Projects { get; set; }
+      public IEnumerable<string> Projects { get; }
 
       public Process(PSObject obj) :
          base(obj, obj.GetValue("name"), obj.GetValue("id"), null)
       {
+         this.Projects = obj.GetValue<object[]>("Projects")?.Select(o => o.ToString()).ToArray();
+
          // Depending on what API was used you might get and ID or a TypeId back.
          // If you get a TypeId you need to set the ID now
          if (string.IsNullOrEmpty(this.Id))

--- a/Source/Classes/Provider/Process.cs
+++ b/Source/Classes/Provider/Process.cs
@@ -15,6 +15,7 @@ namespace vsteam_lib
       public string Type { get; set; }
       public string ProcessTemplate => this.Name;
       public string ParentProcessTypeId { get; set; }
+      public string[] Projects { get; set; }
 
       public Process(PSObject obj) :
          base(obj, obj.GetValue("name"), obj.GetValue("id"), null)

--- a/Source/Classes/Provider/Process.cs
+++ b/Source/Classes/Provider/Process.cs
@@ -8,6 +8,7 @@ namespace vsteam_lib
    {
       public string TypeId { get; set; }
       public string Description { get; set; }
+      public string ReferenceName { get; set; }
       public bool IsEnabled { get; set; }
       public bool IsDefault { get; set; }
       [XmlAttribute("customizationType")]

--- a/Source/Classes/Versions.cs
+++ b/Source/Classes/Versions.cs
@@ -125,6 +125,8 @@ namespace vsteam_lib
       [ExcludeFromCodeCoverage]
       public static string DefaultTimeout { get; set; } = System.Environment.GetEnvironmentVariable("TEAM_TIMEOUT");
       [ExcludeFromCodeCoverage]
+      public static string DefaultProcess { get; set; } = System.Environment.GetEnvironmentVariable("TEAM_PROCESS");
+      [ExcludeFromCodeCoverage]
       public static string DefaultProject { get; set; } = System.Environment.GetEnvironmentVariable("TEAM_PROJECT");
       [ExcludeFromCodeCoverage]
       public static string Version { get; set; } = System.Environment.GetEnvironmentVariable("TEAM_VERSION") ?? "TFS2017";

--- a/Source/Private/common.ps1
+++ b/Source/Private/common.ps1
@@ -966,3 +966,25 @@ function _getDescriptorForACL {
 
    return $descriptor
 }
+
+$script:processTypeIds = @{}
+function _getProcessTemplateUrl {
+   Param (
+      [Parameter(Mandatory=$true,position=0)]
+      $ProcessTemplate
+   )
+   if ($script:processTypeIds[$ProcessTemplate]) {
+         return ((_getInstance) + "/_apis/work/processes/" + $script:processTypeIds[$ProcessTemplate] )
+   }
+   else {
+      $p = Get-VSTeamProcess $ProcessTemplate
+      if ($p -and $p.psobject.properties['typeID']) {
+         $script:processTypeIds[$ProcessTemplate] = $p.typeid
+         return ((_getInstance) + "/_apis/work/processes/" + $p.typeid )
+      }
+      elseif ($p -and $p.psobject.properties['Id']) {
+         $script:processTypeIds[$ProcessTemplate] = $p.Id
+         return ((_getInstance) + "/_apis/work/processes/" + $p.Id )
+      }
+   }
+}

--- a/Source/Public/Add-VSTeamWorkItemState.ps1
+++ b/Source/Public/Add-VSTeamWorkItemState.ps1
@@ -29,7 +29,7 @@ function Add-VSTeamWorkItemState {
       foreach ($result in (Get-VSTeamWorkItemType -ProcessTemplate $ProcessTemplate -WorkItemType $WorkItemType)) {
          if ($Force -or $PSCmdlet.ShouldProcess("$($result.name) in process template '$ProcessTemplate'", "Add new state '$name' to WorkItem type")) {
             # if it  is a system one we need to make it an inherited one
-            
+
             if ($result.customization -eq 'system') {
                $url = ($result.url -replace '/workItemTypes/.*$', '/workItemTypes?api-version=') + (_getApiVersion Processes)
                $body = @{
@@ -40,24 +40,25 @@ function Add-VSTeamWorkItemState {
                   isDisabled   = $result.isDisabled
                   name         = $result.name
                }
-               $result = _callAPI -Url $url -method Post -ContentType   "application/json" -body (ConvertTo-Json $body)
+               $result = _callAPI -method Post -Url $url -body (ConvertTo-Json $body)
             }
             $url = $result.url + '/states?api-version=' + (_getApiVersion Processes)
-         
-            $body = @{'stateCategory' = $StateCategory
-               'name'                 = $Name
-               'color'                = $Color
+
+            $body = @{
+               'stateCategory' = $StateCategory
+               'name'          = $Name
+               'color'         = $Color
             }
-         
+
             if ($PSBoundParameters.ContainsKey('Order')) {
-               $body['order'] = $Order 
+               $body['order']  = $Order
             }
-         
+
             $resp = _callAPI -Url $url -method Post -ContentType "application/json" -body (ConvertTo-Json $body)
-         
+
             $resp.psobject.TypeNames.Insert(0, 'vsteam_lib.WorkItemState')
             Add-Member -InputObject $resp -MemberType NoteProperty -Name ProcessTemplate -Value $ProcessTemplate
-            Add-Member -InputObject $resp -MemberType NoteProperty -Name WorkItemType    -Value $result.name 
+            Add-Member -InputObject $resp -MemberType NoteProperty -Name WorkItemType    -Value $result.name
 
             Write-Output $resp
          }

--- a/Source/Public/Add-VSTeamWorkItemState.ps1
+++ b/Source/Public/Add-VSTeamWorkItemState.ps1
@@ -1,0 +1,66 @@
+function Add-VSTeamWorkItemState {
+   [CmdletBinding(SupportsShouldProcess = $true, ConfirmImpact = 'High')]
+   param(
+      [parameter(ValueFromPipelineByPropertyName = $true)]
+      [vsteam_lib.ProcessTemplateValidateAttribute()]
+      [ArgumentCompleter([vsteam_lib.ProcessTemplateCompleter])]
+      $ProcessTemplate = $env:TEAM_PROCESS,
+
+      [parameter(Mandatory = $true, ValueFromPipelineByPropertyName = $true, Position = 0)]
+      [ArgumentCompleter([vsteam_lib.WorkItemTypeCompleter])]
+      $WorkItemType,
+
+      [parameter(Mandatory = $true, Position = 1)]
+      [string]$Name,
+
+      [ValidateSet('Proposed', 'InProgress', 'Resolved', 'Completed', 'Removed')]
+      [string]$StateCategory = 'InProgress',
+
+      [ArgumentCompleter([vsteam_lib.ColorCompleter])]
+      [vsteam_lib.ColorTransformToHexAttribute()]
+      [string]$Color = '7f7f7f',
+
+      [int]$Order,
+
+      [switch]$Force
+   )
+   process {
+      #Allow the -workitemType parameter to be a wild card -for each workItem type to be updated...
+      foreach ($result in (Get-VSTeamWorkItemType -ProcessTemplate $ProcessTemplate -WorkItemType $WorkItemType)) {
+         if ($Force -or $PSCmdlet.ShouldProcess("$($result.name) in process template '$ProcessTemplate'", "Add new state '$name' to WorkItem type")) {
+            # if it  is a system one we need to make it an inherited one
+            
+            if ($result.customization -eq 'system') {
+               $url = ($result.url -replace '/workItemTypes/.*$', '/workItemTypes?api-version=') + (_getApiVersion Processes)
+               $body = @{
+                  color        = $result.color
+                  description  = $result.description
+                  icon         = $result.icon
+                  inheritsFrom = $result.referenceName
+                  isDisabled   = $result.isDisabled
+                  name         = $result.name
+               }
+               $result = _callAPI -Url $url -method Post -ContentType   "application/json" -body (ConvertTo-Json $body)
+            }
+            $url = $result.url + '/states?api-version=' + (_getApiVersion Processes)
+         
+            $body = @{'stateCategory' = $StateCategory
+               'name'                 = $Name
+               'color'                = $Color
+            }
+         
+            if ($PSBoundParameters.ContainsKey('Order')) {
+               $body['order'] = $Order 
+            }
+         
+            $resp = _callAPI -Url $url -method Post -ContentType "application/json" -body (ConvertTo-Json $body)
+         
+            $resp.psobject.TypeNames.Insert(0, 'vsteam_lib.WorkItemState')
+            Add-Member -InputObject $resp -MemberType NoteProperty -Name ProcessTemplate -Value $ProcessTemplate
+            Add-Member -InputObject $resp -MemberType NoteProperty -Name WorkItemType    -Value $result.name 
+
+            Write-Output $resp
+         }
+      }
+   }
+}

--- a/Source/Public/Add-VSTeamWorkItemType.ps1
+++ b/Source/Public/Add-VSTeamWorkItemType.ps1
@@ -1,11 +1,12 @@
 function Add-VSTeamWorkItemType {
    [cmdletbinding(SupportsShouldProcess=$true)]
    param(
+      [Parameter(Position=0, ValueFromPipelineByPropertyName = $true)]
       [vsteam_lib.ProcessTemplateValidateAttribute()]
       [ArgumentCompleter([vsteam_lib.ProcessTemplateCompleter])]
       $ProcessTemplate = $env:TEAM_PROCESS,
 
-      [parameter(Mandatory = $true)]
+      [parameter(Mandatory = $true,Position=1)]
       [Alias('Name')]
       [string] $WorkItemType,
 

--- a/Source/Public/Add-VSTeamWorkItemType.ps1
+++ b/Source/Public/Add-VSTeamWorkItemType.ps1
@@ -21,36 +21,38 @@ function Add-VSTeamWorkItemType {
       [string]$Icon = 'icon_asterisk'
    )
    process {
-      $url =  _getProcessTemplateUrl $ProcessTemplate
-      if ($url) {$url += "/workitemtypes?api-version=" + (_getApiVersion Processes)}
-      else      {Write-Warning "Could not convert '$ProcessTemplate' into a process template"; return}
+      #Allow additions to more than one ProcessTemplate
+      foreach ($pt in $ProcessTemplate) {
+         $url =  _getProcessTemplateUrl $pt
+         if ($url) {$url += "/workitemtypes?api-version=" + (_getApiVersion Processes)}
+         else      {Write-Warning "Could not convert '$pt' into a process template"; return}
 
-      $body  = @{
-         name  = $WorkItemType
-         color = $Color
-         icon  = $Icon
-      }
-      if ($Description)  {$body['description'] =$Description }
-
-      if ($PSCmdlet.ShouldProcess($ProcessTemplate, "Add workitem '$WorkItemType' to process template"))  {
-         # Call the Rest API. _callAPi displays errors for the user and throws,
-         # if this happens half way through adding to mulitple process templates
-         # don't stop with some done and some not.
-         try {
-            $resp = _callapi -Url $url -method  Post -body (ConvertTo-Json $body) -ErrorAction Stop
+         $body  = @{
+            name  = $WorkItemType
+            color = $Color
+            icon  = $Icon
          }
-         catch {
-            Write-Warning "An error occured trying to add a workitem type to Process template '$ProcessTemplate'"
-            return
+         if ($Description)  {$body['description'] =$Description }
+
+         if ($PSCmdlet.ShouldProcess($pt, "Add workitem '$WorkItemType' to process template"))  {
+            # Call the Rest API. _callAPi displays errors for the user and throws,
+            # if this happens half way through adding to mulitple process templates
+            # don't stop with some done and some not.
+            try {
+               $resp = _callapi -Url $url -method  Post -body (ConvertTo-Json $body) -ErrorAction Stop
+            }
+            catch {
+               Write-Warning "An error occured trying to add a workitem type to Process template '$pt'"
+               continue
+            }
+            if ($pt -eq $env:TEAM_PROCESS) {[vsteam_lib.WorkItemTypeCache]::Invalidate()}
+
+            $resp.PSObject.TypeNames.Insert(0, 'vsteam_lib.WorkItemType')
+            Add-Member -InputObject $resp -MemberType AliasProperty -Name WorkItemType    -Value "name"
+            Add-Member -InputObject $resp -MemberType NoteProperty  -Name ProcessTemplate -Value $pt
+
+            Write-Output $resp
          }
-         if ($ProcessTemplate -eq $env:TEAM_PROCESS) {[vsteam_lib.WorkItemTypeCache]::Invalidate()}
-
-         $resp.PSObject.TypeNames.Insert(0, 'vsteam_lib.WorkItemType')
-         Add-Member -InputObject $resp -MemberType AliasProperty -Name WorkItemType    -Value "name"
-         Add-Member -InputObject $resp -MemberType NoteProperty  -Name ProcessTemplate -Value $ProcessTemplate
-
-         return $resp
-
       }
    }
 }

--- a/Source/Public/Add-VSTeamWorkItemType.ps1
+++ b/Source/Public/Add-VSTeamWorkItemType.ps1
@@ -1,25 +1,3 @@
-$script:processTypeIds = @{}
-function _getProcessTemplateUrl {
-   Param (
-      [Parameter(Mandatory=$true,position=0)]
-      $ProcessTemplate
-   )
-   if ($script:processTypeIds[$ProcessTemplate]) {
-         return ((_getInstance) + "/_apis/work/processes/" + $script:processTypeIds[$ProcessTemplate] )
-   }
-   else {
-      $p = Get-VSTeamProcess $ProcessTemplate
-      if ($p -and $p.psobject.properties['typeID']) {
-         $script:processTypeIds[$ProcessTemplate] = $p.typeid
-         return ((_getInstance) + "/_apis/work/processes/" + $p.typeid )
-      }
-      elseif ($p -and $p.psobject.properties['Id']) {
-         $script:processTypeIds[$ProcessTemplate] = $p.Id
-         return ((_getInstance) + "/_apis/work/processes/" + $p.Id )
-      }
-   }
-}
-
 function Add-VSTeamWorkItemType {
    [cmdletbinding(SupportsShouldProcess=$true)]
    param(
@@ -45,14 +23,14 @@ function Add-VSTeamWorkItemType {
    $url =  _getProcessTemplateUrl $ProcessTemplate
    if ($url) {$url += "/workitemtypes?api-version=" + (_getApiVersion Processes)}
    else      {Write-Warning "Could not convert '$ProcessTemplate' into a process template"; return}
-   
+
    $body  = @{
       name  = $WorkItemType
-      color = $Color 
+      color = $Color
       icon  = $Icon
    }
    if ($Description)  {$body['description'] =$Description }
-   
+
    if ($PSCmdlet.ShouldProcess($ProcessTemplate, "Add workitem '$WorkItemType' to process template"))  {
       $resp = _callapi -Url $url -method  Post  -ContentType "application/json" -body (ConvertTo-Json $body) -erroraction stop
       if ($resp) {

--- a/Source/Public/Add-VSTeamWorkItemType.ps1
+++ b/Source/Public/Add-VSTeamWorkItemType.ps1
@@ -32,7 +32,7 @@ function Add-VSTeamWorkItemType {
    if ($Description)  {$body['description'] =$Description }
 
    if ($PSCmdlet.ShouldProcess($ProcessTemplate, "Add workitem '$WorkItemType' to process template"))  {
-      $resp = _callapi -Url $url -method  Post  -ContentType "application/json" -body (ConvertTo-Json $body) -erroraction stop
+      $resp = _callapi -Url $url -method  Post -body (ConvertTo-Json $body) -ErrorAction Stop
       if ($resp) {
          if ($ProcessTemplate -eq $env:TEAM_PROCESS) {[vsteam_lib.WorkItemTypeCache]::Invalidate()}
 

--- a/Source/Public/Add-VSTeamWorkItemType.ps1
+++ b/Source/Public/Add-VSTeamWorkItemType.ps1
@@ -20,28 +20,29 @@ function Add-VSTeamWorkItemType {
       [ArgumentCompleter([vsteam_lib.IconCompleter])]
       [string]$Icon = 'icon_asterisk'
    )
+   process {
+      $url =  _getProcessTemplateUrl $ProcessTemplate
+      if ($url) {$url += "/workitemtypes?api-version=" + (_getApiVersion Processes)}
+      else      {Write-Warning "Could not convert '$ProcessTemplate' into a process template"; return}
 
-   $url =  _getProcessTemplateUrl $ProcessTemplate
-   if ($url) {$url += "/workitemtypes?api-version=" + (_getApiVersion Processes)}
-   else      {Write-Warning "Could not convert '$ProcessTemplate' into a process template"; return}
+      $body  = @{
+         name  = $WorkItemType
+         color = $Color
+         icon  = $Icon
+      }
+      if ($Description)  {$body['description'] =$Description }
 
-   $body  = @{
-      name  = $WorkItemType
-      color = $Color
-      icon  = $Icon
-   }
-   if ($Description)  {$body['description'] =$Description }
+      if ($PSCmdlet.ShouldProcess($ProcessTemplate, "Add workitem '$WorkItemType' to process template"))  {
+         $resp = _callapi -Url $url -method  Post -body (ConvertTo-Json $body) -ErrorAction Stop
+         if ($resp) {
+            if ($ProcessTemplate -eq $env:TEAM_PROCESS) {[vsteam_lib.WorkItemTypeCache]::Invalidate()}
 
-   if ($PSCmdlet.ShouldProcess($ProcessTemplate, "Add workitem '$WorkItemType' to process template"))  {
-      $resp = _callapi -Url $url -method  Post -body (ConvertTo-Json $body) -ErrorAction Stop
-      if ($resp) {
-         if ($ProcessTemplate -eq $env:TEAM_PROCESS) {[vsteam_lib.WorkItemTypeCache]::Invalidate()}
+            $resp.PSObject.TypeNames.Insert(0, 'vsteam_lib.WorkItemType')
+            Add-Member -InputObject $resp -MemberType AliasProperty -Name WorkItemType    -Value "name"
+            Add-Member -InputObject $resp -MemberType NoteProperty  -Name ProcessTemplate -Value $ProcessTemplate
 
-         $resp.PSObject.TypeNames.Insert(0, 'vsteam_lib.WorkItemType')
-         Add-Member -InputObject $resp -MemberType AliasProperty -Name WorkItemType    -Value "name"
-         Add-Member -InputObject $resp -MemberType NoteProperty  -Name ProcessTemplate -Value $ProcessTemplate
-
-         return $resp
+            return $resp
+         }
       }
    }
 }

--- a/Source/Public/Add-VSTeamWorkItemType.ps1
+++ b/Source/Public/Add-VSTeamWorkItemType.ps1
@@ -1,0 +1,68 @@
+$script:processTypeIds = @{}
+function _getProcessTemplateUrl {
+   Param (
+      [Parameter(Mandatory=$true,position=0)]
+      $ProcessTemplate
+   )
+   if ($script:processTypeIds[$ProcessTemplate]) {
+         return ((_getInstance) + "/_apis/work/processes/" + $script:processTypeIds[$ProcessTemplate] )
+   }
+   else {
+      $p = Get-VSTeamProcess $ProcessTemplate
+      if ($p -and $p.psobject.properties['typeID']) {
+         $script:processTypeIds[$ProcessTemplate] = $p.typeid
+         return ((_getInstance) + "/_apis/work/processes/" + $p.typeid )
+      }
+      elseif ($p -and $p.psobject.properties['Id']) {
+         $script:processTypeIds[$ProcessTemplate] = $p.Id
+         return ((_getInstance) + "/_apis/work/processes/" + $p.Id )
+      }
+   }
+}
+
+function Add-VSTeamWorkItemType {
+   [cmdletbinding(SupportsShouldProcess=$true)]
+   param(
+      [vsteam_lib.ProcessTemplateValidateAttribute()]
+      [ArgumentCompleter([vsteam_lib.ProcessTemplateCompleter])]
+      $ProcessTemplate = $env:TEAM_PROCESS,
+
+      [parameter(Mandatory = $true)]
+      [Alias('Name')]
+      [string] $WorkItemType,
+
+      [string] $Description,
+
+      [ArgumentCompleter([vsteam_lib.ColorCompleter])]
+      [vsteam_lib.ColorTransformToHexAttribute()]
+      $Color = '000000',
+
+      [vsteam_lib.IconTransformAttribute()]
+      [ArgumentCompleter([vsteam_lib.IconCompleter])]
+      [string]$Icon = 'icon_asterisk'
+   )
+
+   $url =  _getProcessTemplateUrl $ProcessTemplate
+   if ($url) {$url += "/workitemtypes?api-version=" + (_getApiVersion Processes)}
+   else      {Write-Warning "Could not convert '$ProcessTemplate' into a process template"; return}
+   
+   $body  = @{
+      name  = $WorkItemType
+      color = $Color 
+      icon  = $Icon
+   }
+   if ($Description)  {$body['description'] =$Description }
+   
+   if ($PSCmdlet.ShouldProcess($ProcessTemplate, "Add workitem '$WorkItemType' to process template"))  {
+      $resp = _callapi -Url $url -method  Post  -ContentType "application/json" -body (ConvertTo-Json $body) -erroraction stop
+      if ($resp) {
+         if ($ProcessTemplate -eq $env:TEAM_PROCESS) {[vsteam_lib.WorkItemTypeCache]::Invalidate()}
+
+         $resp.PSObject.TypeNames.Insert(0, 'vsteam_lib.WorkItemType')
+         Add-Member -InputObject $resp -MemberType AliasProperty -Name WorkItemType    -Value "name"
+         Add-Member -InputObject $resp -MemberType NoteProperty  -Name ProcessTemplate -Value $ProcessTemplate
+
+         return $resp
+      }
+   }
+}

--- a/Source/Public/Get-VSTeamWorkItemIconList.ps1
+++ b/Source/Public/Get-VSTeamWorkItemIconList.ps1
@@ -1,0 +1,18 @@
+function Get-VSTeamWorkItemIconList {
+   [CmdletBinding()]
+   param()
+
+   process {
+
+      $commonArgs = @{
+         Area                 = 'wit' 
+         Resource             = 'workitemicons'
+         IgnoreDefaultProject = $true
+         Version              = $(_getApiVersion Processes)
+      }
+      # Call the REST API
+      $resp = _callAPI @commonArgs 
+
+      Write-Output $resp.value
+   }
+}

--- a/Source/Public/Get-VSTeamWorkItemState.ps1
+++ b/Source/Public/Get-VSTeamWorkItemState.ps1
@@ -1,0 +1,24 @@
+function Get-VsteamWorkItemState {
+   [CmdletBinding()]
+   param(
+      [parameter(ValueFromPipelineByPropertyName=$true)]
+      [vsteam_lib.ProcessTemplateValidateAttribute()]
+      [ArgumentCompleter([vsteam_lib.ProcessTemplateCompleter])]
+      $ProcessTemplate = $env:TEAM_PROCESS,
+
+      [parameter(Mandatory = $true,ValueFromPipelineByPropertyName=$true, Position=1)]
+      [ArgumentCompleter([vsteam_lib.WorkItemTypeCompleter])]
+      $WorkItemType
+   )
+   process {
+      foreach ($result in (Get-VSTeamWorkItemType -ProcessTemplate $ProcessTemplate -WorkItemType $WorkItemType -Expand States)) {
+         $resp = $result.States | Sort-Object -Property Order
+         foreach ($r in $resp) {
+            $r.psobject.TypeNames.Insert(0,'vsteam_lib.WorkItemState')
+            Add-Member -InputObject $r -MemberType NoteProperty -Name ProcessTemplate -Value $ProcessTemplate
+            Add-Member -InputObject $r -MemberType NoteProperty -Name WorkItemType    -Value $result.name 
+         }
+         Write-Output $resp 
+      }
+   }
+}

--- a/Source/Public/Get-VSTeamWorkItemState.ps1
+++ b/Source/Public/Get-VSTeamWorkItemState.ps1
@@ -11,14 +11,26 @@ function Get-VsteamWorkItemState {
       $WorkItemType
    )
    process {
-      foreach ($result in (Get-VSTeamWorkItemType -ProcessTemplate $ProcessTemplate -WorkItemType $WorkItemType -Expand States)) {
-         $resp = $result.States | Sort-Object -Property Order
+      $wit = $null
+      #If $workItemtype contains an object, use it if it was expanded to avoid calling the API again
+      if ($WorkItemType.psobject.TypeNames.Contains('vsteam_lib.WorkItemType')) {
+         if ($WorkItemType.psobject.Properties['states']) {
+            $wit = $WorkItemType
+         }
+         else {
+            $WorkItemType = $workItemType.name
+            $ProcessTemplate = $WorkItemType.ProcessTemplate
+         }
+      }
+      if (-not $wit) {$wit = Get-VSTeamWorkItemType -ProcessTemplate $ProcessTemplate -WorkItemType  $WorkItemType -Expand states}
+      foreach ($w in $wit) {
+         $resp = $w.States | Sort-Object -Property Order
          foreach ($r in $resp) {
             $r.psobject.TypeNames.Insert(0,'vsteam_lib.WorkItemState')
-            Add-Member -InputObject $r -MemberType NoteProperty -Name ProcessTemplate -Value $ProcessTemplate
-            Add-Member -InputObject $r -MemberType NoteProperty -Name WorkItemType    -Value $result.name 
+            Add-Member -InputObject $r -MemberType NoteProperty -Name ProcessTemplate -Value $w.ProcessTemplate
+            Add-Member -InputObject $r -MemberType NoteProperty -Name WorkItemType    -Value $w.name
          }
-         Write-Output $resp 
+         Write-Output $resp
       }
    }
 }

--- a/Source/Public/Get-VSTeamWorkItemType.ps1
+++ b/Source/Public/Get-VSTeamWorkItemType.ps1
@@ -58,35 +58,39 @@ function Get-VSTeamWorkItemType {
             Add-Member -InputObject $item  -MemberType NoteProperty -Name "Hidden" -Value ($item.name -in $hidden)
          }
          if ($NotHidden.IsPresent) {
-            $resp = $resp | Where-Object -not Hidden
+            $result = $resp | Where-Object -not Hidden
+         }
+         else {
+            $result = $resp
          }
          if ($ProjectName -eq $env:TEAM_PROJECT -and $env:TEAM_PROCESS) {$ProcessTemplate = $env:TEAM_PROCESS}
+         if ($ProcessTemplate) {
+            $result | Add-Member -MemberType NoteProperty  -Name "ProcessTemplate" -Value $ProcessTemplate
+         }
       }
       else {
-         $url = _getProcessTemplateUrl $ProcessTemplate
-         if (-not $url) {Write-Warning "Could not find the Process for '$ProcessTemplate" ; return}
-         else           { $url += "/workitemtypes?api-version=" + (_getApiVersion Processes)}
-
-         if ($Expand) { $resp = _callAPI -Url $url -QueryString @{'$expand' = ($Expand -Join ',').ToLower() }    }
-         else         { $resp = _callapi -Url $url }
-
-         $resp = $resp.value
+         $result = @()
+         foreach ($pt in $ProcessTemplate) {
+            $url = _getProcessTemplateUrl $pt
+            if (-not $url) {Write-Warning "Could not find the Process for '$pt" ; continuye}
+            else           { $url += "/workitemtypes?api-version=" + (_getApiVersion Processes)}
+            if ($Expand) { $resp = _callAPI -Url $url -QueryString @{'$expand' = ($Expand -Join ',').ToLower() }    }
+            else         { $resp = _callapi -Url $url }
+            $resp.value | Add-Member -MemberType NoteProperty  -Name "ProcessTemplate" -Value $pt
+            $result += $resp.value
+         }
       }
-
       <# Apply a Type Name so we can use custom format view and custom type extensions
          add an alias so that workitemType can become a parameter when the object is piped into other functions
          and the processTemplate name (if there is one) for the same reason.
          And finally return the items, filtered to any name we given
       #>
-      foreach ($item in $resp) {
+      foreach ($item in $result) {
          _applyTypesWorkItemType -item $item
          Add-Member    -InputObject $item -MemberType AliasProperty -Name "WorkItemType"    -Value "name"
-         if ($ProcessTemplate) {
-            Add-Member -InputObject $item -MemberType NoteProperty  -Name "ProcessTemplate" -Value $ProcessTemplate
-         }
       }
-      #Allow the $WorkItemType to contain wild cards and multiple items, by converting to regex
+      #Allow the $WorkItemType to contain wild cards AND multiple items, by converting to regex
       $regex = "^" + ($WorkItemType -replace '\*','.*' -replace '\?','.' -join '$|^') + '$'
-      return ($resp | Where-Object -Property Name -match $regex)
+      return ($result | Where-Object -Property Name -match $regex)
    }
 }

--- a/Source/Public/Get-VSTeamWorkItemType.ps1
+++ b/Source/Public/Get-VSTeamWorkItemType.ps1
@@ -2,50 +2,83 @@ function Get-VSTeamWorkItemType {
    [CmdletBinding(DefaultParameterSetName = 'List',
     HelpUri='https://methodsandpractices.github.io/vsteam-docs/docs/modules/vsteam/commands/Get-VSTeamWorkItemType')]
    param(
-      [Parameter(Mandatory = $true, ValueFromPipelineByPropertyName = $true)]
+      [Parameter(ParameterSetName = 'List',  Mandatory = $true, ValueFromPipelineByPropertyName = $true)]
+      [parameter(ParameterSetName='Process', Mandatory = $false)]
       [vsteam_lib.ProjectValidateAttribute($false)]
       [ArgumentCompleter([vsteam_lib.ProjectCompleter])]
       [string] $ProjectName,
 
+      [parameter(ParameterSetName='Process', Mandatory = $true , ValueFromPipelineByPropertyName = $true)]
+      [vsteam_lib.ProcessTemplateValidateAttribute()]
+      [ArgumentCompleter([vsteam_lib.ProcessTemplateCompleter])]
+      $ProcessTemplate,
+
       [Parameter()]
-      [vsteam_lib.WorkItemTypeValidateAttribute()]
       [ArgumentCompleter([vsteam_lib.WorkItemTypeCompleter])]
-      [string] $WorkItemType
+      [string] $WorkItemType = '*',
+
+      [parameter(ParameterSetName='Process',ValueFromPipelineByPropertyName=$true)]
+      [ValidateSet('behaviors','layout','states')]
+      [string[]]$Expand
    )
 
-   Process {
-      # Call the REST API
+   process {
+      <# Call the REST API in one of 2 ways; 
+        if process template is given, then call as work/processes/workitemtypes (this API doesn't take a workitem ID, and so always returns multiple values)
+        otherwise call as wit/workitemtypes  (JSON needs special conversion and contains mutliple  values)
+        DON'T validate $workitem type and call with wit/workitemtypes/name - instead allow wildcards and filter down  the workitem(s) will be in $resp after the IF / ELSE 
+      #>
       $commonArgs = @{
          ProjectName = $ProjectName
          Area        = 'wit'
          Resource    = 'workitemtypes'
          Version     = $(_getApiVersion Core)
       }
-
-      if ($WorkItemType) {
-         $resp = _callAPI @commonArgs -id $WorkItemType
-
-         # This call returns JSON with "": which causes the ConvertFrom-Json to fail.
-         # To replace all the "": with "_end":
-         $resp = $resp.Replace('"":', '"_end":') | ConvertFrom-Json
-
-         _applyTypesWorkItemType -item $resp
-
-         return $resp
-      }
-      else {
+      if (-not $ProcessTemplate) {
          $resp = _callAPI @commonArgs
 
          # This call returns JSON with "": which causes the ConvertFrom-Json to fail.
          # To replace all the "": with "_end":
-         $resp = $resp.Replace('"":', '"_end":') | ConvertFrom-Json
+         $resp = $resp.Replace('"":', '"_end":') | ConvertFrom-Json | Select-Object -ExpandProperty Value
 
-         # Apply a Type Name so we can use custom format view and custom type extensions
-         foreach ($item in $resp.value) {
-            _applyTypesWorkItemType -item $item
+         #Find Workitem-Types that are hidden in this project 
+         #(they may be visible in others using the same process template)
+         $commonArgs.Resource = 'workitemtypecategories'
+         $resp2  = _callAPI @commonArgs
+         if (-not $resp2) {$hidden = @() }
+         else             {$hidden = $resp2.value.where({$_.referencename -eq "Microsoft.HiddenCategory"}).workitemtypes.name}
+
+         #Add a property named "hidden" to workitem types, so we can filter pick-lists to visible itmes only later.
+         foreach ($item in $resp) {
+            Add-Member -InputObject $item  -MemberType NoteProperty -Name "Hidden" -Value ($item.name -in $hidden)
          }
 
-         return $resp.value
+         if ($ProjectName -eq $env:TEAM_PROJECT -and $env:TEAM_PROCESS) {$ProcessTemplate = $env:TEAM_PROCESS}
       }
+      else {  
+         $url = _getProcessTemplateUrl $ProcessTemplate
+         if (-not $url) {Write-Warning "Could not find the Process for '$ProcessTemplate" ; return}
+         else           { $url += "/workitemtypes?api-version=" + (_getApiVersion Processes)}
+         
+         if ($Expand) { $resp = _callAPI -Url $url -QueryString @{'$expand' = ($Expand -Join ',').ToLower() }    }
+         else         { $resp = _callapi -Url $url }
+
+         $resp = $resp.value 
+      }
+
+      <# Apply a Type Name so we can use custom format view and custom type extensions
+         add an alias so that workitemType can become a parameter when the object is piped into other functions
+         and the processTemplate name (if there is one) for the same reason. 
+         And finally return the items, filtered to any name we given
+      #>
+      foreach ($item in $resp) {
+         _applyTypesWorkItemType -item $item
+         Add-Member    -InputObject $item -MemberType AliasProperty -Name "WorkItemType"    -Value "name"
+         if ($ProcessTemplate) {
+            Add-Member -InputObject $item -MemberType NoteProperty  -Name "ProcessTemplate" -Value $ProcessTemplate
+         }
+      }
+
+      return ($resp | Where-Object -Property Name -like $WorkItemType)
    }
 }

--- a/Source/Public/Get-VSTeamWorkItemType.ps1
+++ b/Source/Public/Get-VSTeamWorkItemType.ps1
@@ -15,7 +15,7 @@ function Get-VSTeamWorkItemType {
 
       [Parameter(Position=0)]
       [ArgumentCompleter([vsteam_lib.WorkItemTypeCompleter])]
-      [string] $WorkItemType = '*',
+      [string[]] $WorkItemType = '*',
 
       [parameter(ParameterSetName='Process',ValueFromPipelineByPropertyName=$true)]
       [ValidateSet('behaviors','layout','states')]
@@ -85,7 +85,8 @@ function Get-VSTeamWorkItemType {
             Add-Member -InputObject $item -MemberType NoteProperty  -Name "ProcessTemplate" -Value $ProcessTemplate
          }
       }
-
-      return ($resp | Where-Object -Property Name -like $WorkItemType)
+      #Allow the $WorkItemType to contain wild cards and multiple items, by converting to regex
+      $regex = "^" + ($WorkItemType -replace '\*','.*' -replace '\?','.' -join '$|^') + '$'
+      return ($resp | Where-Object -Property Name -match $regex)
    }
 }

--- a/Source/Public/Hide-VSTeamWorkItemState.ps1
+++ b/Source/Public/Hide-VSTeamWorkItemState.ps1
@@ -1,0 +1,49 @@
+
+function Hide-VsteamWorkItemState {
+   [CmdletBinding(SupportsShouldProcess=$true,ConfirmImpact='High')]
+   param(
+      [parameter(ValueFromPipelineByPropertyName=$true)]
+      [vsteam_lib.ProcessTemplateValidateAttribute()]
+      [ArgumentCompleter([vsteam_lib.ProcessTemplateCompleter])]
+      $ProcessTemplate = $env:TEAM_PROCESS,
+
+      [parameter(Mandatory = $true,ValueFromPipelineByPropertyName=$true, Position=0)]
+      [ArgumentCompleter([vsteam_lib.WorkItemTypeCompleter])]
+      $WorkItemType,
+
+      [Parameter(ValueFromPipeline=$true,Mandatory=$true,ValueFromPipelineByPropertyName=$true,position=0)]
+      $Name,
+
+      [Switch]$Force
+   )
+   process {
+      # WorkitemType can be a wildcard and we might have an array or wildcard in Name, 
+      # so get matching WorkItemTypes, loop through them and through names, get matching states(s) and loop through those.
+      foreach ($result in (Get-VSTeamWorkItemType -ProcessTemplate $ProcessTemplate -WorkItemType $WorkItemType -Expand states)){
+         foreach ($n in $Name) {
+            #Check we have at least one matching state
+            $state = $result.states| Where-Object {$_.Name -like $n -and $_.customizationType -eq 'system'}
+            if (-not $State) {
+               Write-Warning "'$n' does not match a system state for the WorkItem type '$($result.name)'."
+            }
+            else {
+               foreach ($s in $state) {
+                  # Hidden states have a second version to hide between so check that doesn't exist for each found state
+                  if ($resp.states| Where-Object {$_.Name -eq $s.Name -and $_.hidden}) {
+                     Write-Warning "'$($s.name)' is already hidden for the WorkItem type '$($result.name)'."
+                  }
+                  elseif ($Force -or $PSCmdlet.ShouldProcess("$($result.name) in process template '$ProcessTemplate'", "Hide state '$($s.name)' from WorkItem type")) {
+                     $url  = "{0}/states/{1}?api-version={2}" -f $result.url, $s.id, (_getApiVersion Processes) 
+                     $resp = _callAPI -Url $url -method Put -body '{"hidden":true}' -ContentType "application/json"
+                     $resp.psobject.TypeNames.Insert(0,'vsteam_lib.WorkItemState')
+                     Add-Member -InputObject $resp -MemberType NoteProperty -Name ProcessTemplate -Value $ProcessTemplate
+                     Add-Member -InputObject $resp -MemberType NoteProperty -Name WorkItemType    -Value $result.name 
+
+                     Write-Output $resp
+                  }
+               }
+            }
+         }
+      }
+   }
+}

--- a/Source/Public/Hide-VSTeamWorkItemState.ps1
+++ b/Source/Public/Hide-VSTeamWorkItemState.ps1
@@ -17,30 +17,43 @@ function Hide-VsteamWorkItemState {
       [Switch]$Force
    )
    process {
-      # WorkitemType can be a wildcard and we might have an array or wildcard in Name, 
-      # so get matching WorkItemTypes, loop through them and through names, get matching states(s) and loop through those.
-      foreach ($result in (Get-VSTeamWorkItemType -ProcessTemplate $ProcessTemplate -WorkItemType $WorkItemType -Expand states)){
-         foreach ($n in $Name) {
-            #Check we have at least one matching state
-            $state = $result.states| Where-Object {$_.Name -like $n -and $_.customizationType -eq 'system'}
-            if (-not $State) {
-               Write-Warning "'$n' does not match a system state for the WorkItem type '$($result.name)'."
-            }
-            else {
-               foreach ($s in $state) {
-                  # Hidden states have a second version to hide between so check that doesn't exist for each found state
-                  if ($resp.states| Where-Object {$_.Name -eq $s.Name -and $_.hidden}) {
-                     Write-Warning "'$($s.name)' is already hidden for the WorkItem type '$($result.name)'."
-                  }
-                  elseif ($Force -or $PSCmdlet.ShouldProcess("$($result.name) in process template '$ProcessTemplate'", "Hide state '$($s.name)' from WorkItem type")) {
-                     $url  = "{0}/states/{1}?api-version={2}" -f $result.url, $s.id, (_getApiVersion Processes) 
-                     $resp = _callAPI -Url $url -method Put -body '{"hidden":true}' -ContentType "application/json"
-                     $resp.psobject.TypeNames.Insert(0,'vsteam_lib.WorkItemState')
-                     Add-Member -InputObject $resp -MemberType NoteProperty -Name ProcessTemplate -Value $ProcessTemplate
-                     Add-Member -InputObject $resp -MemberType NoteProperty -Name WorkItemType    -Value $result.name 
+      $wit = $null
+      #If $workItemtype contains an object, use it (if it was expanded) to avoid calling the API again
+      if ($WorkItemType.psobject.TypeNames.Contains('vsteam_lib.WorkItemType')) {
+         if ($WorkItemType.psobject.Properties['states']) {
+            $wit = $WorkItemType
+         }
+         else {
+            $WorkItemType = $workItemType.name
+            $ProcessTemplate = $WorkItemType.ProcessTemplate
+         }
+      }
+      if (-not $wit) {$wit = Get-VSTeamWorkItemType -ProcessTemplate $ProcessTemplate -WorkItemType  $WorkItemType -Expand states}
+      #Filter matching types to only those with a matching state - and ensure they are unlocked
 
-                     Write-Output $resp
-                  }
+      $wit = $wit | Where-Object {foreach ($n in $name) {if ($_.states.where({$_.name -like $n -and $_.customizationType -eq 'system'})) {$true} }} |
+                     Unlock-VSTeamWorkItemType -Force:$Force -Expand states
+      if (-not $wit) {Write-Warning "Found no suitable WorkItem Types with a system state matching '$name'." ; return}
+      foreach ($w in $wit){
+         foreach ($n in $Name) {
+            $state = $w.states| Where-Object {$_.Name -like $n -and $_.customizationType -eq 'system'}
+            foreach ($s in $state) {
+               # Hidden states have a second version to "hide behind" so check that doesn't exist for each found state
+               if ($resp.states| Where-Object {$_.Name -eq $s.Name -and $_.hidden}) {
+                  Write-Warning "'$($s.name)' is already hidden for the WorkItem type '$($w.name)'."
+               }
+               elseif ($Force -or $PSCmdlet.ShouldProcess("'$($w.name)' in process template '$ProcessTemplate'", "Hide WorkItem state '$($s.name)'")) {
+                  $url  = "{0}/states/{1}?api-version={2}" -f $w.url, $s.id, (_getApiVersion Processes)
+                  #Call the rest API
+                  $resp = _callAPI -method Put -Url $url -body '{"hidden":true}'
+
+                  # Apply a Type Name so we can use custom format view and/or custom type extensions
+                  #and members so it pipes nicely into other functions
+                  $resp.psobject.TypeNames.Insert(0,'vsteam_lib.WorkItemState')
+                  Add-Member -InputObject $resp -MemberType NoteProperty -Name ProcessTemplate -Value $w.ProcessTemplate
+                  Add-Member -InputObject $resp -MemberType NoteProperty -Name WorkItemType    -Value $w.name
+
+                  Write-Output $resp
                }
             }
          }

--- a/Source/Public/Remove-VSTeamWorkItemState.ps1
+++ b/Source/Public/Remove-VSTeamWorkItemState.ps1
@@ -17,20 +17,33 @@ function Remove-VsteamWorkItemState {
       [Switch]$Force
    )
    Process {
-      # WorkitemType can be a wildcard and we might have an array or wildcard in Name, 
-      # so get matching WorkItemTypes, loop through them and through names, get matching states(s) and loop through those.
-      foreach ($result in (Get-VSTeamWorkItemType -ProcessTemplate $ProcessTemplate -WorkItemType $WorkItemType -Expand states)){
+      $wit = $null
+      #If $workItemtype contains an object, use it (if it was expanded) to avoid calling the API again
+      if ($WorkItemType.psobject.TypeNames.Contains('vsteam_lib.WorkItemType')) {
+         if ($WorkItemType.psobject.Properties['states']) {
+            $wit = $WorkItemType
+         }
+         else {
+            $WorkItemType = $workItemType.name
+            $ProcessTemplate = $WorkItemType.ProcessTemplate
+         }
+      }
+      if (-not $wit) {$wit = Get-VSTeamWorkItemType -ProcessTemplate $ProcessTemplate -WorkItemType  $WorkItemType -Expand states}
+
+      #Filter matching types to only those with a matching state - to have a custom state they must be unlocked already.
+      $wit = $wit | Where-Object {foreach ($n in $name) {if ($_.states.where({$_.name -like $n -and $_.customizationType -eq 'custom'})) {$true} }}
+
+      if (-not $wit) {Write-Warning "Found no workitem types matching '$WorkItemType' with a custom state matching '$name'."}
+      # May have more than one workitem type and the Name of the state might be an array or wildcard ,
+      # loop through wildcards and through names, get matching states(s) and loop through those.
+      foreach ($w in $wit){
          foreach ($n in $Name) {
-            $state   = $result.states| Where-Object {$_.Name -like $n -and $_.customizationType -eq 'custom'}
-            if (-not $State) {
-               Write-Warning "'$n' does not  match a custom state for the WorkItem type '$($result.Name)'."
-            }
-            else {
-               foreach ($s in $state) {
-                  if ($Force -or $PSCmdlet.ShouldProcess("$($result.name) in process template '$ProcessTemplate'", "Remove state '$($state.name)' from WorkItem type")) {
-                     $url = "{0}/states/{1}?api-version={2}" -f $result.url, $s.id, (_getApiVersion Processes) 
-                     $null = _callAPI -Url $url -method Delete  #no result to send back
-                  }
+            $state   = $w.states| Where-Object {$_.Name -like $n -and $_.customizationType -eq 'custom'}
+            foreach ($s in $state) {
+               if ($Force -or $PSCmdlet.ShouldProcess("$($w.name) in process template '$ProcessTemplate'", "Remove state '$($state.name)' from WorkItem type")) {
+                  $url = "{0}/states/{1}?api-version={2}" -f $w.url, $s.id, (_getApiVersion Processes)
+                  #Call the REST API - no result to send back for a delete
+                  $null = _callAPI -Url $url -method Delete
                }
             }
          }

--- a/Source/Public/Remove-VSTeamWorkItemState.ps1
+++ b/Source/Public/Remove-VSTeamWorkItemState.ps1
@@ -1,0 +1,39 @@
+
+function Remove-VsteamWorkItemState {
+   [CmdletBinding(SupportsShouldProcess=$true,ConfirmImpact='High')]
+   param(
+      [parameter(ValueFromPipelineByPropertyName=$true)]
+      [vsteam_lib.ProcessTemplateValidateAttribute()]
+      [ArgumentCompleter([vsteam_lib.ProcessTemplateCompleter])]
+      $ProcessTemplate = $env:TEAM_PROCESS,
+
+      [parameter(Mandatory = $true,ValueFromPipelineByPropertyName=$true)]
+      [ArgumentCompleter([vsteam_lib.WorkItemTypeCompleter])]
+      $WorkItemType,
+
+      [Parameter(ValueFromPipelineByPropertyName=$true,Position=0)]
+      $Name,
+
+      [Switch]$Force
+   )
+   Process {
+      # WorkitemType can be a wildcard and we might have an array or wildcard in Name, 
+      # so get matching WorkItemTypes, loop through them and through names, get matching states(s) and loop through those.
+      foreach ($result in (Get-VSTeamWorkItemType -ProcessTemplate $ProcessTemplate -WorkItemType $WorkItemType -Expand states)){
+         foreach ($n in $Name) {
+            $state   = $result.states| Where-Object {$_.Name -like $n -and $_.customizationType -eq 'custom'}
+            if (-not $State) {
+               Write-Warning "'$n' does not  match a custom state for the WorkItem type '$($result.Name)'."
+            }
+            else {
+               foreach ($s in $state) {
+                  if ($Force -or $PSCmdlet.ShouldProcess("$($result.name) in process template '$ProcessTemplate'", "Remove state '$($state.name)' from WorkItem type")) {
+                     $url = "{0}/states/{1}?api-version={2}" -f $result.url, $s.id, (_getApiVersion Processes) 
+                     $null = _callAPI -Url $url -method Delete  #no result to send back
+                  }
+               }
+            }
+         }
+      }
+   }
+}

--- a/Source/Public/Remove-VSTeamWorkItemType.ps1
+++ b/Source/Public/Remove-VSTeamWorkItemType.ps1
@@ -1,0 +1,32 @@
+function Remove-VSTeamWorkItemType {
+   [CmdletBinding(DefaultParameterSetName='LeaveAlone',SupportsShouldProcess=$true,ConfirmImpact='High')]
+   param(
+      [parameter(Mandatory = $true,ValueFromPipelineByPropertyName=$true)]
+      [vsteam_lib.ProcessTemplateValidateAttribute()]
+      [ArgumentCompleter([vsteam_lib.ProcessTemplateCompleter])]
+      $ProcessTemplate,
+
+      [parameter(Mandatory = $true,ValueFromPipelineByPropertyName=$true)]
+      [ArgumentCompleter([vsteam_lib.WorkItemTypeCompleter])]
+      [Alias('Name')]
+      $WorkItemType,
+
+      [switch]$Force
+   )
+   process {
+      #Get the existing workitem-type definition. Drop out if can't be found or if it is a system type 
+      $wit  = Get-VSTeamWorkItemType -ProcessTemplate $ProcessTemplate -WorkItemType $WorkItemType
+      if (-not $wit) {Write-Warning "'$workitemType' does not appear to be a valid Workitem type." ; return}
+      elseif  ($wit.customization -eq 'System') {
+          throw "'$workitemType' is a system WorkItem type and cannot be deleted (but can be disabled)." ; return
+      }
+      else {$url  = "$($wit.url)?api-version=" + (_getApiVersion Processes)  }
+      
+      if ($Force -or $PSCmdlet.ShouldProcess($WorkItemType,"Modify $ProcessTemplate to delete definition of Workitem type") ) {
+         # Call the rest API - nothing to return, if this is the current process invalidate the cache of WorkItemTypeNames.
+         $null =  _callapi -Url $url -method  Delete
+
+         if ($env:TEAM_PROCESS -eq $ProcessTemplate) {[vsteam_lib.WorkItemTypeCache]::Invalidate()}
+      }
+   }
+}

--- a/Source/Public/Remove-VSTeamWorkItemType.ps1
+++ b/Source/Public/Remove-VSTeamWorkItemType.ps1
@@ -14,19 +14,19 @@ function Remove-VSTeamWorkItemType {
       [switch]$Force
    )
    process {
-      #Get the existing workitem-type definition. Drop out if can't be found or if it is a system type 
-      $wit  = Get-VSTeamWorkItemType -ProcessTemplate $ProcessTemplate -WorkItemType $WorkItemType
-      if (-not $wit) {Write-Warning "'$workitemType' does not appear to be a valid Workitem type." ; return}
-      elseif  ($wit.customization -eq 'System') {
-          throw "'$workitemType' is a system WorkItem type and cannot be deleted (but can be disabled)." ; return
-      }
-      else {$url  = "$($wit.url)?api-version=" + (_getApiVersion Processes)  }
-      
-      if ($Force -or $PSCmdlet.ShouldProcess($WorkItemType,"Modify $ProcessTemplate to delete definition of Workitem type") ) {
-         # Call the rest API - nothing to return, if this is the current process invalidate the cache of WorkItemTypeNames.
-         $null =  _callapi -Url $url -method  Delete
+      #Get the existing workitem-type definition. Drop out if can't be found or if it is a system type
+      $wit  = Get-VSTeamWorkItemType -ProcessTemplate $ProcessTemplate -WorkItemType $WorkItemType |
+               Where-Object -Property customization -NE 'System'
+      if (-not $wit) {Write-Warning "'$workitemType' does not match a user defined Workitem type." ; return}
 
-         if ($env:TEAM_PROCESS -eq $ProcessTemplate) {[vsteam_lib.WorkItemTypeCache]::Invalidate()}
+      foreach ($w in $wit) {
+         $url  = "$($w.url)?api-version=" + (_getApiVersion Processes)
+         if ($Force -or $PSCmdlet.ShouldProcess($w.name,"Modify $ProcessTemplate : delete definition of Workitem type.") ) {
+            # Call the rest API - nothing to return, if this is the current process invalidate the cache of WorkItemTypeNames.
+            $null =  _callapi -Url $url -method  Delete
+
+            if ($env:TEAM_PROCESS -eq $ProcessTemplate) {[vsteam_lib.WorkItemTypeCache]::Invalidate()}
+         }
       }
    }
 }

--- a/Source/Public/Remove-VSTeamWorkItemType.ps1
+++ b/Source/Public/Remove-VSTeamWorkItemType.ps1
@@ -6,7 +6,7 @@ function Remove-VSTeamWorkItemType {
       [ArgumentCompleter([vsteam_lib.ProcessTemplateCompleter])]
       $ProcessTemplate,
 
-      [parameter(Mandatory = $true,ValueFromPipelineByPropertyName=$true)]
+      [parameter(Mandatory = $true,ValueFromPipelineByPropertyName=$true,Position=0)]
       [ArgumentCompleter([vsteam_lib.WorkItemTypeCompleter])]
       [Alias('Name')]
       $WorkItemType,

--- a/Source/Public/Set-VSTeamDefaultProject.ps1
+++ b/Source/Public/Set-VSTeamDefaultProject.ps1
@@ -49,19 +49,22 @@ function Set-VSTeamDefaultProject {
 
    process {
       if ($Force -or $pscmdlet.ShouldProcess($Project, "Set-VSTeamDefaultProject")) {
-         if (_isOnWindows) {
-            if (-not $Level) {
-               $Level = "Process"
-            }
+         #Set at the process level, for any OS
+         $env:TEAM_PROJECT = $Project
+         [vsteam_lib.Versions]::DefaultProject = $Project
 
-            # You always have to set at the process level or they will Not
-            # be seen in your current session.
-            $env:TEAM_PROJECT = $Project
-            [vsteam_lib.Versions]::DefaultProject = $Project
+         $env:TEAM_PROCESS = [vsteam_lib.Versions]::DefaultProcess =
+                _callapi -NoProject -area 'work' -resource 'processes' -QueryString @{'$expand'='projects'}  -version (_getAPIVersion Processes) |
+                   Select-Object -ExpandProperty Value  | 
+                     Where-Object {$_.psobject.properties['projects'] -and $_.projects.name -eq $ProjectName} |
+                        Select-Object -ExpandProperty Name 
 
-            [System.Environment]::SetEnvironmentVariable("TEAM_PROJECT", $Project, $Level)
+         if  ((_isOnWindows) -and $Level -and $level -ne "Process") {
+            [System.Environment]::SetEnvironmentVariable("TEAM_PROJECT", $Project,           $Level)
+            [System.Environment]::SetEnvironmentVariable("TEAM_PROCESS", $env:TEAM_PROCESS , $Level)
          }
-
+         
+         # Note: ProjectName Parameters should be given a default value of [vsteam_lib.Versions]::DefaultProject instead of globally forcing it this way.
          $Global:PSDefaultParameterValues["*-vsteam*:projectName"] = $Project
       }
    }

--- a/Source/Public/Set-VSTeamDefaultProject.ps1
+++ b/Source/Public/Set-VSTeamDefaultProject.ps1
@@ -57,8 +57,7 @@ function Set-VSTeamDefaultProject {
                Where-Object Projects -Contains $Project | Select-Object -ExpandProperty Name
 
          if  ((_isOnWindows) -and $Level -and $level -ne "Process") {
-            [System.Environment]::SetEnvironmentVariable("TEAM_PROJECT", $Project,           $Level)
-            [System.Environment]::SetEnvironmentVariable("TEAM_PROCESS", $env:TEAM_PROCESS , $Level)
+            [System.Environment]::SetEnvironmentVariable("TEAM_PROJECT", $Project, $Level)
          }
 
          # Note: ProjectName Parameters should be given a default value of [vsteam_lib.Versions]::DefaultProject instead of globally forcing it this way.

--- a/Source/Public/Set-VSTeamDefaultProject.ps1
+++ b/Source/Public/Set-VSTeamDefaultProject.ps1
@@ -53,17 +53,14 @@ function Set-VSTeamDefaultProject {
          $env:TEAM_PROJECT = $Project
          [vsteam_lib.Versions]::DefaultProject = $Project
 
-         $env:TEAM_PROCESS = [vsteam_lib.Versions]::DefaultProcess =
-                _callapi -NoProject -area 'work' -resource 'processes' -QueryString @{'$expand'='projects'}  -version (_getAPIVersion Processes) |
-                   Select-Object -ExpandProperty Value  | 
-                     Where-Object {$_.psobject.properties['projects'] -and $_.projects.name -eq $ProjectName} |
-                        Select-Object -ExpandProperty Name 
+         $env:TEAM_PROCESS = [vsteam_lib.Versions]::DefaultProcess = Get-VSTeamProcess  -ExpandProjects |
+               Where-Object Projects -Contains $Project | Select-Object -ExpandProperty Name
 
          if  ((_isOnWindows) -and $Level -and $level -ne "Process") {
             [System.Environment]::SetEnvironmentVariable("TEAM_PROJECT", $Project,           $Level)
             [System.Environment]::SetEnvironmentVariable("TEAM_PROCESS", $env:TEAM_PROCESS , $Level)
          }
-         
+
          # Note: ProjectName Parameters should be given a default value of [vsteam_lib.Versions]::DefaultProject instead of globally forcing it this way.
          $Global:PSDefaultParameterValues["*-vsteam*:projectName"] = $Project
       }

--- a/Source/Public/Set-VSTeamWorkItemType.ps1
+++ b/Source/Public/Set-VSTeamWorkItemType.ps1
@@ -1,0 +1,90 @@
+function Set-VSTeamWorkItemType {
+   [CmdletBinding(DefaultParameterSetName='LeaveAlone',SupportsShouldProcess=$true,ConfirmImpact='High')]
+   param(
+      [parameter(ValueFromPipelineByPropertyName=$true)]
+      [vsteam_lib.ProcessTemplateValidateAttribute()]
+      [ArgumentCompleter([vsteam_lib.ProcessTemplateCompleter])]
+      $ProcessTemplate = $env:TEAM_PROCESS,
+
+      [parameter(Mandatory = $true,ValueFromPipelineByPropertyName=$true, Position=0)]
+      [ArgumentCompleter([vsteam_lib.WorkItemTypeCompleter])]
+      [Alias('Name')]
+      $WorkItemType,
+
+      [string] $Description,
+
+      [ArgumentCompleter([vsteam_lib.ColorCompleter])]
+      [vsteam_lib.ColorTransformToHexAttribute()]
+      $Color,
+
+      [vsteam_lib.IconTransformAttribute()]
+      [ArgumentCompleter([vsteam_lib.IconCompleter])]
+      [string]$Icon ,
+
+      [parameter(ParameterSetName='Hide', Mandatory = $true)]
+      [switch]$Disabled,
+
+      [parameter(ParameterSetName='Show', Mandatory = $true)]
+      [switch]$Enabled,
+
+      [switch]$Force
+   )
+   process {
+      #Get the existing workitem-type definition. Drop out if can't be found 
+      $wit  = Get-VSTeamWorkItemType -ProcessTemplate $ProcessTemplate -WorkItemType $WorkItemType
+      if (-not $wit) {Write-Warning "'$workitemType' does not appear to be a valid Workitem type." ; return}
+      else           {$url  = $wit.url + "?api-version=" + (_getApiVersion Processes)  }
+
+#region set up the contents to go in the JSON body
+      $body = @{} #note. "Changing" some options to their current value has caused errors but those below seem OK...
+      if ($Icon -and $Icon -ne $wit.icon) {
+               $body['icon']        = $Icon
+      }
+      else {   $body['icon']        = $wit.icon}
+
+      if ($Color -match '^[\da-f]{6}$' -and $color -ne $wit.color) {
+               $body['color']       = $Color
+      }
+      else {   $body['color']       = $wit.color}
+
+      if ($Description -and $Description -ne $wit.description) {
+               $body['description'] = $Description 
+      } 
+      else {   $body['description'] = $wit.description }
+      
+      if ($Disabled -and -not $wit.isDisabled) {
+               $body['isDisabled']  = $true 
+      }        
+      elseif($Enabled    -and $wit.isDisabled) {
+               $body['isDisabled']  = $false 
+      }
+      else  {  $body['isDisabled']  = $wit.isDisabled }
+#endregion      
+     if ($Force -or $PSCmdlet.ShouldProcess($WorkItemType,"Modify $ProcessTemplate, to update definition of workitem type") ) {
+         <# Call the REST API - 
+            if this system definition POST a new definition inheriting from the existing one
+            if it is a custom or inherited defintion use PATCH to make chanages. 
+         #>
+         try   { 
+               if ($wit.customization -ne 'system') { 
+                   $resp = _callapi -Url $url -method  Patch  -ContentType "application/json" -body (ConvertTo-Json $body) -ErrorAction stop 
+               }
+               else { #for system items we have to POST to the creation URL
+                  $body['inheritsFrom'] = $wit.referenceName
+                  $url    = ($url -replace 'workItemTypes/.*$' , 'workItemTypes?api-version=')  + (_getApiVersion Processes) 
+                  $resp = _callapi -Url $url -method  POST  -ContentType "application/json" -body (ConvertTo-Json $body) -ErrorAction stop 
+               }
+
+          }
+         catch { Write-Warning "$workitemType exists, but failed to update. It may not be possible to change this type."}
+
+         # Apply a Type Name so we can use custom format view and custom type extensions and add workitemType
+         # and processTemplate properties to become a parameters when the object is piped into other functions
+         _applyTypesWorkItemType -item $resp
+         Add-Member -InputObject $resp -MemberType AliasProperty -Name WorkItemType    -Value "name"
+         Add-Member -InputObject $resp -MemberType NoteProperty  -Name ProcessTemplate -Value $ProcessTemplate
+
+         return $resp 
+      }
+   }
+}

--- a/Source/Public/Set-VSTeamWorkItemType.ps1
+++ b/Source/Public/Set-VSTeamWorkItemType.ps1
@@ -30,61 +30,63 @@ function Set-VSTeamWorkItemType {
       [switch]$Force
    )
    process {
-      #Get the existing workitem-type definition. Drop out if can't be found 
+      #Get the existing workitem-type definition. Drop out if can't be found
       $wit  = Get-VSTeamWorkItemType -ProcessTemplate $ProcessTemplate -WorkItemType $WorkItemType
-      if (-not $wit) {Write-Warning "'$workitemType' does not appear to be a valid Workitem type." ; return}
-      else           {$url  = $wit.url + "?api-version=" + (_getApiVersion Processes)  }
+      if (-not $wit) {Write-Warning "'$workitemType' does not match a Workitem type." ; return}
 
-#region set up the contents to go in the JSON body
-      $body = @{} #note. "Changing" some options to their current value has caused errors but those below seem OK...
-      if ($Icon -and $Icon -ne $wit.icon) {
-               $body['icon']        = $Icon
-      }
-      else {   $body['icon']        = $wit.icon}
+      foreach ($w in $wit)   {
+         $url  = $w.url + "?api-version=" + (_getApiVersion Processes)
 
-      if ($Color -match '^[\da-f]{6}$' -and $color -ne $wit.color) {
-               $body['color']       = $Color
-      }
-      else {   $body['color']       = $wit.color}
+         #region set up the contents to go in the JSON body
+         $body = @{} #note. "Changing" some options to their current value has caused errors but those below seem OK...
+         if ($Icon -and $Icon -ne $w.icon) {
+                  $body['icon']        = $Icon
+         }
+         else {   $body['icon']        = $w.icon}
 
-      if ($Description -and $Description -ne $wit.description) {
-               $body['description'] = $Description 
-      } 
-      else {   $body['description'] = $wit.description }
-      
-      if ($Disabled -and -not $wit.isDisabled) {
-               $body['isDisabled']  = $true 
-      }        
-      elseif($Enabled    -and $wit.isDisabled) {
-               $body['isDisabled']  = $false 
-      }
-      else  {  $body['isDisabled']  = $wit.isDisabled }
-#endregion      
-     if ($Force -or $PSCmdlet.ShouldProcess($WorkItemType,"Modify $ProcessTemplate, to update definition of workitem type") ) {
-         <# Call the REST API - 
-            if this system definition POST a new definition inheriting from the existing one
-            if it is a custom or inherited defintion use PATCH to make chanages. 
-         #>
-         try   { 
-               if ($wit.customization -ne 'system') { 
-                   $resp = _callapi -Url $url -method  Patch  -ContentType "application/json" -body (ConvertTo-Json $body) -ErrorAction stop 
-               }
-               else { #for system items we have to POST to the creation URL
-                  $body['inheritsFrom'] = $wit.referenceName
-                  $url    = ($url -replace 'workItemTypes/.*$' , 'workItemTypes?api-version=')  + (_getApiVersion Processes) 
-                  $resp = _callapi -Url $url -method  POST  -ContentType "application/json" -body (ConvertTo-Json $body) -ErrorAction stop 
-               }
+         if ($Color -match '^[\da-f]{6}$' -and $color -ne $w.color) {
+                  $body['color']       = $Color
+         }
+         else {   $body['color']       = $w.color}
 
-          }
-         catch { Write-Warning "$workitemType exists, but failed to update. It may not be possible to change this type."}
+         if ($Description -and $Description -ne $w.description) {
+                  $body['description'] = $Description
+         }
+         else {   $body['description'] = $w.description }
 
-         # Apply a Type Name so we can use custom format view and custom type extensions and add workitemType
-         # and processTemplate properties to become a parameters when the object is piped into other functions
-         _applyTypesWorkItemType -item $resp
-         Add-Member -InputObject $resp -MemberType AliasProperty -Name WorkItemType    -Value "name"
-         Add-Member -InputObject $resp -MemberType NoteProperty  -Name ProcessTemplate -Value $ProcessTemplate
+         if ($Disabled -and -not $w.isDisabled) {
+                  $body['isDisabled']  = $true
+         }
+         elseif($Enabled    -and $w.isDisabled) {
+                  $body['isDisabled']  = $false }
+         else {   $body['isDisabled']  = $w.isDisabled }
+         #endregion
 
-         return $resp 
+         if ($Force -or $PSCmdlet.ShouldProcess($w.Name,"Modify $ProcessTemplate, to update definition of workitem type") ) {
+            <# Call the REST API -
+               if this is a *system* definition then POST a new definition inheriting from the existing one
+               if it is a custom or inherited defintion then use PATCH to make chanages.
+            #>
+            try   {
+                  if ($w.customization -ne 'system') {
+                     $resp = _callapi -Url $url -method  Patch  -ContentType "application/json" -body (ConvertTo-Json $body) -ErrorAction stop
+                  }
+                  else {
+                     $body['inheritsFrom'] = $w.referenceName
+                     $url    = ($url -replace 'workItemTypes/.*$' , 'workItemTypes?api-version=')  + (_getApiVersion Processes)
+                     $resp = _callapi -Url $url -method  POST  -ContentType "application/json" -body (ConvertTo-Json $body) -ErrorAction stop
+                  }
+            }
+            catch { Write-Warning "$workitemType exists, but failed to update. It may not be possible to change this type." ; continue}
+
+            # Apply a Type Name so we can use custom format view and custom type extensions and add workitemType
+            # and processTemplate properties to become a parameters when the object is piped into other functions
+            _applyTypesWorkItemType -item $resp
+            Add-Member -InputObject $resp -MemberType AliasProperty -Name WorkItemType    -Value "name"
+            Add-Member -InputObject $resp -MemberType NoteProperty  -Name ProcessTemplate -Value $ProcessTemplate
+
+            Write-Output $resp
+         }
       }
    }
 }

--- a/Source/Public/Show-VSTeamWorkItemState.ps1
+++ b/Source/Public/Show-VSTeamWorkItemState.ps1
@@ -17,20 +17,36 @@ function Show-VsteamWorkItemState {
       [Switch]$Force
    )
    Process {
-      # WorkitemType can be a wildcard and we might have an array or wildcard in Name, 
-      # so get matching WorkItemTypes, loop through them and through names, get matching states(s) and loop through those.
-      foreach ($result in (Get-VSTeamWorkItemType -ProcessTemplate $ProcessTemplate -WorkItemType $WorkItemType -Expand states)){
+      $wit = $null
+      #If $workItemtype contains an object, use it (if it was expanded) to avoid calling the API again
+      if ($WorkItemType.psobject.TypeNames.Contains('vsteam_lib.WorkItemType')) {
+         if ($WorkItemType.psobject.Properties['states']) {
+            $wit = $WorkItemType
+         }
+         else {
+            $WorkItemType = $workItemType.name
+            $ProcessTemplate = $WorkItemType.ProcessTemplate
+         }
+      }
+      if (-not $wit) {$wit = Get-VSTeamWorkItemType -ProcessTemplate $ProcessTemplate -WorkItemType  $WorkItemType -Expand states}
+
+      #Filter matching types to only those with a matching state - to have an inherited state they must be unlocked already.
+      $wit = $wit | Where-Object {foreach ($n in $name) {if ($_.states.where({$_.name -like $n -and $_.customizationType -eq 'inherited'})) {$true} }}
+      if (-not $wit) {Write-Warning "Found no workitem types matching '$WorkItemType' with a hidden state matching '$name'."}
+      foreach ($w in $wit){
          foreach ($n in $Name) {
-            $state = $result.states| Where-Object {$_.Name -like $n -and $_.customizationType -eq 'inherited' }
-            if (-not $State) {
-               Write-Warning "'$n' does not  match a hidden state for the WorkItem type '$($result.name)'."
-            }
-            else {
-               foreach ($s in $state) {
-                  if ($Force -or $PSCmdlet.ShouldProcess("$($result.name) in process template '$ProcessTemplate'", "Show state '$($s.name)' on WorkItem type")) {
-                     $url = "{0}/states/{1}?api-version={2}" -f $result.url, $s.id, (_getApiVersion Processes) 
-                     $null = _callAPI -Url $url -method Delete  #no result to send back
-                  }
+            $state = $w.states.Where({$_.Name -like $n -and $_.customizationType -eq 'inherited' })
+            foreach ($s in $state) {
+               if ($Force -or $PSCmdlet.ShouldProcess("'$($w.name)' in process template '$ProcessTemplate'", "Show WorkItem state '$($s.name)'")) {
+                  $url = "{0}/states/{1}?api-version={2}" -f $w.url, $s.id, (_getApiVersion Processes)
+                  $null = _callAPI -Url $url -method Delete  #no result to send back
+
+                  $sysState =  $w.states.where(({$_.Name -eq $s.name -and $_.customizationType -eq 'system' })) | Select-Object -First 1
+                  $sysState.PSObject.TypeNames.Insert(0, 'vsteam_lib.WorkItemState')
+                  Add-Member -InputObject $Sysstate -MemberType AliasProperty -Name WorkItemType    -Value "name"
+                  Add-Member -InputObject $sysState -MemberType NoteProperty  -Name ProcessTemplate -Value $w.ProcessTemplate
+
+                  Write-Output $sysState
                }
             }
          }

--- a/Source/Public/Show-VSTeamWorkItemState.ps1
+++ b/Source/Public/Show-VSTeamWorkItemState.ps1
@@ -1,0 +1,39 @@
+
+function Show-VsteamWorkItemState {
+   [CmdletBinding(SupportsShouldProcess=$true,ConfirmImpact='High')]
+   param(
+      [parameter(ValueFromPipelineByPropertyName=$true)]
+      [vsteam_lib.ProcessTemplateValidateAttribute()]
+      [ArgumentCompleter([vsteam_lib.ProcessTemplateCompleter])]
+      $ProcessTemplate =  $env:TEAM_PROCESS,
+
+      [parameter(Mandatory = $true,ValueFromPipelineByPropertyName=$true)]
+      [ArgumentCompleter([vsteam_lib.WorkItemTypeCompleter])]
+      $WorkItemType,
+
+      [Parameter(Mandatory=$true,ValueFromPipelineByPropertyName=$true,Position=0)]
+      $Name,
+
+      [Switch]$Force
+   )
+   Process {
+      # WorkitemType can be a wildcard and we might have an array or wildcard in Name, 
+      # so get matching WorkItemTypes, loop through them and through names, get matching states(s) and loop through those.
+      foreach ($result in (Get-VSTeamWorkItemType -ProcessTemplate $ProcessTemplate -WorkItemType $WorkItemType -Expand states)){
+         foreach ($n in $Name) {
+            $state = $result.states| Where-Object {$_.Name -like $n -and $_.customizationType -eq 'inherited' }
+            if (-not $State) {
+               Write-Warning "'$n' does not  match a hidden state for the WorkItem type '$($result.name)'."
+            }
+            else {
+               foreach ($s in $state) {
+                  if ($Force -or $PSCmdlet.ShouldProcess("$($result.name) in process template '$ProcessTemplate'", "Show state '$($s.name)' on WorkItem type")) {
+                     $url = "{0}/states/{1}?api-version={2}" -f $result.url, $s.id, (_getApiVersion Processes) 
+                     $null = _callAPI -Url $url -method Delete  #no result to send back
+                  }
+               }
+            }
+         }
+      }
+   }
+}

--- a/Source/Public/Unlock-VSTeamWorkItemType.ps1
+++ b/Source/Public/Unlock-VSTeamWorkItemType.ps1
@@ -1,0 +1,44 @@
+function Unlock-VSTeamWorkItemType {
+   [CmdletBinding(SupportsShouldProcess=$true,ConfirmImpact='High')]
+   param(
+      [Parameter(Position=0,ValueFromPipeline=$true,Mandatory=$true)]
+      $WorkItemType,
+
+      [AllowNull()]
+      [ValidateSet('behaviors','layout','states')]
+      [string[]]$Expand,
+
+      [switch]$Force
+   )
+   process {
+      if (-not ($WorkItemType.psobject.properties["customization"] -and $WorkItemType.customization -eq 'system')) {
+         return $WorkItemType
+      }
+      else {
+         $url  = ($WorkItemType.url -replace '/workItemTypes/.*$', '/workItemTypes?api-version=') +  (_getApiVersion Processes)
+         $body = @{
+            color        = $WorkItemType.color
+            description  = $WorkItemType.description
+            icon         = $WorkItemType.icon
+            inheritsFrom = $WorkItemType.referenceName
+            isDisabled   = $WorkItemType.isDisabled
+            name         = $WorkItemType.name
+         }
+         if ($force -or $PSCmdlet.ShouldProcess($WorkItemType.name,"Update WorkItemType")) {
+            $resp = _callAPI -Url $url -method Post -body (ConvertTo-Json $body)
+            if ($expand) {Get-VSTeamWorkItemType -ProcessTemplate $WorkItemType.ProcessTemplate -WorkItemType $WorkItemType.name -Expand $Expand}
+            else         {
+               # Apply a Type Name so we can use custom format view and/or custom type extensions
+               #  add members to help piping into other functions
+               _applyTypesWorkItemType -item $resp
+               Add-Member -InputObject $resp -MemberType AliasProperty -Name "WorkItemType"    -Value "name"
+               if ($WorkItemType.psobject.properties["ProcessTemplate"]) {
+                  Add-Member -InputObject $resp -MemberType NoteProperty  -Name "ProcessTemplate" -Value $WorkItemType.ProcessTemplate
+               }
+               return $resp
+            }
+         }
+      }
+   }
+}
+

--- a/Source/Public/Unlock-VSTeamWorkItemType.ps1
+++ b/Source/Public/Unlock-VSTeamWorkItemType.ps1
@@ -1,6 +1,10 @@
 function Unlock-VSTeamWorkItemType {
    [CmdletBinding(SupportsShouldProcess=$true,ConfirmImpact='High')]
    param(
+      [vsteam_lib.ProcessTemplateValidateAttribute()]
+      [ArgumentCompleter([vsteam_lib.ProcessTemplateCompleter])]
+      $ProcessTemplate = $env:TEAM_PROCESS,
+
       [Parameter(Position=0,ValueFromPipeline=$true,Mandatory=$true)]
       $WorkItemType,
 
@@ -11,7 +15,18 @@ function Unlock-VSTeamWorkItemType {
       [switch]$Force
    )
    process {
-      if (-not ($WorkItemType.psobject.properties["customization"] -and $WorkItemType.customization -eq 'system')) {
+      if ($WorkItemType -is [string]) {
+         if ($expand) {
+            Get-VSTeamWorkItemType -ProcessTemplate $ProcessTemplate -WorkItemType $WorkItemType |
+               Unlock-VSTeamWorkItemType -Expand $Expand -Force:Force
+         }
+         else {
+            Get-VSTeamWorkItemType -ProcessTemplate $ProcessTemplate -WorkItemType $WorkItemType |
+               Unlock-VSTeamWorkItemType -Force:Force
+         }
+         return
+      }
+      elseif (-not ($WorkItemType.psobject.properties["customization"] -and $WorkItemType.customization -eq 'system')) {
          return $WorkItemType
       }
       else {
@@ -52,4 +67,3 @@ function Unlock-VSTeamWorkItemType {
       }
    }
 }
-

--- a/Source/Public/Unlock-VSTeamWorkItemType.ps1
+++ b/Source/Public/Unlock-VSTeamWorkItemType.ps1
@@ -25,11 +25,22 @@ function Unlock-VSTeamWorkItemType {
             name         = $WorkItemType.name
          }
          if ($force -or $PSCmdlet.ShouldProcess($WorkItemType.name,"Update WorkItemType")) {
-            $resp = _callAPI -Url $url -method Post -body (ConvertTo-Json $body)
+            # Call the Rest API. _callAPi displays errors for the user and throws,
+            # if this happens half way through processing to mulitple work item types
+            # don't stop with some done and some not.
+            try   {$resp = _callAPI -Url $url -method Post -body (ConvertTo-Json $body) }
+            catch {
+               $msg = "An Error occured trying to create the inherited version of " + $WorkItemType.name + "."
+               if ($WorkItemType.psobject.Properties["ProcessTemplate"]) {
+                  $msg = $msg -replace "\.$",  " in Process Template $($WorkItemType.ProcessTemplate)."
+               }
+               Write-Warning $msg
+               return
+            }
             if ($expand) {Get-VSTeamWorkItemType -ProcessTemplate $WorkItemType.ProcessTemplate -WorkItemType $WorkItemType.name -Expand $Expand}
             else         {
                # Apply a Type Name so we can use custom format view and/or custom type extensions
-               #  add members to help piping into other functions
+               # and add members to help piping into other functions
                _applyTypesWorkItemType -item $resp
                Add-Member -InputObject $resp -MemberType AliasProperty -Name "WorkItemType"    -Value "name"
                if ($WorkItemType.psobject.properties["ProcessTemplate"]) {

--- a/Source/formats/_formats.json
+++ b/Source/formats/_formats.json
@@ -99,6 +99,7 @@
       "vsteam_lib.WorkItem.ListView.ps1xml",
       "vsteam_lib.WorkItemDeleted.TableView.ps1xml",
       "vsteam_lib.WorkItemDeleted.ListView.ps1xml",
+      "vsteam_lib.WorkItemState.TableView.ps1xml",
       "vsteam_lib.JobRequest.TableView.ps1xml",
       "vsteam_lib.GitCommitRef.TableView.ps1xml",
       "vsteam_lib.GitUserDate.TableView.ps1xml",

--- a/Source/formats/vsteam_lib.WorkItemState.TableView.ps1xml
+++ b/Source/formats/vsteam_lib.WorkItemState.TableView.ps1xml
@@ -1,0 +1,65 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<Configuration>
+	<ViewDefinitions>
+		<View>
+			<Name>vsteam_lib.WorkItemState.TableView</Name>
+			<ViewSelectedBy>
+				<TypeName>vsteam_lib.WorkItemState</TypeName>
+			</ViewSelectedBy>
+			<TableControl>
+				<AutoSize />
+				<TableHeaders>
+					<TableColumnHeader>
+						<Label>WorkItemType</Label>
+					</TableColumnHeader>
+					<TableColumnHeader>
+						<Label>Order</Label>
+					</TableColumnHeader>
+					<TableColumnHeader>
+						<Label>Name</Label>
+					</TableColumnHeader>
+					<TableColumnHeader>
+						<Label>Category</Label>
+					</TableColumnHeader>
+					<TableColumnHeader>
+						<Label>Color</Label>
+					</TableColumnHeader>
+					<TableColumnHeader>
+						<Label>Customization</Label>
+					</TableColumnHeader>
+					<TableColumnHeader>
+						<Label>Hidden</Label>
+					</TableColumnHeader>
+				</TableHeaders>
+				<TableRowEntries>
+					<TableRowEntry>
+						<Wrap />
+						<TableColumnItems>
+							<TableColumnItem>
+								<PropertyName>WorkItemType</PropertyName>
+							</TableColumnItem>
+							<TableColumnItem>
+								<PropertyName>order</PropertyName>
+							</TableColumnItem>
+							<TableColumnItem>
+								<PropertyName>Name</PropertyName>
+							</TableColumnItem>
+							<TableColumnItem>
+								<PropertyName>stateCategory</PropertyName>
+							</TableColumnItem>
+							<TableColumnItem>
+								<PropertyName>color</PropertyName>
+							</TableColumnItem>
+							<TableColumnItem>
+								<PropertyName>customizationType</PropertyName>
+							</TableColumnItem>
+							<TableColumnItem>
+								<PropertyName>hidden</PropertyName>
+							</TableColumnItem>
+                  </TableColumnItems>
+					</TableRowEntry>
+				</TableRowEntries>
+			</TableControl>
+		</View>
+	</ViewDefinitions>
+</Configuration>

--- a/Tests/SampleFiles/Get-VSTeamProcess.json
+++ b/Tests/SampleFiles/Get-VSTeamProcess.json
@@ -4,7 +4,7 @@
     {
       "typeId": "6b724908-ef14-45cf-84f8-768b5384da45",
       "name": "Scrum",
-      "referenceName": null,
+      "referenceName": "test",
       "description": "This template is for teams who follow the Scrum framework.",
       "parentProcessTypeId": "00000000-0000-0000-0000-000000000000",
       "isEnabled": true,
@@ -16,6 +16,20 @@
       "name": "Agile",
       "referenceName": null,
       "description": "This template is flexible and will work great for most teams using Agile planning methods, including those practicing Scrum.",
+      "projects": [
+        {
+          "id": "f5563894-c8da-49cf-bf5c-7caeaeed1af7",
+          "name": "Voting-App",
+          "description": "Vote App",
+          "url": "vstfs:///Classification/TeamProject/f5563894-c8da-49cf-bf5c-7caeaeed1af7"
+        },
+        {
+          "id": "15af52f7-47f1-40a7-817a-7661062cea76",
+          "name": "PeopleTracker",
+          "description": null,
+          "url": "vstfs:///Classification/TeamProject/15af52f7-47f1-40a7-817a-7661062cea76"
+        }
+      ],
       "parentProcessTypeId": "00000000-0000-0000-0000-000000000000",
       "isEnabled": true,
       "isDefault": true,

--- a/Tests/function/tests/Add-VSTeamProject.Tests.ps1
+++ b/Tests/function/tests/Add-VSTeamProject.Tests.ps1
@@ -16,9 +16,8 @@ Describe 'VSTeamProject' {
       Mock _getApiVersion { return '1.0-unitTests' }
       Mock _callApi { Open-SampleFile 'Get-VSTeamProcess.json' } -ParameterFilter { $area -eq 'work' -and $resource -eq 'processes' }
 
-      # Get-VSTeamProject for cache 
-      Mock Invoke-RestMethod { return @() } -ParameterFilter {
-         $Uri -like "*`$top=100*" -and
+      # Get-VSTeamProject for cache
+      Mock Invoke-RestMethod { return [pscustomobject]@{value=@()} } -ParameterFilter {
          $Uri -like "*stateFilter=WellFormed*"
       }
    }
@@ -34,7 +33,7 @@ Describe 'VSTeamProject' {
          }
 
          # Track Progress
-         Mock Invoke-RestMethod {            
+         Mock Invoke-RestMethod {
             # This $i is in the module. Because we use InModuleScope
             # we can see it
             if ($i -gt 9) {

--- a/Tests/function/tests/Add-VSTeamProject.Tests.ps1
+++ b/Tests/function/tests/Add-VSTeamProject.Tests.ps1
@@ -88,6 +88,7 @@ Describe 'VSTeamProject' {
                Typeid = '00000000-0000-0000-0000-000000000002'
             }
          }
+         [vsteam_lib.ProcessTemplateCache]::Invalidate()
       }
 
       It 'Should create project with CMMI' {

--- a/Tests/function/tests/Add-VSTeamWorkItem.Tests.ps1
+++ b/Tests/function/tests/Add-VSTeamWorkItem.Tests.ps1
@@ -3,6 +3,7 @@ Set-StrictMode -Version Latest
 Describe 'VSTeamWorkItem' {
    BeforeAll {
       . "$PSScriptRoot\_testInitialize.ps1" $PSCommandPath
+      . "$PSScriptRoot\..\..\..\Source\Public\Get-VSTeamWorkItemType.ps1"
 
       Mock _getInstance { return 'https://dev.azure.com/test' }
       Mock Invoke-RestMethod { Open-SampleFile 'Get-VSTeamWorkItem-Id16.json' }

--- a/Tests/function/tests/Add-VSTeamWorkItemState.Tests.ps1
+++ b/Tests/function/tests/Add-VSTeamWorkItemState.Tests.ps1
@@ -1,0 +1,119 @@
+Set-StrictMode -Version Latest
+
+Describe 'VSTeamWorkItemState' {
+   BeforeAll {
+      . "$PSScriptRoot\_testInitialize.ps1" $PSCommandPath
+      . "$PSScriptRoot\..\..\..\Source\Public\Get-VSTeamProcess.ps1"
+      . "$PSScriptRoot\..\..\..\Source\Public\Get-VSTeamWorkItemType.ps1"
+      ## Arrange
+      # Set the account to use for testing. A normal user would do this
+      # using the Set-VSTeamAccount function.
+      Mock _getInstance   { return 'https://dev.azure.com/test' }
+      Mock _getApiVersion { return '1.0-unitTests' } -ParameterFilter { $Service -eq 'Processes' }
+      $bug = @{
+         name          = 'Bug'
+         customization = 'System'
+         color         = 'CC293D'
+         description   = 'Describes a divergence between required and actual behavior, and tracks the work done to correct the defect and verify the correction.'
+         icon          = 'Icon_Insect'
+         isDisabled    =  $false
+         referenceName = 'Microsoft.VSTS.WorkItemTypes.Bug'
+         states        = @( 
+            [PSCustomObject]@{
+               id                 = '7b7e3e8c-e500-40b6-ad56-d59b8d64d757'
+               name               = 'New'
+               color              = 'b2b2b2'
+               stateCategory      = 'Proposed'
+               order              = 1
+               url                = 'https://dummy.none/workItemTypes/Microsoft.VSTS.WorkItemTypes.Bug/states/7b7e3e8c-e500-40b6-ad56-d59b8d64d757'
+               customizationType  = 'system'
+            },
+            [PSCustomObject]@{
+               id                 = '02cca570-0896-4a30-aff1-87ccffc68ce0'
+               name               = 'Approved'
+               color              = 'b2b2b2'
+               stateCategory      = 'Proposed'
+               order              = 2
+               url                = 'https://dummy.none/workItemTypes/Microsoft.VSTS.WorkItemTypes.Bug/states/02cca570-0896-4a30-aff1-87ccffc68ce0'
+               customizationType  = 'system'
+            }
+            [PSCustomObject]@{
+               id                 = 'abb54c86-d03a-44fe-8216-309d3c712296'
+               name               = 'Committed'
+               color              = '007acc'
+               stateCategory      = 'InProgress'
+               order              = 3
+               url                = 'https://dummy.none/workItemTypes/Microsoft.VSTS.WorkItemTypes.Bug/states/abb54c86-d03a-44fe-8216-309d3c712296'
+               customizationType  = 'system'
+            }
+            [PSCustomObject]@{
+               id                 = '0c926c15-68f7-467f-96c9-a26a19e9d718'
+               name               = 'Done'
+               color              = '339933'
+               stateCategory      = 'Completed'
+               order              = 4
+               url                = 'https://dummy.none/workItemTypes/Microsoft.VSTS.WorkItemTypes.Bug/states/0c926c15-68f7-467f-96c9-a26a19e9d718'
+               customizationType  = 'system'
+            }
+            [PSCustomObject]@{
+               id                 = '0293a2ce-2a42-4d0e-bbbf-d2237efa0db8'
+               name               = 'Removed'
+               color              = 'ffffff'
+               stateCategory      = 'Removed'
+               order              = 5
+               url                = 'https://dummy.none/workItemTypes/Microsoft.VSTS.WorkItemTypes.Bug/states/0293a2ce-2a42-4d0e-bbbf-d2237efa0db8'
+               customizationType  = 'system'
+            }
+         )
+      }  
+      Mock Get-VSTeamProcess { return @(
+               [PSCustomObject]@{
+                  Name = 'Scrum2'
+                  URL  = 'https://dummy.none/_apis/work/processes/6b724908-ef14-45cf-84f8-768b5384da45'
+               }
+            )
+         }
+      Mock Get-VSTeamWorkItemType {return $bug }
+      Mock _callAPI       -ParameterFilter {$body -match    'inheritsFrom' } {return $bug }
+      Mock _callAPI       -ParameterFilter { $Url -match    'states' } {
+         return [PSCustomObject]@{
+                  id                 = '00000'
+                  name               = 'Postponed'
+                  color              = '0000ff'
+                  stateCategory      = 'Removed'
+                  order              =  4
+                  url                = 'https://dummy.none/workItemTypes/Microsoft.VSTS.WorkItemTypes.Bug/states/00000'
+                  customizationType  = 'custom'
+               }
+      }
+      Mock _callAPI       -ParameterFilter { $Url -NotMatch 'states' -and $body -notmatch  'inheritsFrom' } {return $null}
+      [vsteam_lib.ProcessTemplateCache]::Invalidate()
+   }
+
+   Context 'Add-VsteamWorkItemState' {
+
+
+      It 'should call the REST API to add a state, updating system types as needed' {
+         ## Act
+         $state =  Add-VsteamWorkItemState -WorkItemType bug -Color Blue -Name postponed -ProcessTemplate Scrum2 -order 4 -Force 
+
+         ## Assert
+         Should -Invoke _callAPI -Scope It  -Times 1 -Exactly -ParameterFilter {
+               $Body -match  '"stateCategory"\s*:\s*"InProgress"' -and
+               $Body -match  '"name"\s*:\s*"postponed"'           -and
+               $Body -match  '"color"\s*:\s*"0+ff"'               -and 
+               $Body -match  '"order"\s*:\s*4'
+         }
+         Should -Invoke _callAPI -Scope It  -Times 1 -Exactly -ParameterFilter {
+               $Body -match  '"icon"\s*:\s*"Icon_Insect"'   -and
+               $Body -match  '"name"\s*:\s*"Bug"'           -and
+               $Body -match  '"color"\s*:\s*"CC293D"'       -and 
+               $Body -match  '"inheritsFrom"\s*:\s*"Microsoft.VSTS.WorkItemTypes.Bug"' #>
+         }
+         $state.psobject.Typenames | Should -Contain 'vsteam_lib.WorkItemState'
+         $state.ProcessTemplate    | Should -Be      'Scrum2'
+         $state.WorkItemType       | Should -Be      'Bug'
+      }
+   }
+}
+

--- a/Tests/function/tests/Add-VSTeamWorkItemState.Tests.ps1
+++ b/Tests/function/tests/Add-VSTeamWorkItemState.Tests.ps1
@@ -9,7 +9,7 @@ Describe 'VSTeamWorkItemState' {
       ## Arrange
       # Set the account to use for testing. A normal user would do this
       # using the Set-VSTeamAccount function.
-      Mock _getInstance   { return 'https://dev.azure.com/test' }
+      [vsteam_lib.Versions]::Account = 'https://dev.azure.com/test'
       Mock _getApiVersion { return '1.0-unitTests' } -ParameterFilter { $Service -eq 'Processes' }
       $bug = @{
          name            = 'Bug'

--- a/Tests/function/tests/Add-VSTeamWorkItemState.Tests.ps1
+++ b/Tests/function/tests/Add-VSTeamWorkItemState.Tests.ps1
@@ -115,5 +115,8 @@ Describe 'VSTeamWorkItemState' {
          $state.WorkItemType       | Should -Be      'Bug'
       }
    }
+   AfterAll {
+         [vsteam_lib.Versions]::Account = ""
+   }
 }
 

--- a/Tests/function/tests/Add-VSTeamWorkItemType.Tests.ps1
+++ b/Tests/function/tests/Add-VSTeamWorkItemType.Tests.ps1
@@ -1,10 +1,10 @@
 Set-StrictMode -Version Latest
 
-Describe 'VSTeamWorkItemType' {
+Describe 'AddVSTeamWorkItemType' {
    BeforeAll {
       . "$PSScriptRoot\_testInitialize.ps1" $PSCommandPath
-      . "$PSScriptRoot\..\..\..\Source\Public\Get-VSteamProcess.ps1"
-      . "$PSScriptRoot\..\..\..\Source\Public\Get-VSTeamWorkItemIconList"
+      . "$PSScriptRoot\..\..\..\Source\Public\Get-VSTeamProcess.ps1"
+      . "$PSScriptRoot\..\..\..\Source\Public\Get-VSTeamWorkItemIconList.ps1"
 
       $Global:PSDefaultParameterValues.Remove("*-vsteam*:projectName")
 

--- a/Tests/function/tests/Add-VSTeamWorkItemType.Tests.ps1
+++ b/Tests/function/tests/Add-VSTeamWorkItemType.Tests.ps1
@@ -1,0 +1,57 @@
+Set-StrictMode -Version Latest
+
+Describe 'VSTeamWorkItemType' {
+   BeforeAll {
+      . "$PSScriptRoot\_testInitialize.ps1" $PSCommandPath
+      . "$PSScriptRoot\..\..\..\Source\Public\Get-VSteamProcess.ps1"
+      . "$PSScriptRoot\..\..\..\Source\Public\Get-VSTeamWorkItemIconList"
+
+      $Global:PSDefaultParameterValues.Remove("*-vsteam*:projectName")
+
+      ## Arrange
+      # Set the account to use for testing. A normal user would do this
+      # using the Set-VSTeamAccount function.
+      Mock _getInstance { return 'https://dev.azure.com/test' }
+      Mock _getApiVersion { return '1.0-unitTests' } -ParameterFilter { $Service -eq 'Processes' }
+
+      Mock Get-VSTeamProcess {
+         $processes = @(
+            [PSCustomObject]@{Name = "Scrum"; url = 'http://bogus.none/1'; ID = "6b724908-ef14-45cf-84f8-768b5384da45" },
+            [PSCustomObject]@{Name = "Basic"; url = 'http://bogus.none/2'; ID = "b8a3a935-7e91-48b8-a94c-606d37c3e9f2" },
+            [PSCustomObject]@{Name = "CMMI"; url = 'http://bogus.none/3'; ID = "27450541-8e31-4150-9947-dc59f998fc01" },
+            [PSCustomObject]@{Name = "Agile"; url = 'http://bogus.none/4'; ID = "adcc42ab-9882-485e-a3ed-7678f01f66bc" },
+            [PSCustomObject]@{Name = "Scrum With Space"; url = 'http://bogus.none/5'; ID = "12345678-0000-0000-0000-000000000000" }
+         )
+         if ($name) { return $processes.where( { $_.name -like $name }) }
+         else { return $processes }  
+      }
+      Mock _callApi -ParameterFilter { $resource -eq 'workitemicons' }  -MockWith {
+         return [pscustomobject]@{'Value' = @(
+               [pscustomobject]@{'ID' = 'icon_airplane' }
+               [pscustomobject]@{'ID' = 'icon_asterisk' }
+               [pscustomobject]@{'ID' = 'icon_Book' }
+            ) 
+         }
+      }
+      Mock _callApi -ParameterFilter { $Method -eq 'Post' } -MockWith {
+         return ([psCustomObject]@{name = 'Dummy' })
+      }
+   }
+
+   Context 'Add-VSTeamWorkItemType' {
+      BeforeAll {
+            [vsteam_lib.ProcessTemplateCache]::Invalidate()
+      }
+      It 'Calls the API with the expected body. ' {
+         Add-VSTeamWorkItemType -ProcessTemplate Scrum -WorkItemType NewWit -Description "New Work item Type" -Color Red  -Icon asterisk 
+         Should -Invoke _callApi -Exactly -Times 1 -Scope It -ParameterFilter {
+            $Url -like 'https://dev.azure.com/test/_apis/work/processes/6b724908-ef14-45cf-84f8-768b5384da45/workitemtypes?api-version=*' -and
+            $Body -match '"name":\s+"NewWit"' -and  
+            $Body -match '"color":\s+"ff0000"' -and
+            $Body -match '"icon":\s+"icon_asterisk"' -and  
+            $Body -match '"description":\s+"New Work item Type"' -and  
+            $Method -eq 'Post'
+         }
+      }
+   }
+}

--- a/Tests/function/tests/Add-VSTeamWorkItemType.Tests.ps1
+++ b/Tests/function/tests/Add-VSTeamWorkItemType.Tests.ps1
@@ -36,6 +36,7 @@ Describe 'AddVSTeamWorkItemType' {
       Mock _callApi -ParameterFilter { $Method -eq 'Post' } -MockWith {
          return ([psCustomObject]@{name = 'Dummy' })
       }
+      [vsteam_lib.ProcessTemplateCache]::Invalidate()
    }
 
    Context 'Add-VSTeamWorkItemType' {

--- a/Tests/function/tests/Add-VSTeamWorkItemType.Tests.ps1
+++ b/Tests/function/tests/Add-VSTeamWorkItemType.Tests.ps1
@@ -4,7 +4,6 @@ Describe 'AddVSTeamWorkItemType' {
    BeforeAll {
       . "$PSScriptRoot\_testInitialize.ps1" $PSCommandPath
       . "$PSScriptRoot\..\..\..\Source\Public\Get-VSTeamProcess.ps1"
-      . "$PSScriptRoot\..\..\..\Source\Public\Get-VSTeamWorkItemIconList.ps1"
 
       $Global:PSDefaultParameterValues.Remove("*-vsteam*:projectName")
 
@@ -16,27 +15,18 @@ Describe 'AddVSTeamWorkItemType' {
 
       Mock Get-VSTeamProcess {
          $processes = @(
-            [PSCustomObject]@{Name = "Scrum"; url = 'http://bogus.none/1'; ID = "6b724908-ef14-45cf-84f8-768b5384da45" },
-            [PSCustomObject]@{Name = "Basic"; url = 'http://bogus.none/2'; ID = "b8a3a935-7e91-48b8-a94c-606d37c3e9f2" },
-            [PSCustomObject]@{Name = "CMMI"; url = 'http://bogus.none/3'; ID = "27450541-8e31-4150-9947-dc59f998fc01" },
-            [PSCustomObject]@{Name = "Agile"; url = 'http://bogus.none/4'; ID = "adcc42ab-9882-485e-a3ed-7678f01f66bc" },
+            [PSCustomObject]@{Name = "Scrum";            url = 'http://bogus.none/1'; ID = "6b724908-ef14-45cf-84f8-768b5384da45" },
+            [PSCustomObject]@{Name = "Basic";            url = 'http://bogus.none/2'; ID = "b8a3a935-7e91-48b8-a94c-606d37c3e9f2" },
+            [PSCustomObject]@{Name = "CMMI";             url = 'http://bogus.none/3'; ID = "27450541-8e31-4150-9947-dc59f998fc01" },
+            [PSCustomObject]@{Name = "Agile";            url = 'http://bogus.none/4'; ID = "adcc42ab-9882-485e-a3ed-7678f01f66bc" },
             [PSCustomObject]@{Name = "Scrum With Space"; url = 'http://bogus.none/5'; ID = "12345678-0000-0000-0000-000000000000" }
          )
          if ($name) { return $processes.where( { $_.name -like $name }) }
-         else { return $processes }  
-      }
-      Mock _callApi -ParameterFilter { $resource -eq 'workitemicons' }  -MockWith {
-         return [pscustomobject]@{'Value' = @(
-               [pscustomobject]@{'ID' = 'icon_airplane' }
-               [pscustomobject]@{'ID' = 'icon_asterisk' }
-               [pscustomobject]@{'ID' = 'icon_Book' }
-            ) 
-         }
+         else { return $processes }
       }
       Mock _callApi -ParameterFilter { $Method -eq 'Post' } -MockWith {
          return ([psCustomObject]@{name = 'Dummy' })
       }
-      [vsteam_lib.ProcessTemplateCache]::Invalidate()
    }
 
    Context 'Add-VSTeamWorkItemType' {
@@ -44,13 +34,13 @@ Describe 'AddVSTeamWorkItemType' {
             [vsteam_lib.ProcessTemplateCache]::Invalidate()
       }
       It 'Calls the API with the expected body. ' {
-         Add-VSTeamWorkItemType -ProcessTemplate Scrum -WorkItemType NewWit -Description "New Work item Type" -Color Red  -Icon asterisk 
+         Add-VSTeamWorkItemType -ProcessTemplate Scrum -WorkItemType NewWit -Description "New Work item Type" -Color Red  -Icon asterisk
          Should -Invoke _callApi -Exactly -Times 1 -Scope It -ParameterFilter {
             $Url -like 'https://dev.azure.com/test/_apis/work/processes/6b724908-ef14-45cf-84f8-768b5384da45/workitemtypes?api-version=*' -and
-            $Body -match '"name":\s+"NewWit"' -and  
+            $Body -match '"name":\s+"NewWit"' -and
             $Body -match '"color":\s+"ff0000"' -and
-            $Body -match '"icon":\s+"icon_asterisk"' -and  
-            $Body -match '"description":\s+"New Work item Type"' -and  
+            $Body -match '"icon":\s+"icon_asterisk"' -and
+            $Body -match '"description":\s+"New Work item Type"' -and
             $Method -eq 'Post'
          }
       }

--- a/Tests/function/tests/Get-VSTeamAccessControlList.Tests.ps1
+++ b/Tests/function/tests/Get-VSTeamAccessControlList.Tests.ps1
@@ -4,6 +4,7 @@ Describe 'VSTeamAccessControlList' {
    BeforeAll {
       . "$PSScriptRoot\_testInitialize.ps1" $PSCommandPath
       . "$baseFolder/Source/Public/Set-VSTeamDefaultProject.ps1"
+      . "$baseFolder/Source/Public/Get-VSTeamProcess.ps1"
 
       ## Arrange
       # You have to set the version or the api-version will not be added when versions = ''
@@ -14,6 +15,13 @@ Describe 'VSTeamAccessControlList' {
       # Set the account to use for testing. A normal user would do this
       # using the Set-VSTeamAccount function.
       Mock _getInstance { return 'https://dev.azure.com/test' }
+      Mock Get-VSTeamProcess { return [PSCustomObject]@{
+            name   = 'CMMI'
+            id     = 1
+            Typeid = '00000000-0000-0000-0000-000000000002'
+         }
+      }
+
    }
 
    Context 'Get-VSTeamAccessControlList' {

--- a/Tests/function/tests/Get-VSTeamAgent.Tests.ps1
+++ b/Tests/function/tests/Get-VSTeamAgent.Tests.ps1
@@ -7,7 +7,7 @@ Describe 'VSTeamAgent' {
       
       ## Arrange
       Mock _getApiVersion { return '1.0-unitTests' } -ParameterFilter { $Service -eq 'DistributedTaskReleased' }
-
+      Mock Invoke-RestMethod { return @() } -ParameterFilter {$Uri -like "*_apis/work/processes*" }
       Mock _getInstance { return 'https://dev.azure.com/test' }
 
       # Even with a default set this URI should not have the project added.

--- a/Tests/function/tests/Get-VSTeamAgent.Tests.ps1
+++ b/Tests/function/tests/Get-VSTeamAgent.Tests.ps1
@@ -2,13 +2,22 @@ Set-StrictMode -Version Latest
 
 Describe 'VSTeamAgent' {
    BeforeAll {
-      . "$PSScriptRoot\_testInitialize.ps1" $PSCommandPath      
+      . "$PSScriptRoot\_testInitialize.ps1" $PSCommandPath
       . "$baseFolder/Source/Public/Set-VSTeamDefaultProject.ps1"
-      
+      . "$baseFolder/Source/Public/Get-VSTeamProcess.ps1"
+
+
       ## Arrange
       Mock _getApiVersion { return '1.0-unitTests' } -ParameterFilter { $Service -eq 'DistributedTaskReleased' }
       Mock Invoke-RestMethod { return @() } -ParameterFilter {$Uri -like "*_apis/work/processes*" }
       Mock _getInstance { return 'https://dev.azure.com/test' }
+      Mock Get-VSTeamProcess { return [PSCustomObject]@{
+            name   = 'CMMI'
+            id     = 1
+            Typeid = '00000000-0000-0000-0000-000000000002'
+         }
+      }
+      [vsteam_lib.ProcessTemplateCache]::Invalidate()
 
       # Even with a default set this URI should not have the project added.
       Set-VSTeamDefaultProject -Project Testing

--- a/Tests/function/tests/Get-VSTeamWorkItemIconList.Tests.ps1
+++ b/Tests/function/tests/Get-VSTeamWorkItemIconList.Tests.ps1
@@ -1,0 +1,25 @@
+Set-StrictMode -Version Latest
+
+Describe "VSTeam" {
+   BeforeAll {
+      . "$PSScriptRoot\_testInitialize.ps1" $PSCommandPath
+   }
+
+   Context "Get-VSTeamWorkItemIconList" {
+   
+      BeforeAll {
+         Mock _getInstance { return 'https://dev.azure.com/test' }
+         Mock _getApiVersion { return '1.0-unitTests' } 
+         Mock _callApi {return [pscustomObject]@{value="Dummy"}}
+      }
+      It 'Should call the API correctly' {
+
+         ## Act
+         Get-VSTeamWorkItemIconList
+         ## Assert
+         Should -Invoke _callApi -Exactly 1 -ParameterFilter {
+               $Area -eq 'wit' -and   $Resource -eq 'workitemicons' -and $IgnoreDefaultProject -eq $true
+         }
+      }
+   }
+}

--- a/Tests/function/tests/Get-VSTeamWorkItemState.Tests.ps1
+++ b/Tests/function/tests/Get-VSTeamWorkItemState.Tests.ps1
@@ -1,0 +1,42 @@
+Set-StrictMode -Version Latest
+
+Describe 'VSTeamWorkItemState' {
+   BeforeAll {
+      . "$PSScriptRoot\_testInitialize.ps1" $PSCommandPath
+      . "$PSScriptRoot\..\..\..\Source\Public\Get-VSTeamProcess.ps1"
+      . "$PSScriptRoot\..\..\..\Source\Public\Get-VSTeamWorkItemType.ps1"
+      ## Arrange
+      # Set the account to use for testing. A normal user would do this
+      # using the Set-VSTeamAccount function.
+      Mock _getInstance       { return 'https://dev.azure.com/test' }
+      Mock _getApiVersion     { return '1.0-unitTests' } -ParameterFilter { $Service -eq 'Processes' }
+      Mock _getDefaultProject { return "MockProject"}
+   }
+
+   Context 'Get-VSTeamWorkItemState' {
+      BeforeAll {
+         ## Arrange
+         Mock Get-VSTeamWorkItemType { Open-SampleFile 'bug.json'   }
+         Mock Get-VSTeamProcess { return @(
+              [PSCustomObject]@{
+                  Name = "Scrum"
+                  URL  = "https://dummy.none/_apis/work/processes/6b724908-ef14-45cf-84f8-768b5384da45"
+               }
+            )
+         }
+         [vsteam_lib.ProcessTemplateCache]::Invalidate()
+      }
+
+      It 'should get states and add WorkItem type and ProcessTemplate to them' {
+         ## Act
+         $states = Get-VSTeamWorkItemState -WorkItemType bug -ProcessTemplate Scrum  
+
+         ## Assert
+         Should -Invoke Get-VSTeamWorkItemType -Scope It -ParameterFilter {$Expand -eq 'States'} -Times 1 -Exactly
+         $states.count                 | Should -Be 4
+         $states[0].psobject.Typenames | Should -Contain 'vsteam_lib.WorkItemState'
+         $states[0].ProcessTemplate    | Should -Be      'Scrum'
+         $states[0].WorkItemType       | Should -Be      'Bug'
+      }
+   }
+}

--- a/Tests/function/tests/Get-VSTeamWorkItemState.Tests.ps1
+++ b/Tests/function/tests/Get-VSTeamWorkItemState.Tests.ps1
@@ -39,4 +39,9 @@ Describe 'VSTeamWorkItemState' {
          $states[0].WorkItemType       | Should -Be      'Bug'
       }
    }
+
+   AfterAll {
+         [vsteam_lib.Versions]::Account = ""
+   }
+
 }

--- a/Tests/function/tests/Get-VSTeamWorkItemState.Tests.ps1
+++ b/Tests/function/tests/Get-VSTeamWorkItemState.Tests.ps1
@@ -8,7 +8,7 @@ Describe 'VSTeamWorkItemState' {
       ## Arrange
       # Set the account to use for testing. A normal user would do this
       # using the Set-VSTeamAccount function.
-      Mock _getInstance       { return 'https://dev.azure.com/test' }
+      [vsteam_lib.Versions]::Account = 'https://dev.azure.com/test'
       Mock _getApiVersion     { return '1.0-unitTests' } -ParameterFilter { $Service -eq 'Processes' }
       Mock _getDefaultProject { return "MockProject"}
    }

--- a/Tests/function/tests/Get-VSTeamWorkItemState.Tests.ps1
+++ b/Tests/function/tests/Get-VSTeamWorkItemState.Tests.ps1
@@ -16,7 +16,7 @@ Describe 'VSTeamWorkItemState' {
    Context 'Get-VSTeamWorkItemState' {
       BeforeAll {
          ## Arrange
-         Mock Get-VSTeamWorkItemType { Open-SampleFile 'bug.json'   }
+         Mock Get-VSTeamWorkItemType { Open-SampleFile 'bug.json'| add-member -NotePropertyName "ProcessTemplate" -NotePropertyValue "Scrum" -PassThru}
          Mock Get-VSTeamProcess { return @(
               [PSCustomObject]@{
                   Name = "Scrum"
@@ -29,7 +29,7 @@ Describe 'VSTeamWorkItemState' {
 
       It 'should get states and add WorkItem type and ProcessTemplate to them' {
          ## Act
-         $states = Get-VSTeamWorkItemState -WorkItemType bug -ProcessTemplate Scrum  
+         $states = Get-VSTeamWorkItemState -WorkItemType bug -ProcessTemplate Scrum
 
          ## Assert
          Should -Invoke Get-VSTeamWorkItemType -Scope It -ParameterFilter {$Expand -eq 'States'} -Times 1 -Exactly

--- a/Tests/function/tests/Get-VSTeamWorkItemType.Tests.ps1
+++ b/Tests/function/tests/Get-VSTeamWorkItemType.Tests.ps1
@@ -23,6 +23,7 @@ Describe 'VSTeamWorkItemType' {
          if ($name) { return $processes.where( { $_.name -like $name }) }
          else { return $processes }  
       }
+      [vsteam_lib.ProcessTemplateCache]::Invalidate()
    }
 
    Context 'Get-VSTeamWorkItemType' {

--- a/Tests/function/tests/Get-VSTeamWorkItemType.Tests.ps1
+++ b/Tests/function/tests/Get-VSTeamWorkItemType.Tests.ps1
@@ -3,7 +3,7 @@ Set-StrictMode -Version Latest
 Describe 'VSTeamWorkItemType' {
    BeforeAll {
       . "$PSScriptRoot\_testInitialize.ps1" $PSCommandPath
-      . "$PSScriptRoot\..\..\..\Source\Public\Get-VSteamProcess.ps1"
+      . "$PSScriptRoot\..\..\..\Source\Public\Get-VSTeamProcess.ps1"
 
       $Global:PSDefaultParameterValues.Remove("*-vsteam*:projectName")
 

--- a/Tests/function/tests/Get-VSTeamWorkItemType.Tests.ps1
+++ b/Tests/function/tests/Get-VSTeamWorkItemType.Tests.ps1
@@ -3,6 +3,7 @@ Set-StrictMode -Version Latest
 Describe 'VSTeamWorkItemType' {
    BeforeAll {
       . "$PSScriptRoot\_testInitialize.ps1" $PSCommandPath
+      . "$PSScriptRoot\..\..\..\Source\Public\Get-VSteamProcess.ps1"
 
       $Global:PSDefaultParameterValues.Remove("*-vsteam*:projectName")
 
@@ -10,51 +11,84 @@ Describe 'VSTeamWorkItemType' {
       # Set the account to use for testing. A normal user would do this
       # using the Set-VSTeamAccount function.
       Mock _getInstance { return 'https://dev.azure.com/test' }
-      Mock _getApiVersion { return '1.0-unitTests' } -ParameterFilter { $Service -eq 'Core' }
+      Mock _getApiVersion { return '1.0-unitTests' } 
+      Mock Get-VSTeamProcess {
+         $processes = @(
+            [PSCustomObject]@{Name = "Scrum"; url = 'http://bogus.none/1'; ID = "6b724908-ef14-45cf-84f8-768b5384da45" },
+            [PSCustomObject]@{Name = "Basic"; url = 'http://bogus.none/2'; ID = "b8a3a935-7e91-48b8-a94c-606d37c3e9f2" },
+            [PSCustomObject]@{Name = "CMMI"; url = 'http://bogus.none/3'; ID = "27450541-8e31-4150-9947-dc59f998fc01" },
+            [PSCustomObject]@{Name = "Agile"; url = 'http://bogus.none/4'; ID = "adcc42ab-9882-485e-a3ed-7678f01f66bc" },
+            [PSCustomObject]@{Name = "Scrum With Space"; url = 'http://bogus.none/5'; ID = "12345678-0000-0000-0000-000000000000" }
+         )
+         if ($name) { return $processes.where( { $_.name -like $name }) }
+         else { return $processes }  
+      }
    }
 
    Context 'Get-VSTeamWorkItemType' {
       BeforeAll {
-         Mock Invoke-RestMethod { Open-SampleFile 'get-vsteamworkitemtype.json' -Json }
+         Mock Invoke-RestMethod { Get-Content "$sampleFiles\get-vsteamworkitemtype.json" -Raw  } ##<<This file doesn't properly read as JSON!!!
          Mock Invoke-RestMethod { Open-SampleFile 'bug.json' -Json } -ParameterFilter {
             $Uri -like "*bug*" 
          }
+         Mock Invoke-RestMethod { ( Get-Content "$sampleFiles\get-vsteamworkitemtype.json" -Raw ).Replace('"":', '"_end":') | ConvertFrom-Json  } -ParameterFilter {
+            $Uri -like "*processes*" 
+         }
+         Mock Invoke-RestMethod {@() } -ParameterFilter {
+            $Uri -like "*workitemtypecategories*" 
+         }
+       
       }
 
-      It 'with project only should return all work item types' {
+      It 'should return all work item types when called with project only' {
          ## Act
-         Get-VSTeamWorkItemType -ProjectName VSTeamWorkItemType
+         $wit = Get-VSTeamWorkItemType -ProjectName VSTeamWorkItemType
 
          ## Assert
          Should -Invoke Invoke-RestMethod -Exactly -Scope It -Times 1 -ParameterFilter {
             $Uri -eq "https://dev.azure.com/test/VSTeamWorkItemType/_apis/wit/workitemtypes?api-version=$(_getApiVersion Core)"
          }
+         $wit.count | should -BeGreaterThan 1
       }
 
-      It 'by type with default project should return 1 work item type' {
+
+      It 'should return 1 work item type when called with type & default project ' {
          ## Arrange
          $Global:PSDefaultParameterValues["*-vsteam*:projectName"] = 'VSTeamWorkItemType'
 
          ## Act
-         Get-VSTeamWorkItemType -WorkItemType bug
+         $wit = Get-VSTeamWorkItemType -WorkItemType bug
 
          ## Assert
          Should -Invoke Invoke-RestMethod -Exactly -Scope It -Times 1 -ParameterFilter {
-            $Uri -eq "https://dev.azure.com/test/VSTeamWorkItemType/_apis/wit/workitemtypes/bug?api-version=$(_getApiVersion Core)"
+            $Uri -eq "https://dev.azure.com/test/VSTeamWorkItemType/_apis/wit/workitemtypes?api-version=$(_getApiVersion Core)"
          }
+         $wit.count | Should -BeExactly 1
       }
 
-      It 'by type with explicit project should return 1 work item type' {
+      It 'should return 1 work item type when by with type & explicit project ' {
          ## Arrange
          $Global:PSDefaultParameterValues.Remove("*-vsteam*:projectName")
 
          ## Act
-         Get-VSTeamWorkItemType -ProjectName VSTeamWorkItemType -WorkItemType bug
+         $wit = Get-VSTeamWorkItemType -ProjectName VSTeamWorkItemType -WorkItemType bug
 
          ## Assert
          Should -Invoke Invoke-RestMethod -Exactly -Scope It -Times 1 -ParameterFilter {
-            $Uri -eq "https://dev.azure.com/test/VSTeamWorkItemType/_apis/wit/workitemtypes/bug?api-version=$(_getApiVersion Core)"
+            $Uri -eq "https://dev.azure.com/test/VSTeamWorkItemType/_apis/wit/workitemtypes?api-version=$(_getApiVersion Core)"
          }
+         $wit.count | should -BeExactly 1
       }
-   }
+
+      It 'should return all work item types when with processTemplate' {
+         ## Act   
+         $wit = Get-VSTeamWorkItemType -ProcessTemplate Scrum
+
+         ##Assert
+         Should -Invoke Invoke-RestMethod -Exactly -Scope It -Times 1 -ParameterFilter {
+            $Uri -like "https://dev.azure.com/test/_apis/work/processes/6b724908-ef14-45cf-84f8-768b5384da45/workitemtypes?api-version=$(_getApiVersion Processes)"
+         }
+         $wit.count | should -BeGreaterThan 1
+      }
+  }
 }

--- a/Tests/function/tests/Hide-VSTeamWorkItemState.Tests.ps1
+++ b/Tests/function/tests/Hide-VSTeamWorkItemState.Tests.ps1
@@ -1,0 +1,145 @@
+Set-StrictMode -Version Latest
+
+Describe 'VSTeamWorkItemState' {
+   BeforeAll {
+      . "$PSScriptRoot\_testInitialize.ps1" $PSCommandPath
+      . "$PSScriptRoot\..\..\..\Source\Public\Get-VSTeamProcess.ps1"
+      . "$PSScriptRoot\..\..\..\Source\Public\Get-VSTeamWorkItemType.ps1"
+      ## Arrange
+      # Set the account to use for testing. A normal user would do this
+      # using the Set-VSTeamAccount function.
+      Mock _getInstance   { return 'https://dev.azure.com/test' }
+      Mock _getApiVersion { return '1.0-unitTests' } -ParameterFilter { $Service -eq 'Processes' }
+     
+      Mock _callAPI       -ParameterFilter { $Url -match 'states' } {
+         return [PSCustomObject]@{
+                  id                 = '7b7e3e8c-e500-40b6-ad56-d59b8d64d757'
+                  name               = 'New'
+                  color              = 'b2b2b2'
+                  stateCategory      = 'Proposed'
+                  order              = 1
+                  url                = 'https://dummy.none/workItemTypes/Microsoft.VSTS.WorkItemTypes.Bug/states/7b7e3e8c-e500-40b6-ad56-d59b8d64d757'
+                  customizationType  = 'inherited'
+                  hidden             = $true
+               }
+      }
+      Mock _callAPI       { return $null}
+   }
+
+   Context 'Hide-VsteamWorkItemState' {
+      BeforeAll {
+         #Different version of bug with states set for this test
+         $bug = @{
+            name          = 'Bug'
+            customization = 'System'
+            color         = 'CC293D'
+            description   = 'Describes a divergence between required and actual behavior, and tracks the work done to correct the defect and verify the correction.'
+            icon          = 'Icon_Insect'
+            isDisabled    =  $false
+            referenceName = 'Microsoft.VSTS.WorkItemTypes.Bug'
+            url           = 'https://dummy.none/workItemTypes/Microsoft.VSTS.WorkItemTypes.Bug'
+            states        = @( 
+               [PSCustomObject]@{
+                  id                 = '7b7e3e8c-e500-40b6-ad56-d59b8d64d757'
+                  name               = 'New'
+                  color              = 'b2b2b2'
+                  stateCategory      = 'Proposed'
+                  order              = 1
+                  url                = 'https://dummy.none/workItemTypes/Microsoft.VSTS.WorkItemTypes.Bug/states/7b7e3e8c-e500-40b6-ad56-d59b8d64d757'
+                  customizationType  = 'system'
+               },
+               [PSCustomObject]@{
+                  id                 = '02cca570-0896-4a30-aff1-87ccffc68ce0'
+                  name               = 'Approved'
+                  color              = 'b2b2b2'
+                  stateCategory      = 'Proposed'
+                  order              = 2
+                  url                = 'https://dummy.none/workItemTypes/Microsoft.VSTS.WorkItemTypes.Bug/states/02cca570-0896-4a30-aff1-87ccffc68ce0'
+                  customizationType  = 'inherited'
+               }
+               [PSCustomObject]@{
+                  id                 = 'abb54c86-d03a-44fe-8216-309d3c712296'
+                  name               = 'Committed'
+                  color              = '007acc'
+                  stateCategory      = 'InProgress'
+                  order              = 3
+                  url                = 'https://dummy.none/workItemTypes/Microsoft.VSTS.WorkItemTypes.Bug/states/abb54c86-d03a-44fe-8216-309d3c712296'
+                  customizationType  = 'system'
+               }
+               [PSCustomObject]@{
+                  id                 = '000000'
+                  name               = 'Postponed'
+                  color              = '0000ff'
+                  stateCategory      = 'InProgress'
+                  order              = 4
+                  url                = 'https://dummy.none/workItemTypes/Microsoft.VSTS.WorkItemTypes.Bug/states/00000'
+                  customizationType  = 'Custom'
+               }
+               [PSCustomObject]@{
+                  id                 = '0c926c15-68f7-467f-96c9-a26a19e9d718'
+                  name               = 'Done'
+                  color              = '339933'
+                  stateCategory      = 'Completed'
+                  order              = 5
+                  url                = 'https://dummy.none/workItemTypes/Microsoft.VSTS.WorkItemTypes.Bug/states/0c926c15-68f7-467f-96c9-a26a19e9d718'
+                  customizationType  = 'system'
+               }
+               [PSCustomObject]@{
+                  id                 = '0293a2ce-2a42-4d0e-bbbf-d2237efa0db8'
+                  name               = 'Removed'
+                  color              = 'ffffff'
+                  stateCategory      = 'Removed'
+                  order              = 6
+                  url                = 'https://dummy.none/workItemTypes/Microsoft.VSTS.WorkItemTypes.Bug/states/0293a2ce-2a42-4d0e-bbbf-d2237efa0db8'
+                  customizationType  = 'system'
+               }
+            )
+         }  
+         Mock Get-VSTeamWorkItemType {return $bug }
+         Mock Get-VSTeamProcess { return @(
+               [PSCustomObject]@{
+                  Name = 'Scrum2'
+                  URL  = 'https://dummy.none/_apis/work/processes/6b724908-ef14-45cf-84f8-768b5384da45'
+               }
+            )
+         }
+         [vsteam_lib.ProcessTemplateCache]::Invalidate()
+         Mock Write-Warning {}
+      }
+
+      It 'should warn for states which have already been hidden' {
+         ## Act
+         $state = Hide-VsteamWorkItemState -WorkItemType bug -Name Resolved -ProcessTemplate Scrum2 -Force 
+
+         ## Assert
+         Should -Invoke Get-VSTeamWorkItemType   -ParameterFilter {
+            $Expand       -eq "States" -and 
+            $WorkItemType -eq "Bug"
+         }  -Scope It                 -Times 1 -Exactly
+         Should -Invoke Write-Warning -Times 1 -Exactly
+         Should -invoke _callAPI      -Times 0 -Exactly
+          $State | Should -BeNullOrEmpty
+      }
+      It 'should call the REST API with the PUT method and the correct URL to hide a system WorkItem state' {
+         ## Act
+         $state = Hide-VsteamWorkItemState -WorkItemType bug -Name New -ProcessTemplate Scrum2 -Force 
+         
+         ## Assert
+
+         Should -Invoke Get-VSTeamWorkItemType -ParameterFilter {
+            $Expand       -eq "States" -and 
+            $WorkItemType -eq "Bug"
+         } -Scope It                   -Times 1 -Exactly
+         Should -Invoke _callAPI               -ParameterFilter {
+               $method -eq  'PUT' -and 
+               $url -match "WorkItemTypes\.Bug/states/7b7e3e8c-e500-40b6-ad56-d59b8d64d757\?api-version=" -and
+               $body -match '"hidden"\s*:\s*true'
+         } -Scope It                    -Times 1 -Exactly 
+         Should -Invoke Write-Warning -Times 0 -Exactly
+         $state.Psobject.typenames  | Should -Contain 'vsteam_lib.WorkItemState'
+         $state.ProcessTemplate     | should -be      'Scrum2'
+         $state.WorkItemType        | should -be      'bug'
+      }
+   }
+}
+

--- a/Tests/function/tests/Hide-VSTeamWorkItemState.Tests.ps1
+++ b/Tests/function/tests/Hide-VSTeamWorkItemState.Tests.ps1
@@ -145,5 +145,10 @@ Describe 'VSTeamWorkItemState' {
          $state.WorkItemType        | should -be      'bug'
       }
    }
+
+   AfterAll {
+         [vsteam_lib.Versions]::Account = ""
+   }
+
 }
 

--- a/Tests/function/tests/Hide-VSTeamWorkItemState.Tests.ps1
+++ b/Tests/function/tests/Hide-VSTeamWorkItemState.Tests.ps1
@@ -9,7 +9,7 @@ Describe 'VSTeamWorkItemState' {
       ## Arrange
       # Set the account to use for testing. A normal user would do this
       # using the Set-VSTeamAccount function.
-      Mock _getInstance   { return 'https://dev.azure.com/test' }
+      [vsteam_lib.Versions]::Account = 'https://dev.azure.com/test'
       Mock _getApiVersion { return '1.0-unitTests' } -ParameterFilter { $Service -eq 'Processes' }
 
       Mock _callAPI       -ParameterFilter { $Url -match 'states' } {

--- a/Tests/function/tests/Remove-VSTeamWorkItemState.Tests.ps1
+++ b/Tests/function/tests/Remove-VSTeamWorkItemState.Tests.ps1
@@ -1,0 +1,108 @@
+Set-StrictMode -Version Latest
+
+Describe 'VSTeamWorkItemState' {
+   BeforeAll {
+      . "$PSScriptRoot\_testInitialize.ps1" $PSCommandPath
+      . "$PSScriptRoot\..\..\..\Source\Public\Get-VSTeamProcess.ps1"
+      . "$PSScriptRoot\..\..\..\Source\Public\Get-VSTeamWorkItemType.ps1"
+      ## Arrange
+      # Set the account to use for testing. A normal user would do this
+      # using the Set-VSTeamAccount function.
+      Mock _getInstance   { return 'https://dev.azure.com/test' }
+      Mock _getApiVersion { return '1.0-unitTests' } -ParameterFilter { $Service -eq 'Processes' }
+      Mock _callAPI       {return $null}
+   }
+
+   Context 'Remove-VsteamWorkItemState' {
+      BeforeAll {
+         $bug = @{
+            name          = 'Bug'
+            customization = 'System'
+            color         = 'CC293D'
+            description   = 'Describes a divergence between required and actual behavior, and tracks the work done to correct the defect and verify the correction.'
+            icon          = 'Icon_Insect'
+            isDisabled    =  $false
+            referenceName = 'Microsoft.VSTS.WorkItemTypes.Bug'
+            url           = 'https://dummy.none/workItemTypes/Microsoft.VSTS.WorkItemTypes.Bug'
+            states        = @( 
+               [PSCustomObject]@{
+                  id                 = '7b7e3e8c-e500-40b6-ad56-d59b8d64d757'
+                  name               = 'New'
+                  color              = 'b2b2b2'
+                  stateCategory      = 'Proposed'
+                  order              = 1
+                  url                = 'https://dummy.none/workItemTypes/Microsoft.VSTS.WorkItemTypes.Bug/states/7b7e3e8c-e500-40b6-ad56-d59b8d64d757'
+                  customizationType  = 'system'
+               },
+               [PSCustomObject]@{
+                  id                 = '02cca570-0896-4a30-aff1-87ccffc68ce0'
+                  name               = 'Approved'
+                  color              = 'b2b2b2'
+                  stateCategory      = 'Proposed'
+                  order              = 2
+                  url                = 'https://dummy.none/workItemTypes/Microsoft.VSTS.WorkItemTypes.Bug/states/02cca570-0896-4a30-aff1-87ccffc68ce0'
+                  customizationType  = 'system'
+               }
+               [PSCustomObject]@{
+                  id                 = 'abb54c86-d03a-44fe-8216-309d3c712296'
+                  name               = 'Committed'
+                  color              = '007acc'
+                  stateCategory      = 'InProgress'
+                  order              = 3
+                  url                = 'https://dummy.none/workItemTypes/Microsoft.VSTS.WorkItemTypes.Bug/states/abb54c86-d03a-44fe-8216-309d3c712296'
+                  customizationType  = 'system'
+               }
+               [PSCustomObject]@{
+                  id                 = '000000'
+                  name               = 'Postponed'
+                  color              = '0000ff'
+                  stateCategory      = 'InProgress'
+                  order              = 4
+                  url                = 'https://dummy.none/workItemTypes/Microsoft.VSTS.WorkItemTypes.Bug/states/00000'
+                  customizationType  = 'Custom'
+               }
+               [PSCustomObject]@{
+                  id                 = '0c926c15-68f7-467f-96c9-a26a19e9d718'
+                  name               = 'Done'
+                  color              = '339933'
+                  stateCategory      = 'Completed'
+                  order              = 5
+                  url                = 'https://dummy.none/workItemTypes/Microsoft.VSTS.WorkItemTypes.Bug/states/0c926c15-68f7-467f-96c9-a26a19e9d718'
+                  customizationType  = 'system'
+               }
+               [PSCustomObject]@{
+                  id                 = '0293a2ce-2a42-4d0e-bbbf-d2237efa0db8'
+                  name               = 'Removed'
+                  color              = 'ffffff'
+                  stateCategory      = 'Removed'
+                  order              = 6
+                  url                = 'https://dummy.none/workItemTypes/Microsoft.VSTS.WorkItemTypes.Bug/states/0293a2ce-2a42-4d0e-bbbf-d2237efa0db8'
+                  customizationType  = 'system'
+               }
+            )
+         }  
+         Mock Get-VSTeamWorkItemType {return $bug }
+         Mock Get-VSTeamProcess { return @(
+               [PSCustomObject]@{
+                  Name = 'Scrum2'
+                  URL  = 'https://dummy.none/_apis/work/processes/6b724908-ef14-45cf-84f8-768b5384da45'
+               }
+            )
+         }
+         [vsteam_lib.ProcessTemplateCache]::Invalidate()
+      }
+
+      It 'should call the REST API with the Delete method and the correct URL to remove a custom WorkItem state' {
+         ## Act
+         Remove-VsteamWorkItemState -WorkItemType bug -Name postponed -ProcessTemplate Scrum2 -Force 
+
+         ## Assert
+         Should -Invoke _callAPI -Scope It  -Times 1 -Exactly -ParameterFilter {
+               $method -eq  'Delete' -and 
+               $url -match "WorkItemTypes\.Bug/states/000000\?api-version="
+         }
+         
+      }
+   }
+}
+

--- a/Tests/function/tests/Remove-VSTeamWorkItemState.Tests.ps1
+++ b/Tests/function/tests/Remove-VSTeamWorkItemState.Tests.ps1
@@ -104,5 +104,10 @@ Describe 'VSTeamWorkItemState' {
 
       }
    }
+
+   AfterAll {
+         [vsteam_lib.Versions]::Account = ""
+   }
+
 }
 

--- a/Tests/function/tests/Remove-VSTeamWorkItemState.Tests.ps1
+++ b/Tests/function/tests/Remove-VSTeamWorkItemState.Tests.ps1
@@ -8,7 +8,7 @@ Describe 'VSTeamWorkItemState' {
       ## Arrange
       # Set the account to use for testing. A normal user would do this
       # using the Set-VSTeamAccount function.
-      Mock _getInstance   { return 'https://dev.azure.com/test' }
+      [vsteam_lib.Versions]::Account = 'https://dev.azure.com/test'
       Mock _getApiVersion { return '1.0-unitTests' } -ParameterFilter { $Service -eq 'Processes' }
       Mock _callAPI       {return $null}
    }
@@ -24,7 +24,7 @@ Describe 'VSTeamWorkItemState' {
             isDisabled    =  $false
             referenceName = 'Microsoft.VSTS.WorkItemTypes.Bug'
             url           = 'https://dummy.none/workItemTypes/Microsoft.VSTS.WorkItemTypes.Bug'
-            states        = @( 
+            states        = @(
                [PSCustomObject]@{
                   id                 = '7b7e3e8c-e500-40b6-ad56-d59b8d64d757'
                   name               = 'New'
@@ -80,7 +80,7 @@ Describe 'VSTeamWorkItemState' {
                   customizationType  = 'system'
                }
             )
-         }  
+         }
          Mock Get-VSTeamWorkItemType {return $bug }
          Mock Get-VSTeamProcess { return @(
                [PSCustomObject]@{
@@ -94,14 +94,14 @@ Describe 'VSTeamWorkItemState' {
 
       It 'should call the REST API with the Delete method and the correct URL to remove a custom WorkItem state' {
          ## Act
-         Remove-VsteamWorkItemState -WorkItemType bug -Name postponed -ProcessTemplate Scrum2 -Force 
+         Remove-VsteamWorkItemState -WorkItemType bug -Name postponed -ProcessTemplate Scrum2 -Force
 
          ## Assert
          Should -Invoke _callAPI -Scope It  -Times 1 -Exactly -ParameterFilter {
-               $method -eq  'Delete' -and 
+               $method -eq  'Delete' -and
                $url -match "WorkItemTypes\.Bug/states/000000\?api-version="
          }
-         
+
       }
    }
 }

--- a/Tests/function/tests/Remove-VSTeamWorkItemType.Tests.ps1
+++ b/Tests/function/tests/Remove-VSTeamWorkItemType.Tests.ps1
@@ -52,6 +52,7 @@ Describe 'RemoveVSTeamWorkItemType' {
          else               { return $wits }  
       } 
       [vsteam_lib.IconCache]::Invalidate()
+      [vsteam_lib.ProcessTemplateCache]::Invalidate()
    }
 
    Context 'Delete workItem Type' {

--- a/Tests/function/tests/Remove-VSTeamWorkItemType.Tests.ps1
+++ b/Tests/function/tests/Remove-VSTeamWorkItemType.Tests.ps1
@@ -1,9 +1,9 @@
 Set-StrictMode -Version Latest
 
-Describe 'VSTeamWorkItemType' {
+Describe 'RemoveVSTeamWorkItemType' {
    BeforeAll {
       . "$PSScriptRoot\_testInitialize.ps1" $PSCommandPath
-      . "$PSScriptRoot\..\..\..\Source\Public\Get-VSteamProcess.ps1" 
+      . "$PSScriptRoot\..\..\..\Source\Public\Get-VSTeamProcess.ps1" 
       . "$PSScriptRoot\..\..\..\Source\Public\Get-VSTeamWorkItemType.ps1"
 
       $Global:PSDefaultParameterValues.Remove("*-vsteam*:projectName")

--- a/Tests/function/tests/Remove-VSTeamWorkItemType.Tests.ps1
+++ b/Tests/function/tests/Remove-VSTeamWorkItemType.Tests.ps1
@@ -1,0 +1,76 @@
+Set-StrictMode -Version Latest
+
+Describe 'VSTeamWorkItemType' {
+   BeforeAll {
+      . "$PSScriptRoot\_testInitialize.ps1" $PSCommandPath
+      . "$PSScriptRoot\..\..\..\Source\Public\Get-VSteamProcess.ps1" 
+      . "$PSScriptRoot\..\..\..\Source\Public\Get-VSTeamWorkItemType.ps1"
+
+      $Global:PSDefaultParameterValues.Remove("*-vsteam*:projectName")
+
+      ## Arrange
+      # Set the account to use for testing. A normal user would do this
+      # using the Set-VSTeamAccount function.
+      Mock _getInstance { return 'https://dev.azure.com/test' }
+      Mock _getApiVersion { return '1.0-unitTests' } -ParameterFilter { $Service -eq 'Processes' }
+
+      Mock Get-VSTeamProcess {
+         $processes = @(
+            [PSCustomObject]@{Name = "Scrum"; url = 'http://bogus.none/1'; ID = "6b724908-ef14-45cf-84f8-768b5384da45" },
+            [PSCustomObject]@{Name = "Basic"; url = 'http://bogus.none/2'; ID = "b8a3a935-7e91-48b8-a94c-606d37c3e9f2" },
+            [PSCustomObject]@{Name = "CMMI"; url = 'http://bogus.none/3'; ID = "27450541-8e31-4150-9947-dc59f998fc01" },
+            [PSCustomObject]@{Name = "Agile"; url = 'http://bogus.none/4'; ID = "adcc42ab-9882-485e-a3ed-7678f01f66bc" },
+            [PSCustomObject]@{Name = "Scrum With Space"; url = 'http://bogus.none/5'; ID = "12345678-0000-0000-0000-000000000000" }
+         )
+         if ($name) { return $processes.where( { $_.name -like $name }) }
+         else { return $processes }  
+      }
+      Mock _callApi -ParameterFilter {$Method -eq 'Delete'} {
+            return $null
+      }
+      Mock Get-VSTeamWorkItemType {
+            $wits = @(
+                  [psCustomObject]@{name          = 'Bug'
+                                    customization = 'system'
+                                    referenceName = 'Microsoft.VSTS.WorkItemTypes.Bug'
+                                    icon          = 'icon_insect'
+                                    color         = 'cc293d'
+                                    isDisabled    =  $false
+                                    description   = 'A divergence...' 
+                                    url           = 'http://bogus.none/98'
+                  }
+                  [psCustomObject]@{name          = 'Gub'
+                                    customization = 'custom'
+                                    icon          = 'icon_book'
+                                    color         = 'ff0000'
+                                    isDisabled    =  $false
+                                    description   = 'Test Item' 
+                                    url           = 'http://bogus.none/99';
+                  }
+               )
+         if ($WorkItemType) { return $wits.where( { $_.name -like $WorkItemType }) }
+         else               { return $wits }  
+      } 
+      [vsteam_lib.IconCache]::Invalidate()
+   }
+
+   Context 'Delete workItem Type' {
+
+      It 'Catches invalid WorkItem type names.' {
+         Remove-VSTeamWorkItemType -ProcessTemplate "Scrum With Space" -WorkItemType NewWit -WarningVariable "Warn" -warningAction SilentlyContinue
+         # Should not call the rest API from the function body, but may populate the work-item icons cache 
+         Should -Invoke _callApi -Exactly -Times 0 -Scope It {-not ($resource -eq "workitemicons")} 
+         $warn | Should -Be "'NewWit' does not appear to be a valid Workitem type."
+      }
+      It 'Deletes custom WorkItem types.' {
+         Remove-VSTeamWorkItemType -ProcessTemplate "Scrum With Space" -WorkItemType Gub -Force
+         Should -Invoke _callApi -Exactly -Times 1 -Scope It -ParameterFilter {
+            $Url    -like     '*99?api-version=*'           -and  #found expected item
+            $Method -eq       'Delete'
+         }
+      }
+       It 'Rejects deletion for system WorkItem Types' {
+         {Remove-VSTeamWorkItemType -ProcessTemplate "Scrum With Space" -WorkItemType Bug } | should -Throw
+      }
+   }
+}

--- a/Tests/function/tests/Remove-VSTeamWorkItemType.Tests.ps1
+++ b/Tests/function/tests/Remove-VSTeamWorkItemType.Tests.ps1
@@ -3,7 +3,7 @@ Set-StrictMode -Version Latest
 Describe 'RemoveVSTeamWorkItemType' {
    BeforeAll {
       . "$PSScriptRoot\_testInitialize.ps1" $PSCommandPath
-      . "$PSScriptRoot\..\..\..\Source\Public\Get-VSTeamProcess.ps1" 
+      . "$PSScriptRoot\..\..\..\Source\Public\Get-VSTeamProcess.ps1"
       . "$PSScriptRoot\..\..\..\Source\Public\Get-VSTeamWorkItemType.ps1"
 
       $Global:PSDefaultParameterValues.Remove("*-vsteam*:projectName")
@@ -23,7 +23,7 @@ Describe 'RemoveVSTeamWorkItemType' {
             [PSCustomObject]@{Name = "Scrum With Space"; url = 'http://bogus.none/5'; ID = "12345678-0000-0000-0000-000000000000" }
          )
          if ($name) { return $processes.where( { $_.name -like $name }) }
-         else { return $processes }  
+         else { return $processes }
       }
       Mock _callApi -ParameterFilter {$Method -eq 'Delete'} {
             return $null
@@ -36,7 +36,7 @@ Describe 'RemoveVSTeamWorkItemType' {
                                     icon          = 'icon_insect'
                                     color         = 'cc293d'
                                     isDisabled    =  $false
-                                    description   = 'A divergence...' 
+                                    description   = 'A divergence...'
                                     url           = 'http://bogus.none/98'
                   }
                   [psCustomObject]@{name          = 'Gub'
@@ -44,13 +44,13 @@ Describe 'RemoveVSTeamWorkItemType' {
                                     icon          = 'icon_book'
                                     color         = 'ff0000'
                                     isDisabled    =  $false
-                                    description   = 'Test Item' 
+                                    description   = 'Test Item'
                                     url           = 'http://bogus.none/99';
                   }
                )
          if ($WorkItemType) { return $wits.where( { $_.name -like $WorkItemType }) }
-         else               { return $wits }  
-      } 
+         else               { return $wits }
+      }
       [vsteam_lib.IconCache]::Invalidate()
       [vsteam_lib.ProcessTemplateCache]::Invalidate()
    }
@@ -59,9 +59,9 @@ Describe 'RemoveVSTeamWorkItemType' {
 
       It 'Catches invalid WorkItem type names.' {
          Remove-VSTeamWorkItemType -ProcessTemplate "Scrum With Space" -WorkItemType NewWit -WarningVariable "Warn" -warningAction SilentlyContinue
-         # Should not call the rest API from the function body, but may populate the work-item icons cache 
-         Should -Invoke _callApi -Exactly -Times 0 -Scope It {-not ($resource -eq "workitemicons")} 
-         $warn | Should -Be "'NewWit' does not appear to be a valid Workitem type."
+         # Should not call the rest API from the function body, but may populate the work-item icons cache
+         Should -Invoke _callApi -Exactly -Times 0 -Scope It {-not ($resource -eq "workitemicons")}
+         $warn | Should -Match "'NewWit'.*Workitem type."
       }
       It 'Deletes custom WorkItem types.' {
          Remove-VSTeamWorkItemType -ProcessTemplate "Scrum With Space" -WorkItemType Gub -Force
@@ -71,7 +71,10 @@ Describe 'RemoveVSTeamWorkItemType' {
          }
       }
        It 'Rejects deletion for system WorkItem Types' {
-         {Remove-VSTeamWorkItemType -ProcessTemplate "Scrum With Space" -WorkItemType Bug } | should -Throw
+         Remove-VSTeamWorkItemType -ProcessTemplate "Scrum With Space" -WorkItemType Bug -WarningVariable "Warn" -warningAction SilentlyContinue
+         Should -Invoke _callApi -Exactly -Times 0  -Scope It {-not ($resource -eq "workitemicons")}
+         $warn | Should -Match "'Bug'.*Workitem type."
+
       }
    }
 }

--- a/Tests/function/tests/Set-VSTeamDefaultProject.Tests.ps1
+++ b/Tests/function/tests/Set-VSTeamDefaultProject.Tests.ps1
@@ -3,9 +3,9 @@ Set-StrictMode -Version Latest
 Describe 'VSTeamDefaultProject' {
    BeforeAll {
       . "$PSScriptRoot\_testInitialize.ps1" $PSCommandPath
-
+      . "$PSScriptRoot\_testInitialize.ps1" Get-VSTeamProcess
       Mock _getInstance { return 'https://dev.azure.com/test' }
-      Mock Invoke-RestMethod { return @() } -ParameterFilter {$Uri -like "*_apis/work/processes*" }
+      Mock Get-VSTeamProcess { return @() }
    }
 
    Context 'Set-VSTeamDefaultProject' {

--- a/Tests/function/tests/Set-VSTeamDefaultProject.Tests.ps1
+++ b/Tests/function/tests/Set-VSTeamDefaultProject.Tests.ps1
@@ -5,6 +5,7 @@ Describe 'VSTeamDefaultProject' {
       . "$PSScriptRoot\_testInitialize.ps1" $PSCommandPath
 
       Mock _getInstance { return 'https://dev.azure.com/test' }
+      Mock Invoke-RestMethod { return @() } -ParameterFilter {$Uri -like "*_apis/work/processes*" }
    }
 
    Context 'Set-VSTeamDefaultProject' {

--- a/Tests/function/tests/Set-VSTeamWorkItemType.Tests.ps1
+++ b/Tests/function/tests/Set-VSTeamWorkItemType.Tests.ps1
@@ -3,8 +3,6 @@ Set-StrictMode -Version Latest
 Describe 'VSTeamWorkItemType' {
    BeforeAll {
       . "$PSScriptRoot\_testInitialize.ps1" $PSCommandPath
-      . "$PSScriptRoot\..\..\..\Source\Public\Get-VSTeamProcess.ps1"
-      . "$PSScriptRoot\..\..\..\Source\Public\Get-VSTeamWorkItemIconList.ps1"
       . "$PSScriptRoot\..\..\..\Source\Public\Get-VSTeamWorkItemType.ps1"
       . "$PSScriptRoot\..\..\..\Source\Public\Unlock-VSTeamWorkItemType.ps1"
       $Global:PSDefaultParameterValues.Remove("*-vsteam*:projectName")
@@ -15,25 +13,6 @@ Describe 'VSTeamWorkItemType' {
       Mock _getInstance { return 'https://dev.azure.com/test' }
       Mock _getApiVersion { return '1.0-unitTests' } -ParameterFilter { $Service -eq 'Processes' }
 
-      Mock Get-VSTeamProcess {
-         $processes = @(
-            [PSCustomObject]@{Name = "Scrum"; url = 'http://bogus.none/1'; ID = "6b724908-ef14-45cf-84f8-768b5384da45" },
-            [PSCustomObject]@{Name = "Basic"; url = 'http://bogus.none/2'; ID = "b8a3a935-7e91-48b8-a94c-606d37c3e9f2" },
-            [PSCustomObject]@{Name = "CMMI"; url = 'http://bogus.none/3'; ID = "27450541-8e31-4150-9947-dc59f998fc01" },
-            [PSCustomObject]@{Name = "Agile"; url = 'http://bogus.none/4'; ID = "adcc42ab-9882-485e-a3ed-7678f01f66bc" },
-            [PSCustomObject]@{Name = "Scrum With Space"; url = 'http://bogus.none/5'; ID = "12345678-0000-0000-0000-000000000000" }
-         )
-         if ($name) { return $processes.where( { $_.name -like $name }) }
-         else { return $processes }
-      }
-      Mock _callApi -ParameterFilter { $resource -eq 'workitemicons' }  -MockWith {
-        return [pscustomobject]@{'Value' = @(
-               [pscustomobject]@{'ID' = 'icon_airplane' }
-               [pscustomobject]@{'ID' = 'icon_asterisk' }
-               [pscustomobject]@{'ID' = 'icon_book' }
-            )
-         }
-      }
       Mock _callApi -ParameterFilter { $Method -eq 'Post' } -MockWith {
          return ([psCustomObject]@{name = 'Dummy' })
       }
@@ -42,29 +21,30 @@ Describe 'VSTeamWorkItemType' {
       }
       Mock Get-VSTeamWorkItemType   {
             $wits = @(
-                  [psCustomObject]@{name          = 'Bug'
-                                    customization = 'system'
-                                    referenceName = 'Microsoft.VSTS.WorkItemTypes.Bug'
-                                    icon          = 'icon_insect'
-                                    color         = 'cc293d'
-                                    isDisabled    =  $false
-                                    description   = 'A divergence...'
-                                    url           = 'http://bogus.none/workitemTypes/98'
+                  [psCustomObject]@{name            = 'Bug'
+                                    customization   = 'system'
+                                    referenceName   = 'Microsoft.VSTS.WorkItemTypes.Bug'
+                                    icon            = 'icon_insect'
+                                    color           = 'cc293d'
+                                    isDisabled      =  $false
+                                    description     = 'A divergence...'
+                                    url             = 'http://bogus.none/workitemTypes/98'
+                                    processTemplate = 'scrum'
                   }
-                  [psCustomObject]@{name          = 'Gub'
-                                    customization = 'custom'
-                                    icon          = 'icon_book'
-                                    color         = 'ff0000'
-                                    isDisabled    =  $false
-                                    description   = 'Test Item'
-                                    url           = 'http://bogus.none/workitemTypes/99';
+                  [psCustomObject]@{name            = 'Gub'
+                                    customization   = 'custom'
+                                    icon            = 'icon_book'
+                                    color           = 'ff0000'
+                                    isDisabled      =  $false
+                                    description     = 'Test Item'
+                                    url             = 'http://bogus.none/workitemTypes/99'
+                                    processTemplate = 'scrum'
                   }
                )
          if ($WorkItemType) { return $wits.where( { $_.name -like $WorkItemType }) }
          else               { return $wits }
       }
-      [vsteam_lib.IconCache]::Invalidate()
-      [vsteam_lib.ProcessTemplateCache]::Invalidate()
+
 
        Mock Write-Warning {
          return

--- a/Tests/function/tests/Set-VSTeamWorkItemType.Tests.ps1
+++ b/Tests/function/tests/Set-VSTeamWorkItemType.Tests.ps1
@@ -49,7 +49,7 @@ Describe 'VSTeamWorkItemType' {
                                     color         = 'cc293d'
                                     isDisabled    =  $false
                                     description   = 'A divergence...'
-                                    url           = 'http://bogus.none/98'
+                                    url           = 'http://bogus.none/workitemTypes/98'
                   }
                   [psCustomObject]@{name          = 'Gub'
                                     customization = 'custom'
@@ -57,7 +57,7 @@ Describe 'VSTeamWorkItemType' {
                                     color         = 'ff0000'
                                     isDisabled    =  $false
                                     description   = 'Test Item'
-                                    url           = 'http://bogus.none/99';
+                                    url           = 'http://bogus.none/workitemTypes/99';
                   }
                )
          if ($WorkItemType) { return $wits.where( { $_.name -like $WorkItemType }) }
@@ -89,7 +89,7 @@ Describe 'VSTeamWorkItemType' {
        It 'Posts changes for system WorkItem Types' {
          Set-VSTeamWorkItemType -ProcessTemplate "Scrum With Space" -WorkItemType Bug -Disabled -Force
          Should -Invoke _callApi -Exactly -Times 1 -Scope It -ParameterFilter {
-            $Url    -like     '*98?api-version=*'           -and  #found expected item
+            $Url    -like     '*workitemTypes?api-version=*'           -and  #found expected item
             $Body   -match    '"isDisabled":\s+true'        -and
             $Body   -match    '"inheritsFrom":\s+"Microsoft.VSTS.WorkItemTypes.Bug"' -and
             $Method -eq       'Post'

--- a/Tests/function/tests/Set-VSTeamWorkItemType.Tests.ps1
+++ b/Tests/function/tests/Set-VSTeamWorkItemType.Tests.ps1
@@ -1,0 +1,98 @@
+Set-StrictMode -Version Latest
+
+Describe 'VSTeamWorkItemType' {
+   BeforeAll {
+      . "$PSScriptRoot\_testInitialize.ps1" $PSCommandPath
+      . "$PSScriptRoot\..\..\..\Source\Public\Get-VSteamProcess.ps1"
+      . "$PSScriptRoot\..\..\..\Source\Public\Get-VSTeamWorkItemIconList"
+      . "$PSScriptRoot\..\..\..\Source\Public\Get-VSTeamWorkItemType.ps1"
+
+      $Global:PSDefaultParameterValues.Remove("*-vsteam*:projectName")
+
+      ## Arrange
+      # Set the account to use for testing. A normal user would do this
+      # using the Set-VSTeamAccount function.
+      Mock _getInstance { return 'https://dev.azure.com/test' }
+      Mock _getApiVersion { return '1.0-unitTests' } -ParameterFilter { $Service -eq 'Processes' }
+
+      Mock Get-VSTeamProcess {
+         $processes = @(
+            [PSCustomObject]@{Name = "Scrum"; url = 'http://bogus.none/1'; ID = "6b724908-ef14-45cf-84f8-768b5384da45" },
+            [PSCustomObject]@{Name = "Basic"; url = 'http://bogus.none/2'; ID = "b8a3a935-7e91-48b8-a94c-606d37c3e9f2" },
+            [PSCustomObject]@{Name = "CMMI"; url = 'http://bogus.none/3'; ID = "27450541-8e31-4150-9947-dc59f998fc01" },
+            [PSCustomObject]@{Name = "Agile"; url = 'http://bogus.none/4'; ID = "adcc42ab-9882-485e-a3ed-7678f01f66bc" },
+            [PSCustomObject]@{Name = "Scrum With Space"; url = 'http://bogus.none/5'; ID = "12345678-0000-0000-0000-000000000000" }
+         )
+         if ($name) { return $processes.where( { $_.name -like $name }) }
+         else { return $processes }  
+      }
+      Mock _callApi -ParameterFilter { $resource -eq 'workitemicons' }  -MockWith {
+        return [pscustomobject]@{'Value' = @(
+               [pscustomobject]@{'ID' = 'icon_airplane' }
+               [pscustomobject]@{'ID' = 'icon_asterisk' }
+               [pscustomobject]@{'ID' = 'icon_book' }
+            ) 
+         }
+      }
+      Mock _callApi -ParameterFilter { $Method -eq 'Post' } -MockWith {
+         return ([psCustomObject]@{name = 'Dummy' })
+      }
+      Mock _callApi -ParameterFilter { $Method -eq 'Patch' } -MockWith {
+         return ([psCustomObject]@{name = 'Dummy' })
+      }
+      Mock Get-VSTeamWorkItemType   {
+            $wits = @(
+                  [psCustomObject]@{name          = 'Bug'
+                                    customization = 'system'
+                                    referenceName = 'Microsoft.VSTS.WorkItemTypes.Bug'
+                                    icon          = 'icon_insect'
+                                    color         = 'cc293d'
+                                    isDisabled    =  $false
+                                    description   = 'A divergence...' 
+                                    url           = 'http://bogus.none/98'
+                  }
+                  [psCustomObject]@{name          = 'Gub'
+                                    customization = 'custom'
+                                    icon          = 'icon_book'
+                                    color         = 'ff0000'
+                                    isDisabled    =  $false
+                                    description   = 'Test Item' 
+                                    url           = 'http://bogus.none/99';
+                  }
+               )
+         if ($WorkItemType) { return $wits.where( { $_.name -like $WorkItemType }) }
+         else               { return $wits }  
+      } 
+      [vsteam_lib.IconCache]::Invalidate()
+   }
+
+   Context 'Update WorkItem Types' {
+
+      It 'Catches invalid WorkItem Type names.' {
+         Set-VSTeamWorkItemType -ProcessTemplate "Scrum With Space" -WorkItemType NewWit -Description "New Work item Type" -Color ff0000  -Icon icon_asterisk  -WarningVariable "Warn" -warningAction SilentlyContinue 
+         # Should not call the rest API from the function body, but may populate the work-item icons cache 
+         Should -Invoke _callApi -Exactly -Times 0 -Scope It {-not ($resource -eq "workitemicons")} 
+         $warn | Should -Be "'NewWit' does not appear to be a valid Workitem type."
+      }
+      It 'Patches custom WorkItem Types.' {
+         Set-VSTeamWorkItemType -ProcessTemplate "Scrum With Space" -WorkItemType Gub -Description 'New Text' -Color Green  -Icon icon_book    -Force
+         Should -Invoke _callApi -Exactly -Times 1 -Scope It -ParameterFilter {
+            $Url    -like     '*99?api-version=*'           -and  #found expected item
+            $Body   -match    '"isDisabled":\s+false'       -and  #Should expressly set   
+            $Body   -match    '"color":\s+"008000"'         -and  #Should convert from green
+            $Body   -match    '"icon":\s+"icon_book"'       -and  
+            $Body   -match    '"description":\s+"New Text'  -and  
+            $Method -eq       'Patch'
+         }
+      }
+       It 'Posts changes for system WorkItem Types' {
+         Set-VSTeamWorkItemType -ProcessTemplate "Scrum With Space" -WorkItemType Bug -Disabled -Force
+         Should -Invoke _callApi -Exactly -Times 1 -Scope It -ParameterFilter {
+            $Url    -like     '*98?api-version=*'           -and  #found expected item
+            $Body   -match    '"isDisabled":\s+true'        -and   
+            $Body   -match    '"inheritsFrom":\s+"Microsoft.VSTS.WorkItemTypes.Bug"' -and  
+            $Method -eq       'Post'
+         }
+      }
+   }
+}

--- a/Tests/function/tests/Set-VSTeamWorkItemType.Tests.ps1
+++ b/Tests/function/tests/Set-VSTeamWorkItemType.Tests.ps1
@@ -64,6 +64,7 @@ Describe 'VSTeamWorkItemType' {
          else               { return $wits }  
       } 
       [vsteam_lib.IconCache]::Invalidate()
+      [vsteam_lib.ProcessTemplateCache]::Invalidate()
    }
 
    Context 'Update WorkItem Types' {

--- a/Tests/function/tests/Set-VSTeamWorkItemType.Tests.ps1
+++ b/Tests/function/tests/Set-VSTeamWorkItemType.Tests.ps1
@@ -24,14 +24,14 @@ Describe 'VSTeamWorkItemType' {
             [PSCustomObject]@{Name = "Scrum With Space"; url = 'http://bogus.none/5'; ID = "12345678-0000-0000-0000-000000000000" }
          )
          if ($name) { return $processes.where( { $_.name -like $name }) }
-         else { return $processes }  
+         else { return $processes }
       }
       Mock _callApi -ParameterFilter { $resource -eq 'workitemicons' }  -MockWith {
         return [pscustomobject]@{'Value' = @(
                [pscustomobject]@{'ID' = 'icon_airplane' }
                [pscustomobject]@{'ID' = 'icon_asterisk' }
                [pscustomobject]@{'ID' = 'icon_book' }
-            ) 
+            )
          }
       }
       Mock _callApi -ParameterFilter { $Method -eq 'Post' } -MockWith {
@@ -48,7 +48,7 @@ Describe 'VSTeamWorkItemType' {
                                     icon          = 'icon_insect'
                                     color         = 'cc293d'
                                     isDisabled    =  $false
-                                    description   = 'A divergence...' 
+                                    description   = 'A divergence...'
                                     url           = 'http://bogus.none/98'
                   }
                   [psCustomObject]@{name          = 'Gub'
@@ -56,13 +56,13 @@ Describe 'VSTeamWorkItemType' {
                                     icon          = 'icon_book'
                                     color         = 'ff0000'
                                     isDisabled    =  $false
-                                    description   = 'Test Item' 
+                                    description   = 'Test Item'
                                     url           = 'http://bogus.none/99';
                   }
                )
          if ($WorkItemType) { return $wits.where( { $_.name -like $WorkItemType }) }
-         else               { return $wits }  
-      } 
+         else               { return $wits }
+      }
       [vsteam_lib.IconCache]::Invalidate()
       [vsteam_lib.ProcessTemplateCache]::Invalidate()
    }
@@ -70,19 +70,19 @@ Describe 'VSTeamWorkItemType' {
    Context 'Update WorkItem Types' {
 
       It 'Catches invalid WorkItem Type names.' {
-         Set-VSTeamWorkItemType -ProcessTemplate "Scrum With Space" -WorkItemType NewWit -Description "New Work item Type" -Color ff0000  -Icon icon_asterisk  -WarningVariable "Warn" -warningAction SilentlyContinue 
-         # Should not call the rest API from the function body, but may populate the work-item icons cache 
-         Should -Invoke _callApi -Exactly -Times 0 -Scope It {-not ($resource -eq "workitemicons")} 
-         $warn | Should -Be "'NewWit' does not appear to be a valid Workitem type."
+         Set-VSTeamWorkItemType -ProcessTemplate "Scrum With Space" -WorkItemType NewWit -Description "New Work item Type" -Color ff0000  -Icon icon_asterisk  -WarningVariable "Warn" -warningAction SilentlyContinue
+         # Should not call the rest API from the function body, but may populate the work-item icons cache
+         Should -Invoke _callApi -Exactly -Times 0 -Scope It {-not ($resource -eq "workitemicons")}
+         $warn | Should -Match "'NewWit'"
       }
       It 'Patches custom WorkItem Types.' {
          Set-VSTeamWorkItemType -ProcessTemplate "Scrum With Space" -WorkItemType Gub -Description 'New Text' -Color Green  -Icon icon_book    -Force
          Should -Invoke _callApi -Exactly -Times 1 -Scope It -ParameterFilter {
             $Url    -like     '*99?api-version=*'           -and  #found expected item
-            $Body   -match    '"isDisabled":\s+false'       -and  #Should expressly set   
+            $Body   -match    '"isDisabled":\s+false'       -and  #Should expressly set
             $Body   -match    '"color":\s+"008000"'         -and  #Should convert from green
-            $Body   -match    '"icon":\s+"icon_book"'       -and  
-            $Body   -match    '"description":\s+"New Text'  -and  
+            $Body   -match    '"icon":\s+"icon_book"'       -and
+            $Body   -match    '"description":\s+"New Text'  -and
             $Method -eq       'Patch'
          }
       }
@@ -90,8 +90,8 @@ Describe 'VSTeamWorkItemType' {
          Set-VSTeamWorkItemType -ProcessTemplate "Scrum With Space" -WorkItemType Bug -Disabled -Force
          Should -Invoke _callApi -Exactly -Times 1 -Scope It -ParameterFilter {
             $Url    -like     '*98?api-version=*'           -and  #found expected item
-            $Body   -match    '"isDisabled":\s+true'        -and   
-            $Body   -match    '"inheritsFrom":\s+"Microsoft.VSTS.WorkItemTypes.Bug"' -and  
+            $Body   -match    '"isDisabled":\s+true'        -and
+            $Body   -match    '"inheritsFrom":\s+"Microsoft.VSTS.WorkItemTypes.Bug"' -and
             $Method -eq       'Post'
          }
       }

--- a/Tests/function/tests/Set-VSTeamWorkItemType.Tests.ps1
+++ b/Tests/function/tests/Set-VSTeamWorkItemType.Tests.ps1
@@ -3,8 +3,8 @@ Set-StrictMode -Version Latest
 Describe 'VSTeamWorkItemType' {
    BeforeAll {
       . "$PSScriptRoot\_testInitialize.ps1" $PSCommandPath
-      . "$PSScriptRoot\..\..\..\Source\Public\Get-VSteamProcess.ps1"
-      . "$PSScriptRoot\..\..\..\Source\Public\Get-VSTeamWorkItemIconList"
+      . "$PSScriptRoot\..\..\..\Source\Public\Get-VSTeamProcess.ps1"
+      . "$PSScriptRoot\..\..\..\Source\Public\Get-VSTeamWorkItemIconList.ps1"
       . "$PSScriptRoot\..\..\..\Source\Public\Get-VSTeamWorkItemType.ps1"
 
       $Global:PSDefaultParameterValues.Remove("*-vsteam*:projectName")

--- a/Tests/function/tests/Show-VSTeamWorkItemState.Tests.ps1
+++ b/Tests/function/tests/Show-VSTeamWorkItemState.Tests.ps1
@@ -24,7 +24,7 @@ Describe 'VSTeamWorkItemState' {
             isDisabled    =  $false
             referenceName = 'Microsoft.VSTS.WorkItemTypes.Bug'
             url           = 'https://dummy.none/workItemTypes/Microsoft.VSTS.WorkItemTypes.Bug'
-            states        = @( 
+            states        = @(
                [PSCustomObject]@{
                   id                 = '7b7e3e8c-e500-40b6-ad56-d59b8d64d757'
                   name               = 'New'
@@ -42,6 +42,15 @@ Describe 'VSTeamWorkItemState' {
                   order              = 2
                   url                = 'https://dummy.none/workItemTypes/Microsoft.VSTS.WorkItemTypes.Bug/states/02cca570-0896-4a30-aff1-87ccffc68ce0'
                   customizationType  = 'inherited'
+               }
+               [PSCustomObject]@{
+                  id                 = '02cca570-0896-4a30-aff1-87ccffc68ce0'
+                  name               = 'Approved'
+                  color              = 'b2b2b2'
+                  stateCategory      = 'Proposed'
+                  order              = 2
+                  url                = 'https://dummy.none/workItemTypes/Microsoft.VSTS.WorkItemTypes.Bug/states/02cca570-0896-4a30-aff1-87ccffc68ce0'
+                  customizationType  = 'system'
                }
                [PSCustomObject]@{
                   id                 = 'abb54c86-d03a-44fe-8216-309d3c712296'
@@ -80,7 +89,7 @@ Describe 'VSTeamWorkItemState' {
                   customizationType  = 'system'
                }
             )
-         }  
+         }
          Mock Get-VSTeamWorkItemType {return $bug }
          Mock Get-VSTeamProcess { return @(
                [PSCustomObject]@{
@@ -95,30 +104,30 @@ Describe 'VSTeamWorkItemState' {
 
       It 'should warn for states which have not been hidden' {
          ## Act
-         Show-VsteamWorkItemState -WorkItemType bug -Name postponed -ProcessTemplate Scrum2 -Force 
+         Show-VsteamWorkItemState -WorkItemType bug -Name postponed -ProcessTemplate Scrum2 -Force
 
          ## Assert
          Should -Invoke Get-VSTeamWorkItemType   -ParameterFilter {
-            $Expand       -eq "States" -and 
+            $Expand       -eq "States" -and
             $WorkItemType -eq "Bug"
          }  -Scope It                 -Times 1 -Exactly
          Should -Invoke Write-Warning -Times 1 -Exactly
          Should -invoke _callAPI      -Times 0 -Exactly
-       
+
       }
       It 'should call the REST API with the Delete method and the correct URL to stop hiding a system WorkItem state' {
          ## Act
-         Show-VsteamWorkItemState -WorkItemType bug -Name Approved -ProcessTemplate Scrum2 -Force 
-         
+         Show-VsteamWorkItemState -WorkItemType bug -Name Approved -ProcessTemplate Scrum2 -Force
+
          ## Assert
          Should -Invoke Get-VSTeamWorkItemType -ParameterFilter {
-            $Expand       -eq "States" -and 
+            $Expand       -eq "States" -and
             $WorkItemType -eq "Bug"
          } -Scope It                   -Times 1 -Exactly
          Should -Invoke _callAPI               -ParameterFilter {
-               $method -eq  'Delete' -and 
+               $method -eq  'Delete' -and
                $url -match "WorkItemTypes\.Bug/states/02cca570-0896-4a30-aff1-87ccffc68ce0\?api-version="
-         } -Scope It                    -Times 1 -Exactly 
+         } -Scope It                    -Times 1 -Exactly
          Should -Invoke Write-Warning -Times 0 -Exactly
       }
    }

--- a/Tests/function/tests/Show-VSTeamWorkItemState.Tests.ps1
+++ b/Tests/function/tests/Show-VSTeamWorkItemState.Tests.ps1
@@ -131,5 +131,10 @@ Describe 'VSTeamWorkItemState' {
          Should -Invoke Write-Warning -Times 0 -Exactly
       }
    }
+
+   AfterAll {
+         [vsteam_lib.Versions]::Account = ""
+   }
+
 }
 

--- a/Tests/function/tests/Show-VSTeamWorkItemState.Tests.ps1
+++ b/Tests/function/tests/Show-VSTeamWorkItemState.Tests.ps1
@@ -1,0 +1,126 @@
+Set-StrictMode -Version Latest
+
+Describe 'VSTeamWorkItemState' {
+   BeforeAll {
+      . "$PSScriptRoot\_testInitialize.ps1" $PSCommandPath
+      . "$PSScriptRoot\..\..\..\Source\Public\Get-VSTeamProcess.ps1"
+      . "$PSScriptRoot\..\..\..\Source\Public\Get-VSTeamWorkItemType.ps1"
+      ## Arrange
+      # Set the account to use for testing. A normal user would do this
+      # using the Set-VSTeamAccount function.
+      Mock _getInstance   { return 'https://dev.azure.com/test' }
+      Mock _getApiVersion { return '1.0-unitTests' } -ParameterFilter { $Service -eq 'Processes' }
+      Mock _callAPI       { return $null}
+   }
+
+   Context 'Show-VsteamWorkItemState' {
+      BeforeAll {
+         $bug = @{
+            name          = 'Bug'
+            customization = 'System'
+            color         = 'CC293D'
+            description   = 'Describes a divergence between required and actual behavior, and tracks the work done to correct the defect and verify the correction.'
+            icon          = 'Icon_Insect'
+            isDisabled    =  $false
+            referenceName = 'Microsoft.VSTS.WorkItemTypes.Bug'
+            url           = 'https://dummy.none/workItemTypes/Microsoft.VSTS.WorkItemTypes.Bug'
+            states        = @( 
+               [PSCustomObject]@{
+                  id                 = '7b7e3e8c-e500-40b6-ad56-d59b8d64d757'
+                  name               = 'New'
+                  color              = 'b2b2b2'
+                  stateCategory      = 'Proposed'
+                  order              = 1
+                  url                = 'https://dummy.none/workItemTypes/Microsoft.VSTS.WorkItemTypes.Bug/states/7b7e3e8c-e500-40b6-ad56-d59b8d64d757'
+                  customizationType  = 'system'
+               },
+               [PSCustomObject]@{
+                  id                 = '02cca570-0896-4a30-aff1-87ccffc68ce0'
+                  name               = 'Approved'
+                  color              = 'b2b2b2'
+                  stateCategory      = 'Proposed'
+                  order              = 2
+                  url                = 'https://dummy.none/workItemTypes/Microsoft.VSTS.WorkItemTypes.Bug/states/02cca570-0896-4a30-aff1-87ccffc68ce0'
+                  customizationType  = 'inherited'
+               }
+               [PSCustomObject]@{
+                  id                 = 'abb54c86-d03a-44fe-8216-309d3c712296'
+                  name               = 'Committed'
+                  color              = '007acc'
+                  stateCategory      = 'InProgress'
+                  order              = 3
+                  url                = 'https://dummy.none/workItemTypes/Microsoft.VSTS.WorkItemTypes.Bug/states/abb54c86-d03a-44fe-8216-309d3c712296'
+                  customizationType  = 'system'
+               }
+               [PSCustomObject]@{
+                  id                 = '000000'
+                  name               = 'Postponed'
+                  color              = '0000ff'
+                  stateCategory      = 'InProgress'
+                  order              = 4
+                  url                = 'https://dummy.none/workItemTypes/Microsoft.VSTS.WorkItemTypes.Bug/states/00000'
+                  customizationType  = 'Custom'
+               }
+               [PSCustomObject]@{
+                  id                 = '0c926c15-68f7-467f-96c9-a26a19e9d718'
+                  name               = 'Done'
+                  color              = '339933'
+                  stateCategory      = 'Completed'
+                  order              = 5
+                  url                = 'https://dummy.none/workItemTypes/Microsoft.VSTS.WorkItemTypes.Bug/states/0c926c15-68f7-467f-96c9-a26a19e9d718'
+                  customizationType  = 'system'
+               }
+               [PSCustomObject]@{
+                  id                 = '0293a2ce-2a42-4d0e-bbbf-d2237efa0db8'
+                  name               = 'Removed'
+                  color              = 'ffffff'
+                  stateCategory      = 'Removed'
+                  order              = 6
+                  url                = 'https://dummy.none/workItemTypes/Microsoft.VSTS.WorkItemTypes.Bug/states/0293a2ce-2a42-4d0e-bbbf-d2237efa0db8'
+                  customizationType  = 'system'
+               }
+            )
+         }  
+         Mock Get-VSTeamWorkItemType {return $bug }
+         Mock Get-VSTeamProcess { return @(
+               [PSCustomObject]@{
+                  Name = 'Scrum2'
+                  URL  = 'https://dummy.none/_apis/work/processes/6b724908-ef14-45cf-84f8-768b5384da45'
+               }
+            )
+         }
+         Mock Write-Warning {}
+         [vsteam_lib.ProcessTemplateCache]::Invalidate()
+      }
+
+      It 'should warn for states which have not been hidden' {
+         ## Act
+         Show-VsteamWorkItemState -WorkItemType bug -Name postponed -ProcessTemplate Scrum2 -Force 
+
+         ## Assert
+         Should -Invoke Get-VSTeamWorkItemType   -ParameterFilter {
+            $Expand       -eq "States" -and 
+            $WorkItemType -eq "Bug"
+         }  -Scope It                 -Times 1 -Exactly
+         Should -Invoke Write-Warning -Times 1 -Exactly
+         Should -invoke _callAPI      -Times 0 -Exactly
+       
+      }
+      It 'should call the REST API with the Delete method and the correct URL to stop hiding a system WorkItem state' {
+         ## Act
+         Show-VsteamWorkItemState -WorkItemType bug -Name Approved -ProcessTemplate Scrum2 -Force 
+         
+         ## Assert
+         Should -Invoke Get-VSTeamWorkItemType -ParameterFilter {
+            $Expand       -eq "States" -and 
+            $WorkItemType -eq "Bug"
+         } -Scope It                   -Times 1 -Exactly
+         Should -Invoke _callAPI               -ParameterFilter {
+               $method -eq  'Delete' -and 
+               $url -match "WorkItemTypes\.Bug/states/02cca570-0896-4a30-aff1-87ccffc68ce0\?api-version="
+         } -Scope It                    -Times 1 -Exactly 
+         Should -Invoke Write-Warning -Times 0 -Exactly
+      }
+   }
+}
+

--- a/Tests/function/tests/Show-VSTeamWorkItemState.Tests.ps1
+++ b/Tests/function/tests/Show-VSTeamWorkItemState.Tests.ps1
@@ -8,7 +8,7 @@ Describe 'VSTeamWorkItemState' {
       ## Arrange
       # Set the account to use for testing. A normal user would do this
       # using the Set-VSTeamAccount function.
-      Mock _getInstance   { return 'https://dev.azure.com/test' }
+      [vsteam_lib.Versions]::Account = 'https://dev.azure.com/test'
       Mock _getApiVersion { return '1.0-unitTests' } -ParameterFilter { $Service -eq 'Processes' }
       Mock _callAPI       { return $null}
    }

--- a/Tests/function/tests/Unlock-VSTeamWorkItemType.Tests.ps1
+++ b/Tests/function/tests/Unlock-VSTeamWorkItemType.Tests.ps1
@@ -1,0 +1,60 @@
+Set-StrictMode -Version Latest
+
+Describe 'VSTeamWorkItemType' {
+   BeforeAll {
+      . "$PSScriptRoot\_testInitialize.ps1" $PSCommandPath
+
+      ## Arrange
+      # Set the account to use for testing. A normal user would do this
+      # using the Set-VSTeamAccount function.
+      Mock _getInstance { return 'https://dev.azure.com/test' }
+      Mock _getApiVersion { return '1.0-unitTests' }
+      Mock _callApi -ParameterFilter { $Method -eq 'Post' } -MockWith {
+         return ([psCustomObject]@{name = 'Dummy' })
+      }
+   }
+
+   Context 'Update WorkItem Types' {
+
+
+      It 'Returns custom WorkItem Types untouched.' {
+
+         $wit = [psCustomObject]@{
+            name          = 'Gub'
+            customization = 'custom'
+            icon          = 'icon_book'
+            color         = 'ff0000'
+            isDisabled    =  $false
+            description   = 'Test Item'
+            url           = 'http://bogus.none/workItemTypes/99';
+         }
+         $x = $wit | Unlock-VSTeamWorkItemType -Force
+
+         Should -Invoke _callApi -Exactly -Times 0 -Scope It
+         $x.customization | should -BeExactly $wit.customization
+         $x.url | should -BeExactly $wit.url
+      }
+
+      It 'Posts changes for system WorkItem Types' {
+         $wit =   [psCustomObject]@{
+            name          = 'Bug'
+            customization = 'system'
+            referenceName = 'Microsoft.VSTS.WorkItemTypes.Bug'
+            icon          = 'icon_insect'
+            color         = 'cc293d'
+            isDisabled    =  $false
+            description   = 'A divergence...'
+            url           = 'http://bogus.none/workItemTypes/98'
+         }
+
+         $x = $wit | Unlock-VSTeamWorkItemType -Force
+         Should -Invoke _callApi -Exactly -Times 1 -Scope It -ParameterFilter {
+            $Url    -like     '*workitemTypes?api-version=*'           -and  #found expected item
+            $Body   -match    '"inheritsFrom":\s+"Microsoft.VSTS.WorkItemTypes.Bug"' -and
+            $Method -eq       'Post'
+         }
+         $x.psobject.TypeNames | Should -Contain 'vsteam_lib.WorkItemType'
+         $x.name               | Should -Be 'Dummy'
+      }
+   }
+}

--- a/Tests/function/tests/_testInitialize.ps1
+++ b/Tests/function/tests/_testInitialize.ps1
@@ -11,7 +11,7 @@ Import-Module SHiPS
 
 $baseFolder = "$PSScriptRoot/../../.."
 $sampleFiles = "$PSScriptRoot/../../SampleFiles"
-      
+
 Add-Type -Path "$baseFolder/dist/bin/vsteam-lib.dll"
 
 $sut = (Split-Path -Leaf $testPath).Replace(".Tests.", ".")
@@ -22,7 +22,7 @@ $sut = (Split-Path -Leaf $testPath).Replace(".Tests.", ".")
 if ($private.IsPresent) {
    . "$baseFolder/Source/Private/$sut"
 }
-else {   
+else {
    . "$baseFolder/Source/Public/$sut"
 }
 
@@ -31,7 +31,7 @@ if ($doNotPrimeCache.IsPresent) {
 }
 
 # Prime the project cache with an empty list. This will make sure
-# any project name used will pass validation and Get-VSTeamProject 
+# any project name used will pass validation and Get-VSTeamProject
 # will not need to be called.
 [vsteam_lib.ProjectCache]::Update([string[]]@(), 120)
 
@@ -41,13 +41,13 @@ function Open-SampleFile {
       [string] $file,
       [switch] $ReturnValue,
       # The index of the value array to return
-      [int] $index = -1, 
+      [int] $index = -1,
       [switch] $Json
    )
    if ($Json.IsPresent) {
-      return $(Get-Content "$sampleFiles\$file" -Raw | ConvertTo-Json)
+      return $(Get-Content "$sampleFiles\$file" -Raw ) #had convertTo-json but this files are json text, caused warning with PS 7.1
    }
-   
+
    if ($ReturnValue.IsPresent) {
       return $(Get-Content "$sampleFiles\$file" -Raw | ConvertFrom-Json).value
    }

--- a/Tests/library/Provider/ProcessTests.cs
+++ b/Tests/library/Provider/ProcessTests.cs
@@ -17,16 +17,44 @@ namespace vsteam_lib.Test.Provider
          var target = new Process(obj[0]);
 
          // Assert
+         Assert.IsNull(target.Projects, "Projects");
          Assert.AreEqual("Scrum", target.Name, "Name");
          Assert.AreEqual("system", target.Type, "Type");
          Assert.AreEqual(true, target.IsEnabled, "IsEnabled");
          Assert.AreEqual(false, target.IsDefault, "IsDefault");
          Assert.AreEqual("Scrum", target.ToString(), "ToString()");
+         Assert.AreEqual("test", target.ReferenceName, "ReferenceName");
          Assert.AreEqual("Scrum", target.ProcessTemplate, "ProcessTemplate");
          Assert.AreEqual("6b724908-ef14-45cf-84f8-768b5384da45", target.Id, "Id");
          Assert.AreEqual("6b724908-ef14-45cf-84f8-768b5384da45", target.TypeId, "TypeId");
          Assert.AreEqual("00000000-0000-0000-0000-000000000000", target.ParentProcessTypeId, "ParentProcessTypeId");
          Assert.AreEqual("This template is for teams who follow the Scrum framework.", target.Description, "Description");
+      }
+
+      [TestMethod]
+      public void Process_Constructor_WithProjects()
+      {
+         // Arrange
+         var obj = BaseTests.LoadJson("Get-VSTeamProcess.json");
+
+         // Act
+         var target = new Process(obj[1]);
+
+         // Assert
+         Assert.IsNotNull(target.Projects, "Projects");
+         Assert.AreEqual("Agile", target.Name, "Name");
+         Assert.AreEqual("system", target.Type, "Type");
+         Assert.IsNull(target.ReferenceName, "ReferenceName");
+         Assert.AreEqual(true, target.IsEnabled, "IsEnabled");
+         Assert.AreEqual(true, target.IsDefault, "IsDefault");
+         Assert.AreEqual("Agile", target.ToString(), "ToString()");
+         Assert.AreEqual("Agile", target.ProcessTemplate, "ProcessTemplate");
+         Assert.AreEqual("adcc42ab-9882-485e-a3ed-7678f01f66bc", target.Id, "Id");
+         Assert.AreEqual("adcc42ab-9882-485e-a3ed-7678f01f66bc", target.TypeId, "TypeId");
+         Assert.AreEqual("00000000-0000-0000-0000-000000000000", target.ParentProcessTypeId, "ParentProcessTypeId");
+         Assert.AreEqual("This template is flexible and will work great for most teams using Agile planning methods, including those practicing Scrum.", 
+                         target.Description, 
+                         "Description");
       }
    }
 }


### PR DESCRIPTION
# PR Summary
Follow on from #361 
 Add support for workitem states    
*  Get-VsteamWorkItemState    
*  Add-VSTeamWorkItemState   
*  Remove-VsteamWorkItemState  
*  Hide-VsteamWorkItemState    
*  Show-VsteamWorkItemState 
and associated Format file + tests and help


Each WorkItem-type in each process-template has a set of possible states e.g. "To Do", "In Progress" and "Done". Some are system states which cannot be removed but can be hidden (and shown). Other states are custom/user-added and can be removed (but not hidden). This PR provides tools for listing the states, hiding and showing system ones, and adding and removing user ones. 



## PR Checklist

- [X] [Write Help](https://github.com/DarqueWarrior/vsteam/blob/master/.github/CONTRIBUTING.md#write-help)
- [X] [Write Unit Test](https://github.com/DarqueWarrior/vsteam/blob/master/.github/CONTRIBUTING.md#write-unit-test)
- [X] [Update CHANGELOG.md](https://github.com/DarqueWarrior/vsteam/blob/master/.github/CONTRIBUTING.md#update-changelogmd)
