### PR TITLE
Extra process commands

### DIFF
--- a/.docs/Add-VSTeamProcess.md
+++ b/.docs/Add-VSTeamProcess.md
@@ -1,0 +1,83 @@
+<!-- #include "./common/header.md" -->
+
+# Add-VSTeamProcess
+
+## SYNOPSIS
+
+<!-- #include "./synopsis/Add-VSTeamProcess" -->
+
+## SYNTAX
+
+## DESCRIPTION
+
+Add-VSTeamProcess will add a new Process template to your organization. Processes define the available WorkItem Types and the behaviours (backlog levels) for projects. Existing projects can be switched to a new process, and any enabled process can be used for creating new projects.
+
+## EXAMPLES
+
+### Example 1
+
+```powershell
+Add-VSTeamProcess -ParentProcess Basic -ProcessName "Basic J" -Description "New Basic Process"
+
+Name    Enabled Default Description
+----    ------- ------- -----------
+Basic J True    False  New Basic Process
+```
+
+Creates a new process derived from the built-in process named "Basic". 
+
+## PARAMETERS
+
+<!-- #include "./params/confirm.md" -->
+
+### -Description
+
+The Description of the new process.
+
+```yaml
+Type: String
+Required: False
+```
+
+<!-- #include "./params/force.md" -->
+
+### -ParentProcess
+
+New processes must be base on an existing process. This can be one of the built in processes names or the namea user defined process. The names should tab-complete.  
+
+```yaml
+Type: String
+Required: True
+```
+### -ProcessName
+
+The display-name for the new process. 
+
+```yaml
+Type: String
+Aliases: Name
+Required: True
+```
+
+### -ReferenceName
+
+If not specified the a system-generated name will be assigned using the new process's GUID.
+
+```yaml
+Type: String
+Required: False
+```
+
+## INPUTS
+
+## OUTPUTS
+
+## NOTES
+
+<!-- #include "./common/prerequisites.md" -->
+
+## RELATED LINKS
+
+<!-- #include "./common/related.md" -->
+
+[Set-VSTeamWorkItemType](Set-VSTeamWorkItemType.md)

--- a/.docs/Add-VSTeamProcess.md
+++ b/.docs/Add-VSTeamProcess.md
@@ -10,7 +10,7 @@
 
 ## DESCRIPTION
 
-Add-VSTeamProcess will add a new Process template to your organization. Processes define the available WorkItem Types and the behaviours (backlog levels) for projects. Existing projects can be switched to a new process, and any enabled process can be used for creating new projects.
+Add-VSTeamProcess will add a new Process template to your organization. Processes define the available WorkItem Types and the Behaviors (backlog levels) for Projects. Existing Projects can be switched to a new Process, and any enabled Process can be used for creating new Projects.
 
 ## EXAMPLES
 
@@ -24,7 +24,7 @@ Name    Enabled Default Description
 Basic J True    False  New Basic Process
 ```
 
-Creates a new process derived from the built-in process named "Basic". 
+Creates a new Process template derived from the built-in Process named "Basic".
 
 ## PARAMETERS
 
@@ -32,7 +32,7 @@ Creates a new process derived from the built-in process named "Basic".
 
 ### -Description
 
-The Description of the new process.
+The description of the new Process.
 
 ```yaml
 Type: String
@@ -43,7 +43,7 @@ Required: False
 
 ### -ParentProcess
 
-New processes must be base on an existing process. This can be one of the built in processes names or the namea user defined process. The names should tab-complete.  
+New Processes must be based on an existing {rocess. This can be one of the built in Processes names or the name of a user defined process. The names should tab-complete.
 
 ```yaml
 Type: String
@@ -51,7 +51,7 @@ Required: True
 ```
 ### -ProcessName
 
-The display-name for the new process. 
+The display-name for the new Process.
 
 ```yaml
 Type: String
@@ -61,7 +61,7 @@ Required: True
 
 ### -ReferenceName
 
-If not specified the a system-generated name will be assigned using the new process's GUID.
+If not specified the a system-generated name will be assigned using the new Process's GUID.
 
 ```yaml
 Type: String
@@ -74,10 +74,8 @@ Required: False
 
 ## NOTES
 
-<!-- #include "./common/prerequisites.md" -->
-
 ## RELATED LINKS
 
-<!-- #include "./common/related.md" -->
+[Set-VSTeamProcess](Set-VSTeamProcess.md)
 
-[Set-VSTeamWorkItemType](Set-VSTeamWorkItemType.md)
+[Get-VSTeamProcess](Get-VSTeamProcess.md)

--- a/.docs/Add-VSTeamProcess.md
+++ b/.docs/Add-VSTeamProcess.md
@@ -4,7 +4,7 @@
 
 ## SYNOPSIS
 
-<!-- #include "./synopsis/Add-VSTeamProcess" -->
+<!-- #include "./synopsis/Add-VSTeamProcess.md" -->
 
 ## SYNTAX
 

--- a/.docs/Add-VSTeamProcess.md
+++ b/.docs/Add-VSTeamProcess.md
@@ -10,7 +10,7 @@
 
 ## DESCRIPTION
 
-Add-VSTeamProcess will add a new Process template to your organization. Processes define the available WorkItem Types and the Behaviors (backlog levels) for Projects. Existing Projects can be switched to a new Process, and any enabled Process can be used for creating new Projects.
+Add-VSTeamProcess will add a new process template to your organization. Processes define the available WorkItem types and the behaviors (backlog levels) for projects. Existing projects can be switched to a new process, and any enabled process can be used for creating new projects.
 
 ## EXAMPLES
 
@@ -26,7 +26,7 @@ Name    Enabled Default Description
 ----    ------- ------- -----------
 Basic J True    False  New Basic Process
 ```
-Creates a new Process template derived from the built-in Process named "Basic", and sets its description. The -Force switch was not specified, so the command prompts for confirmation
+Creates a new Process template, derived from the built-in Process named "Basic", and sets its description. The -Force switch was not specified, so the command prompts for confirmation.
 
 ### Example 2
 
@@ -40,7 +40,7 @@ Name   Enabled Default Description
 Scrum4 True    False
 Scrum5 True    False   
 ```
-Here the parent template is an object representing an existing process, and multiple names for different variations of the "Scrum" template are created. Note that in addition to being output, the proceses are stored in a variable, $Processes, for later use by using the OutVariable common parameter. 
+Here the parent template is an object representing an existing process, and multiple names for different variations of the "Scrum" template are created. Note that in addition to being output, the processes are stored in a variable, $Processes, for later use by using the OutVariable common parameter. 
 
 
 ## PARAMETERS
@@ -60,7 +60,7 @@ Required: False
 
 ### -ParentProcess
 
-New Processes must be based on an existing {rocess. This can be one of the built in Processes names or the name of a user defined process. The names should tab-complete.
+New Processes must be based on an existing process. This can be one of the built in process names or the name of a user defined process. The names should tab-complete.
 
 ```yaml
 Type: String
@@ -79,7 +79,7 @@ Accept pipeline input: true (ByValue)
 
 ### -ReferenceName
 
-Allows the a system-generated name based on the new Process's assigned GUID to be overriden. This parameter can usually be omitted, and should be omitted when piping multiple names into the command.  
+Allows the system-generated name based on the new process's assigned GUID to be overriden. This parameter can usually be omitted, and should be omitted when piping multiple names into the command.  
 
 ```yaml
 Type: String

--- a/.docs/Add-VSTeamProcess.md
+++ b/.docs/Add-VSTeamProcess.md
@@ -18,13 +18,30 @@ Add-VSTeamProcess will add a new Process template to your organization. Processe
 
 ```powershell
 Add-VSTeamProcess -ParentProcess Basic -ProcessName "Basic J" -Description "New Basic Process"
-
+Confirm
+Are you sure you want to perform this action?
+Performing the operation "Create New Process" on target "Basic J".
+[Y] Yes [A] Yes to All [N] No [L] No to All [S] Suspend [?] Help (default is "Yes"):y
 Name    Enabled Default Description
 ----    ------- ------- -----------
 Basic J True    False  New Basic Process
 ```
+Creates a new Process template derived from the built-in Process named "Basic", and sets its description. The -Force switch was not specified, so the command prompts for confirmation
 
-Creates a new Process template derived from the built-in Process named "Basic".
+### Example 2
+
+```powershell
+$s = Get-VSTeamProcess Scrum
+'Scrum4', 'Scrum5' | Add-VSTeamProcess -Parent $s -Force -OutVariable Processes 
+
+
+Name   Enabled Default Description
+----   ------- ------- -----------
+Scrum4 True    False
+Scrum5 True    False   
+```
+Here the parent template is an object representing an existing process, and multiple names for different variations of the "Scrum" template are created. Note that in addition to being output, the proceses are stored in a variable, $Processes, for later use by using the OutVariable common parameter. 
+
 
 ## PARAMETERS
 
@@ -51,17 +68,18 @@ Required: True
 ```
 ### -ProcessName
 
-The display-name for the new Process.
+The display-name for the new Process(es).
 
 ```yaml
-Type: String
+Type: String[]
 Aliases: Name
 Required: True
+Accept pipeline input: true (ByValue)
 ```
 
 ### -ReferenceName
 
-If not specified the a system-generated name will be assigned using the new Process's GUID.
+Allows the a system-generated name based on the new Process's assigned GUID to be overriden. This parameter can usually be omitted, and should be omitted when piping multiple names into the command.  
 
 ```yaml
 Type: String
@@ -76,6 +94,8 @@ Required: False
 
 ## RELATED LINKS
 
+[Get-VSTeamProcess](Get-VSTeamProcess.md)
+
 [Set-VSTeamProcess](Set-VSTeamProcess.md)
 
-[Get-VSTeamProcess](Get-VSTeamProcess.md)
+[Remove-VSTeamProcess](Remove-VSTeamProcess.md)

--- a/.docs/Add-VSTeamProcessBehavior.md
+++ b/.docs/Add-VSTeamProcessBehavior.md
@@ -10,23 +10,24 @@
 
 ## Description
 
-Adds a new portfolio backlog (a.k.a behavior) to a Process Template. 
-Note (1) the built-in Process templates (Scrum, Agile etc.) do not allow their backlogs to be customized, this is only allowed for custom processes. 
+Adds a new portfolio backlog (a.k.a behavior) to a Process Template.
+Note (1) the built-in Process templates (Scrum, Agile etc.) do not allow their backlogs to be customized, this is only allowed for custom processes.
 Note (2) System behaviors include a description, but this cannot be changed or set for custom behaviors.
+Note (3) The user interface hides any backlog which does not have any WorkItem type(s) assocuated with it.
 
 ## EXAMPLES
 
 ### Example 1
 
 ```powershell
-Add-VSTeamProcessBehavior -ProcessTemplate Scrum5 -Name "Change Requests" -Color AliceBlue         
+Add-VSTeamProcessBehavior -ProcessTemplate Scrum5 -Name "Change Requests" -Color AliceBlue
 
 
 Rank Name            Workitem types Inherits                        color  Description
 ---- ----            -------------- --------                        -----  -----------
 50   Change Requests                System.PortfolioBacklogBehavior f0f8ff
 ```
-This adds a new portfolio backlog to the scrum5 processs template (note that the built-in templates, like "Scrum" cannot be changed, only user-defined ones - like scrum5 in this case - can have new backlogs). Initially no work item types are attached to the new backlog. 
+This adds a new portfolio backlog to the scrum5 processs template (note that the built-in templates, like "Scrum" cannot be changed, only user-defined ones - like scrum5 in this case - can have new backlogs). Initially no work item types are attached to the new backlog.
 
 ## PARAMETERS
 

--- a/.docs/Add-VSTeamProcessBehavior.md
+++ b/.docs/Add-VSTeamProcessBehavior.md
@@ -11,9 +11,9 @@
 ## Description
 
 Adds a new portfolio backlog (a.k.a behavior) to a Process Template.
-Note (1) the built-in Process templates (Scrum, Agile etc.) do not allow their backlogs to be customized, this is only allowed for custom processes.
+Note (1) The built-in Process templates (Scrum, Agile etc.) do not allow their backlogs to be customized, this is only allowed for custom processes.
 Note (2) System behaviors include a description, but this cannot be changed or set for custom behaviors.
-Note (3) The user interface hides any backlog which does not have any WorkItem type(s) assocuated with it.
+Note (3) The user interface hides any backlog which does not have any WorkItem type(s) associated with it.
 
 ## EXAMPLES
 
@@ -27,13 +27,13 @@ Rank Name            Workitem types Inherits                        color  Descr
 ---- ----            -------------- --------                        -----  -----------
 50   Change Requests                System.PortfolioBacklogBehavior f0f8ff
 ```
-This adds a new portfolio backlog to the scrum5 processs template (note that the built-in templates, like "Scrum" cannot be changed, only user-defined ones - like scrum5 in this case - can have new backlogs). Initially no work item types are attached to the new backlog.
+This adds a new Portfolio Backlog to the "scrum5" Processs Template (note that the built-in templates, like "Scrum" cannot be changed, only user-defined ones - like scrum5 in this case - can have new Backlogs). Initially no work item types are attached to the new Backlog.
 
 ## PARAMETERS
 
 ### -Color
 
-Sets the the icon color for the backlog. The input value can be the name of a color name like "Red" or "Aqua" or a hex value for red, green and blue parts. Color names should tab complete. If no Color is provided, mid gray is used.
+Sets the the icon color for the Backlog. The input value can be the name of a color, like "Red" or "Aqua" or a hex value for red, green and blue parts. Color names should tab complete. If no color is provided, mid gray is used.
 
 ```yaml
 Type: Object
@@ -49,7 +49,7 @@ Accept wildcard characters: False
 
 ### -Confirm
 
-<!-- #include "./params/confirm.md" -->
+<!-- #include "./params/forcegroup.md" -->
 
 ```yaml
 Type: SwitchParameter
@@ -65,7 +65,7 @@ Accept wildcard characters: False
 
 ### -Name
 
-Name for the new behavior / backlog
+Name for the new Behavior / Backlog
 
 ```yaml
 Type: String
@@ -80,7 +80,7 @@ Accept wildcard characters: False
 ```
 ### -ProcessTemplate
 
-The process template to modify. Note that the built-in templates ("Scrum", "Agile" etc.) cannot be modified, only custom templates (derived from the built-in ones) can be changed.
+The Process Template to modify. Note that the built-in templates ("Scrum", "Agile" etc.) cannot be modified, only custom templates (derived from the built-in ones) can be changed.
 
 ```yaml
 Type: Object
@@ -94,12 +94,6 @@ Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
-<!-- #include "./params/whatIf.md" -->
-
-### CommonParameters
-
-This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](http://go.microsoft.com/fwlink/?LinkID=113216).
-
 ## INPUTS
 
 ### System.String
@@ -110,11 +104,8 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 ## NOTES
 
-<!-- #include "./common/prerequisites.md" -->
-
 ## RELATED LINKS
 
-<!-- #include "./common/related.md" -->
 [Get-VSTeamProcessBehavior](Get-VSTeamProcessBehavior.md)
 
 [Remove-VSTeamProcessBehavior](Remove-VSTeamProcessBehavior.md)

--- a/.docs/Add-VSTeamProcessBehavior.md
+++ b/.docs/Add-VSTeamProcessBehavior.md
@@ -10,9 +10,9 @@
 
 ## Description
 
-Adds a new portfolio backlog (a.k.a behavior) to a Process Template.
-Note (1) The built-in Process templates (Scrum, Agile etc.) do not allow their backlogs to be customized, this is only allowed for custom processes.
-Note (2) System behaviors include a description, but this cannot be changed or set for custom behaviors.
+Adds a new portfolio backlog (a.k.a behavior) to a Process Template.     
+Note (1) The built-in Process templates (Scrum, Agile etc.) do not allow their backlogs to be customized, this is only allowed for custom processes.    
+Note (2) System behaviors include a description, but this cannot be changed or set for custom behaviors.    
 Note (3) The user interface hides any backlog which does not have any WorkItem type(s) associated with it.
 
 ## EXAMPLES
@@ -27,13 +27,13 @@ Rank Name            Workitem types Inherits                        color  Descr
 ---- ----            -------------- --------                        -----  -----------
 50   Change Requests                System.PortfolioBacklogBehavior f0f8ff
 ```
-This adds a new Portfolio Backlog to the "scrum5" Processs Template (note that the built-in templates, like "Scrum" cannot be changed, only user-defined ones - like scrum5 in this case - can have new Backlogs). Initially no work item types are attached to the new Backlog.
+This adds a new Portfolio Backlog to the "scrum5" process template (note that the built-in templates, like "Scrum" cannot be changed, only user-defined ones - like scrum5 in this case - can have new Backlogs). Initially no WorkItem types are attached to the new Backlog.
 
 ## PARAMETERS
 
 ### -Color
 
-Sets the the icon color for the Backlog. The input value can be the name of a color, like "Red" or "Aqua" or a hex value for red, green and blue parts. Color names should tab complete. If no color is provided, mid gray is used.
+Sets the icon color for the Backlog. The input value can be the name of a color, like "Red" or "Aqua" or a hex value for red, green and blue parts. Color names should tab complete. If no color is provided, mid gray is used.
 
 ```yaml
 Type: Object
@@ -65,7 +65,7 @@ Accept wildcard characters: False
 
 ### -Name
 
-Name for the new Behavior / Backlog
+Name for the new Behavior / Backlog.
 
 ```yaml
 Type: String
@@ -80,7 +80,7 @@ Accept wildcard characters: False
 ```
 ### -ProcessTemplate
 
-The Process Template to modify. Note that the built-in templates ("Scrum", "Agile" etc.) cannot be modified, only custom templates (derived from the built-in ones) can be changed.
+The process template to modify. Note that the built-in templates ("Scrum", "Agile" etc.) cannot be modified, only custom templates (derived from the built-in ones) can be changed.
 
 ```yaml
 Type: Object
@@ -96,11 +96,7 @@ Accept wildcard characters: False
 
 ## INPUTS
 
-### System.String
-
 ## OUTPUTS
-
-### System.Object
 
 ## NOTES
 

--- a/.docs/Add-VSTeamProcessBehavior.md
+++ b/.docs/Add-VSTeamProcessBehavior.md
@@ -1,0 +1,120 @@
+<!-- #include "./common/header.md" -->
+
+# Add-VSTeamProcessBehavior
+
+## SYNOPSIS
+
+<!-- #include "./synopsis/Add-VSTeamProcessBehavior.md" -->
+
+## SYNTAX
+
+## Description
+
+Adds a new work portfolio backlog (a.k.a behavior) to a Process Template. Note that the built-in Process templates (Scrum, Agile etc.) do not allow their backlogs to be customized, this is only allowed for custom processes. 
+Note that System behaviors include a description, but this cannot be changed or set for custom behaviors.
+
+## EXAMPLES
+
+### Example 1
+
+```powershell
+Add-VSTeamProcessBehavior -ProcessTemplate Scrum5 -Name "Change Requests" -Color AliceBlue         
+
+
+Rank Name            Workitem types Inherits                        color  Description
+---- ----            -------------- --------                        -----  -----------
+50   Change Requests                System.PortfolioBacklogBehavior f0f8ff
+```
+This adds a new portfolio backlog to the scrum5 processs template (note that the built-in templates, like "Scrum" cannot be changed, only user-defined ones - like scrum5 in this case - can have new backlogs). Initially no work item types are attached to the new backlog. 
+
+## PARAMETERS
+
+### -Color
+
+Sets the the icon color for the backlog. The input value can be the name of a color name like "Red" or "Aqua" or a hex value for red, green and blue parts. Color names should tab complete. If no Color is provided, mid gray is used.
+
+```yaml
+Type: Object
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: 3
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Confirm
+
+<!-- #include "./params/confirm.md" -->
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: (All)
+Aliases: cf
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Name
+
+Name for the new behavior / backlog
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: 2
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+### -ProcessTemplate
+
+The process template to modify. Note that the built-in templates ("Scrum", "Agile" etc.) cannot be modified, only custom templates (derived from the built-in ones) can be changed.
+
+```yaml
+Type: Object
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: 0
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+<!-- #include "./params/whatIf.md" -->
+
+### CommonParameters
+
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](http://go.microsoft.com/fwlink/?LinkID=113216).
+
+## INPUTS
+
+### System.String
+
+## OUTPUTS
+
+### System.Object
+
+## NOTES
+
+<!-- #include "./common/prerequisites.md" -->
+
+## RELATED LINKS
+
+<!-- #include "./common/related.md" -->
+[Get-VSTeamProcessBehavior](Get-VSTeamProcessBehavior.md)
+
+[Remove-VSTeamProcessBehavior](Remove-VSTeamProcessBehavior.md)
+
+[Set-VSTeamProcessBehavior](Set-VSTeamProcessBehavior.md)

--- a/.docs/Add-VSTeamProcessBehavior.md
+++ b/.docs/Add-VSTeamProcessBehavior.md
@@ -10,8 +10,9 @@
 
 ## Description
 
-Adds a new work portfolio backlog (a.k.a behavior) to a Process Template. Note that the built-in Process templates (Scrum, Agile etc.) do not allow their backlogs to be customized, this is only allowed for custom processes. 
-Note that System behaviors include a description, but this cannot be changed or set for custom behaviors.
+Adds a new portfolio backlog (a.k.a behavior) to a Process Template. 
+Note (1) the built-in Process templates (Scrum, Agile etc.) do not allow their backlogs to be customized, this is only allowed for custom processes. 
+Note (2) System behaviors include a description, but this cannot be changed or set for custom behaviors.
 
 ## EXAMPLES
 

--- a/.docs/Add-VSTeamWorkItemType.md
+++ b/.docs/Add-VSTeamWorkItemType.md
@@ -24,6 +24,10 @@ Modifies the custom process "Scrum5", creating a user-defined work item type "Ch
 
 ## PARAMETERS
 
+<!-- #include "./params/forcegroup.md" -->
+
+<!-- #include "./params/processTemplate.md" -->
+
 ### -Color
 
 Sets the the icon color. The input value can be the name of a color name like "Red" or "Aqua" or a hex value for red, green and blue parts. Color names should tab complete.
@@ -35,22 +39,6 @@ Aliases:
 
 Required: False
 Position: 3
-Default value: None
-Accept pipeline input: False
-Accept wildcard characters: False
-```
-
-### -Confirm
-
-Prompts you for confirmation before running the cmdlet. (By default new types are added without confirmation)
-
-```yaml
-Type: SwitchParameter
-Parameter Sets: (All)
-Aliases: cf
-
-Required: False
-Position: Named
 Default value: None
 Accept pipeline input: False
 Accept wildcard characters: False
@@ -89,42 +77,9 @@ Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
-### -ProcessTemplate
-
-The process template to modify. Note that the built-in templates ("Scrum", "Agile" etc.) cannot be modified, only custom templates (derived from the built-in ones) can be changed.
-
-```yaml
-Type: Object
-Parameter Sets: (All)
-Aliases:
-
-Required: False
-Position: 0
-Default value: None
-Accept pipeline input: False
-Accept wildcard characters: False
-```
-
-### -WhatIf
-
-Shows what would happen if the cmdlet runs.
-The cmdlet is not run.
-
-```yaml
-Type: SwitchParameter
-Parameter Sets: (All)
-Aliases: wi
-
-Required: False
-Position: Named
-Default value: None
-Accept pipeline input: False
-Accept wildcard characters: False
-```
-
 ### -WorkItemType
 
-The name for the new work item type.
+The name for the new work item type. (Alias "Name")
 
 ```yaml
 Type: String
@@ -140,19 +95,12 @@ Accept wildcard characters: False
 
 ## INPUTS
 
-### System.String
-
 ## OUTPUTS
-
-### System.Object
 
 ## NOTES
 
-<!-- #include "./common/prerequisites.md" -->
-
 ## RELATED LINKS
 
-<!-- #include "./common/related.md" -->
 [Get-VSTeamWorkItemType](Get-VSTeamWorkItemType.md)
 
 [Set-VSTeamWorkItemType](Set-VSTeamWorkItemType.md)

--- a/.docs/Add-VSTeamWorkItemType.md
+++ b/.docs/Add-VSTeamWorkItemType.md
@@ -138,10 +138,6 @@ Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
-### CommonParameters
-
-This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](http://go.microsoft.com/fwlink/?LinkID=113216).
-
 ## INPUTS
 
 ### System.String

--- a/.docs/Add-VSTeamWorkItemType.md
+++ b/.docs/Add-VSTeamWorkItemType.md
@@ -10,17 +10,17 @@
 
 ## Description
 
-Adds a new work item type to a custom process. Note that the built-in Process templates (Scrum, Agile etc.) do not allow their work item types to be customized, this is only allowed for custom processes
+Adds a new WorkItem type to a custom process template. Note that the built-in process templates (Scrum, Agile etc.) do not allow their WorkItem types to be customized, this is only allowed for custom processes.
 
 ## EXAMPLES
 
 ### Example 1
 
 ```powershell
-Add-VSTeamWorkItemType  -ProcessTemplate Scrum5 -WorkItemType ChangeRequest  -Description "New Work item Type" -Color Red  -Icon icon_asterisk
+Add-VSTeamWorkItemType  -ProcessTemplate Scrum5 -WorkItemType ChangeRequest  -Description "New WorkItem Type" -Color Red  -Icon icon_asterisk
 ```
 
-Modifies the custom process "Scrum5", creating a user-defined work item type "ChangeRequest" with a red asterisk as its icon and some simple text in the description.
+Modifies the custom process "Scrum5", creating a user-defined WorkItem type "ChangeRequest" with a red asterisk as its icon and some simple text in the description.
 
 ## PARAMETERS
 
@@ -30,7 +30,7 @@ Modifies the custom process "Scrum5", creating a user-defined work item type "Ch
 
 ### -Color
 
-Sets the the icon color. The input value can be the name of a color name like "Red" or "Aqua" or a hex value for red, green and blue parts. Color names should tab complete.
+Sets the icon color. The input value can be the name of a color name like "Red" or "Aqua" or a hex value for red, green and blue parts. Color names should tab complete.
 
 ```yaml
 Type: Object
@@ -46,7 +46,7 @@ Accept wildcard characters: False
 
 ### -Description
 
-Long text description of the the work item type.
+Long text description of the WorkItem type.
 
 ```yaml
 Type: String
@@ -62,7 +62,7 @@ Accept wildcard characters: False
 
 ### -Icon
 
-One of the predefined icons for work item types. Possible values should tab complete and
+One of the predefined icons for WorkItem types. Possible values should tab complete and
 if the name omits the leading "Icon\_" it will be added automatically.
 
 ```yaml
@@ -79,7 +79,7 @@ Accept wildcard characters: False
 
 ### -WorkItemType
 
-The name for the new work item type. (Alias "Name")
+The name for the new WorkItem type. (Alias "Name")
 
 ```yaml
 Type: String

--- a/.docs/Add-VSTeamWorkItemType.md
+++ b/.docs/Add-VSTeamWorkItemType.md
@@ -1,0 +1,164 @@
+<!-- #include "./common/header.md" -->
+
+# Add-VSTeamWorkItemType
+
+## SYNOPSIS
+
+<!-- #include "./synopsis/Add-VSTeamWorkItemType.md" -->
+
+## SYNTAX
+
+## Description
+
+Adds a new work item type to a custom process. Note that the built-in Process templates (Scrum, Agile etc.) do not allow their work item types to be customized, this is only allowed for custom processes
+
+## EXAMPLES
+
+### Example 1
+
+```powershell
+Add-VSTeamWorkItemType  -ProcessTemplate Scrum5 -WorkItemType ChangeRequest  -Description "New Work item Type" -Color Red  -Icon icon_asterisk
+```
+
+Modifies the custom process "Scrum5", creating a user-defined work item type "ChangeRequest" with a red asterisk as its icon and some simple text in the description.
+
+## PARAMETERS
+
+### -Color
+
+Sets the the icon color. The input value can be the name of a color name like "Red" or "Aqua" or a hex value for red, green and blue parts. Color names should tab complete.
+
+```yaml
+Type: Object
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: 3
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Confirm
+
+Prompts you for confirmation before running the cmdlet. (By default new types are added without confirmation)
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: (All)
+Aliases: cf
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Description
+
+Long text description of the the work item type.
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: 2
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Icon
+
+One of the predefined icons for work item types. Possible values should tab complete and
+if the name omits the leading "Icon\_" it will be added automatically.
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: 4
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -ProcessTemplate
+
+The process template to modify. Note that the built-in templates ("Scrum", "Agile" etc.) cannot be modified, only custom templates (derived from the built-in ones) can be changed.
+
+```yaml
+Type: Object
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: 0
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -WhatIf
+
+Shows what would happen if the cmdlet runs.
+The cmdlet is not run.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: (All)
+Aliases: wi
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -WorkItemType
+
+The name for the new work item type.
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases: Name
+
+Required: True
+Position: 1
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### CommonParameters
+
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](http://go.microsoft.com/fwlink/?LinkID=113216).
+
+## INPUTS
+
+### System.String
+
+## OUTPUTS
+
+### System.Object
+
+## NOTES
+
+<!-- #include "./common/prerequisites.md" -->
+
+## RELATED LINKS
+
+<!-- #include "./common/related.md" -->
+[Get-VSTeamWorkItemType](Get-VSTeamWorkItemType.md)
+
+[Set-VSTeamWorkItemType](Set-VSTeamWorkItemType.md)
+
+[Remove-VSTeamWorkItemType](Remove-VSTeamWorkItemType.md)

--- a/.docs/Connect-VSTeam.md
+++ b/.docs/Connect-VSTeam.md
@@ -1,0 +1,196 @@
+<!-- #include "./common/header.md" -->
+
+#Connect-VSTeam
+
+## SYNOPSIS
+
+<!-- #include "./synopsis/Connect-VSTeam.md" -->
+
+## SYNTAX
+
+## DESCRIPTION
+Connects using an account name and optional prokect and an access token, OR
+using a credential object with the access token as the passwords and account/project as the username (the /project part is optional) or using an exported credential object - which can can only be read by the user who created it. If -save is specified the credential will be written to a file. 
+
+## EXAMPLES
+
+### Example 1
+```powershell
+ Connect-VSTeam -Save -Account "my-azure-devops-account" -Project 'Proj1' -TokenFromClipboard  
+```
+Here the accesstoken has just been created in the portal and copied to the windows clipboard, so the -TokenFromClipboard switch is used, the user is connected to the account and a default project is set. A credential object with a user name of 
+"my-azure-devops-account/Proj1" is created with the access token as the password. The Credential is saved, no path is given so the default path VsTeamCred.xml in the user's home directory is used.  The password is stored in this file as a securestring which can only be decoded by the user who created it. 
+After the command is run the user is logged in and the default project is set
+
+### Example 2
+```powershell
+ Connect-VSTeam
+```
+This will connect the user the default XML file -  VsTeamCred.xml in their home directory 
+
+### Example 3
+```powershell
+ Connect-VSTeam -save -path NewProject.xml 
+```
+This will create the a new credential file - because no account has been specified the user will be prompted for credentials, and can enter account/project or just account as the user name, and the accesstoken as the password. 
+later sessions can login with  connect-vsteam -path NewProject.xml 
+
+
+### Example 4
+```powershell
+ Connect-VSTeam  -TokenFromClipboard -Save -Path Project4.xml
+```
+This version will create a new credential file, however the user is already logged on so the account name and default project are visible, and as with example 1 the the access token is in the clipboard so the user is re-logged on with the access token, re-connected to the same account and project, and the credentials are written to a file. 
+
+## PARAMETERS
+
+### -Account
+The Azure DevOps (AzD) account name to use. 
+DO NOT enter the entire URL. Just the portion after dev.azure.com. For example in the
+following url mydemos is the account name.
+<https://dev.azure.com/mydemos>
+
+If the PowerShell session has a connection, the current account will be used by default.
+
+```yaml
+Type: String
+Parameter Sets: None, Clipboard, Secure, Insecure
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Credential
+A credential object with the Account / Azure Devops organization name and optionally the project name as the username, and the access token as the password. 
+
+```yaml
+Type: PSCredential
+Parameter Sets: Cred
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Path
+Path to an existing credential XML file, or if -Save is specified the path to a file to be created or over-written (no warning is given when overwriting). By default the file name  VsTeamCred.xml is used and the file is located in the users home directory.
+
+```yaml
+Type: Object
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -PersonalAccessToken
+The access token as a plain string. It is preferable not to enter this as a string literal in at the commandline or in a script, ideally it is created and copied and the -TokenFromClipboard switch is used, or it is stored as a secureString.  
+
+```yaml
+Type: String
+Parameter Sets: Insecure
+Aliases: Token
+
+Required: True
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Project
+The name of the default project to connect to; if signed in this should tab complete with the names from the current project. 
+
+```yaml
+Type: String
+Parameter Sets: None, Clipboard, Secure, Insecure
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Save
+If specified the credential will be saved to file determined by the path parameter. If the file exists it will be overwritten. 
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -SecurePersonalAccessToken
+The personal accesstoken as a SecureString. 
+
+```yaml
+Type: SecureString
+Parameter Sets: Secure
+Aliases: PAT
+
+Required: True
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -TokenFromClipboard
+Specifies that the token is currently in the clipboard. This relies on the PowerShell command Get-Clipboard, which may not be present on all platforms. 
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: Clipboard
+Aliases: Clipboard
+
+Required: True
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -UseBearerToken
+Switches the authorization from Basic to Bearer.  You still use the PAT for PersonalAccessToken parameters to store the token.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+<!-- #include "./params/version.md" -->
+
+## INPUTS
+
+## OUTPUTS
+ 
+## NOTES
+
+## RELATED LINKS
+<!-- #include "./common/related.md" -->

--- a/.docs/Get-VSTeamIteration.md
+++ b/.docs/Get-VSTeamIteration.md
@@ -22,6 +22,21 @@ Depth of children to fetch.
 Type: int32
 ```
 
+### -Expand
+If specified expands the `Children` node so the functions returns all decendants to the limit specified in depth.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: WorkingDays
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
 ### Path
 
 Path of the classification node.

--- a/.docs/Get-VSTeamProcess.md
+++ b/.docs/Get-VSTeamProcess.md
@@ -95,4 +95,8 @@ Parameter Sets: (All)
 
 <!-- #include "./common/related.md" -->
 
-[Add-VSTeamProject](Add-VSTeamProject.md)
+[Add-VSTeamProcess](Add-VSTeamProcess.md)
+
+[Set-VSTeamProcess](Add-VSTeamProcess.md)
+
+[Remove-VSTeamProcess](Remove-VSTeamProcess.md)

--- a/.docs/Get-VSTeamProcess.md
+++ b/.docs/Get-VSTeamProcess.md
@@ -42,6 +42,20 @@ This will return an process templates with names containing scrum,
 in other words, the default "Scrum" template and custom ones with
 names like "Custom Scrum", "Scrum for Contoso" will all be returned.
 
+### Example 4
+
+```powershell
+Get-VSTeamProcess  -ExpandProjects | where Projects -Contains "MyProject"
+
+Name  Enabled Default Description
+----  ------- ------- -----------
+Scrum True    False   This template is for teams who follow the Scrum framework.
+```
+
+This gets the projects associated with each process template,
+and filters the list down to the one which contains a particular project,
+the "Scrum" template in this example.
+
 ## PARAMETERS
 
 <!-- #include "./params/ProcessName.md" -->
@@ -55,6 +69,19 @@ Type: String
 Parameter Sets: ByID
 Aliases: ProcessID
 ```
+
+### ExpandProjects
+
+Gets the projects associated with the process, and sets the the .Projects property of the Process item to be a list of project-names.
+
+```yaml
+Type: SwitchParameter
+Required: false
+Position: Named
+Accept pipeline input: false
+Parameter Sets: (All)
+```
+
 
 ## INPUTS
 

--- a/.docs/Get-VSTeamProcess.md
+++ b/.docs/Get-VSTeamProcess.md
@@ -38,7 +38,7 @@ This will return the Process Templates only showing their name
 Get-VSTeamProcess *scrum*
 ```
 
-This will return an process templates with names containing scrum,
+This will return all process templates with names containing scrum,
 in other words, the default "Scrum" template and custom ones with
 names like "Custom Scrum", "Scrum for Contoso" will all be returned.
 
@@ -52,8 +52,7 @@ Name  Enabled Default Description
 Scrum True    False   This template is for teams who follow the Scrum framework.
 ```
 
-This gets the projects associated with each process template,
-and filters the list down to the one which contains a particular project,
+This gets all process template with their associated  projects and filters the list to the one which contains a particular project,
 the "Scrum" template in this example.
 
 ## PARAMETERS

--- a/.docs/Get-VSTeamProcess.md
+++ b/.docs/Get-VSTeamProcess.md
@@ -38,7 +38,7 @@ This will return the Process Templates only showing their name
 Get-VSTeamProcess *scrum*
 ```
 
-This will return an process templates with names containing scrum,
+This will return all process templates with names containing "scrum",
 in other words, the default "Scrum" template and custom ones with
 names like "Custom Scrum", "Scrum for Contoso" will all be returned.
 
@@ -52,9 +52,8 @@ Name  Enabled Default Description
 Scrum True    False   This template is for teams who follow the Scrum framework.
 ```
 
-This gets the projects associated with each process template,
-and filters the list down to the one which contains a particular project,
-the "Scrum" template in this example.
+This gets the processes with their associated projects and filters the list
+to the one which contains a particular project, the "Scrum" template in this example.
 
 ## PARAMETERS
 
@@ -72,7 +71,7 @@ Aliases: ProcessID
 
 ### ExpandProjects
 
-Gets the projects associated with the process, and sets the the .Projects property of the Process item to be a list of project-names.
+Gets the projects associated with the process, and sets the .Projects property of the Process item to be a list of project-names.
 
 ```yaml
 Type: SwitchParameter
@@ -81,7 +80,6 @@ Position: Named
 Accept pipeline input: false
 Parameter Sets: (All)
 ```
-
 
 ## INPUTS
 

--- a/.docs/Get-VSTeamProcessBehavior.md
+++ b/.docs/Get-VSTeamProcessBehavior.md
@@ -1,0 +1,66 @@
+<!-- #include "./common/header.md" -->
+
+# Get-VSTeamWorkItemType
+
+## SYNOPSIS
+
+<!-- #include "./synopsis/Get-VSTeamProcessBehavior.md" -->
+
+## SYNTAX
+
+## Description
+
+In the user interface work items may be shown on multiple boards. In the Scrum process template, for example, Sprints shows the iteration backlog, and backlogs can select either features or backlog items. In Project Settings, under team configuration there is a list of Backlogs which can appear for any given team; Scrum offers and "Backlog items" as a "Requirement backlog and "Epics" and "Features" as "Portfolio Backlogs", although Epics are not displayed by default.  Some built-in WorkItem types are tied to particular backlogs, so the "Epic" and "Feature"  WorkItem types are tied to the "Epics" and "Features" porfolio backlogs respectively. .  
+The "Product Backlog Item" type is tied to the "Backlog items" requirement backlog  and the "Task" type is tied to the "iteration backlog". In team settings the bug type can be linked to the  requirement backlog or the iteration backlog. There is only one of each of these all they can be renamed. Other portfolio backlogs can be created and user-defined work item types can be added to any backlog. 
+The API describes the backlogs workitems appear on as workitem behaviors, and each process as a set of system behaviors and potentially user defined ones.  Get-VSTeamProcessBehavior lists these. 
+
+## EXAMPLES
+
+### Example 1
+
+```powershell
+Get-VSTeamProcessBehavior -ProcessTemplate Scrum
+Rank Name          Workitem types       Inherits                        color  Description
+---- ----          --------------       --------                        -----  -----------
+40   Epics         Epic                 System.PortfolioBacklogBehavior FF7B00 Epic level ...
+30   Features      Feature              System.PortfolioBacklogBehavior 773B93 Feature level... 
+20   Backlog items Product Backlog Item System.OrderedBehavior          009CCC Requirement level...
+10   Tasks         Task                 System.OrderedBehavior          F2CB1D Task level ...
+0    Portfolio                          System.OrderedBehavior                 Portfolio ...
+0    Ordered                                                                   Enables work items...
+```
+
+This shows the Backlogs for the the built-in Process template, "Scrum"
+
+
+## PARAMETERS
+
+
+### -ProcessTemplate
+
+The Process template of interest; if not template is specified the template for the current project will be used.
+
+```yaml
+Type: String
+Parameter Sets: Process
+```
+
+## INPUTS
+
+### System.String
+
+## OUTPUTS
+
+### System.Object
+
+## NOTES
+<!-- #include "./common/prerequisites.md" -->
+
+## RELATED LINKS
+
+<!-- #include "./common/related.md" -->
+[Add-VSTeamWorkItemType](Add-VSTeamProcessBehavior.md)
+
+[Remove-VSTeamWorkItemType](Remove-VSTeamProcessBehavior.md)
+
+[Set-VSTeamWorkItemType](Set-VSTeamProcessBehavior.md)

--- a/.docs/Get-VSTeamProcessBehavior.md
+++ b/.docs/Get-VSTeamProcessBehavior.md
@@ -10,15 +10,15 @@
 
 ## Description
 
-In the user interface, WorkItems are shown on boards. The API refers to them as WorkItem and Process Behaviours.
+In the user interface, WorkItems are shown on Boards. The API refers appearing on a board as a "Behavior".
 
-In settings for a project based on the  "Scrum" process template, for example, under team configuration  "Epics", "Features" and/or "Backlog items" can be selected as "Backlog Navigation Levels" to display, and a fourth board "Tasks" is always used for displaying Sprints.  Bugs can either be displayed either on the Tasks board (as part of the "Iteration backlog" in a sprint) or on the Backlog Items board (as part of the "requirement backlog"). Iteration and Requirement are two categories of backlog which only have one board. The third category, Portfolio backlogs contains Epics, Features and user-defined boards/behaviors
+In settings for a Project based on the "Scrum" process template, for example, under Team Configuration  "Epics", "Features" and/or "Backlog Items" can be selected as "Backlog Navigation Levels" to display, and a fourth board "Tasks" is always used for displaying Sprints.  Bugs can either be displayed either on the Tasks board (as part of the Iteration Backlog in a sprint) or on the Backlog-Items board (as part of the Requirement backlog). Iteration and Requirement are two categories of backlog which only have one board each. The third category of board, Portfolio backlogs, contains Epics, Features and user-defined boards/behaviors
 
-As well as bugs, other built-in WorkItem types are tied to a particular board, the Epic type is always on the Epics board, the Feature type on Features, the Task type on Tasks and the Product BackLog item Type on Backlog items. (In Agile-based templates, the board for the requirement backlog is named "Stories" and the WorkItems type is User Story, CMMI-Based ones call their requirements backlog "Requirements" and the workitem type a Requirement and templates based on Basic use a board named "Issues" and the Issue workItem type ). 
+As well as bugs, other built-in WorkItem types are tied to a particular Board, the Epic type is always on the Epics Board, the Feature type on Features, the Task type on Tasks and (in Scrum-based templates) the Product BackLog Item type on Backlog Items. (In Agile-based templates, the board for the requirement backlog is named "Stories" and the WorkItem type is "User Story", CMMI-Based ones call their requirements backlog "Requirements" and the WorkItem type a "Requirement" and templates based on Basic use a board named "Issues" and the "Issue" workItem type ).
 
-Other workitem types -in particular custom-defined ones are available to add to any of these boards. So a new workitem type named "Change" might appear with tasks, with requirements, with features, or on a portfolio board of its own. When two or more work item types are available on the same board, one type is selected as the default for new items added to the board. 
+Other workitem types -in particular custom-defined ones - are available to add to any of these boards. So a new WorkItem type named "Change" might appear with tasks, with requirements, with features, or on a Portfolio Backlog board of its own. When two or more WorkItem types are available on the same Board, one type is selected as the default for new items added to the Board.
 
-Get-VSTeamProcessBehavior lists the boards available in the process template. And Get-VSTeamWorkItemBehavior shows the boards an Item can appear on and whether it is the default for that board. 
+Get-VSTeamProcessBehavior lists the boards available in a Process Template. And Get-VSTeamWorkItemBehavior shows the boards an items of a given WorkItem type can appear on and whether that type is the default for that board.
 
 ## EXAMPLES
 
@@ -29,22 +29,20 @@ Get-VSTeamProcessBehavior -ProcessTemplate Scrum
 Rank Name          Workitem types       Inherits                        color  Description
 ---- ----          --------------       --------                        -----  -----------
 40   Epics         Epic                 System.PortfolioBacklogBehavior FF7B00 Epic level ...
-30   Features      Feature              System.PortfolioBacklogBehavior 773B93 Feature level... 
+30   Features      Feature              System.PortfolioBacklogBehavior 773B93 Feature level...
 20   Backlog items Product Backlog Item System.OrderedBehavior          009CCC Requirement level...
 10   Tasks         Task                 System.OrderedBehavior          F2CB1D Task level ...
 0    Portfolio                          System.OrderedBehavior                 Portfolio ...
 0    Ordered                                                                   Enables work items...
 ```
 
-This shows the Backlogs for the the built-in Process template, "Scrum"
-
+This shows the Backlogs for the the built-in Process Template, "Scrum"
 
 ## PARAMETERS
 
-
 ### -ProcessTemplate
 
-The Process template of interest; if not template is specified the template for the current project will be used.
+The Process Template of interest; if no Template is specified the Template for the current Project will be used.
 
 ```yaml
 Type: String
@@ -53,20 +51,14 @@ Parameter Sets: Process
 
 ## INPUTS
 
-### System.String
-
 ## OUTPUTS
 
-### System.Object
-
 ## NOTES
-<!-- #include "./common/prerequisites.md" -->
 
 ## RELATED LINKS
 
-<!-- #include "./common/related.md" -->
-[Add-VSTeamWorkItemType](Add-VSTeamProcessBehavior.md)
+[Add-VSTeamProcessBehavior](Add-VSTeamProcessBehavior.md)
 
-[Remove-VSTeamWorkItemType](Remove-VSTeamProcessBehavior.md)
+[Remove-VSTeamProcessBehavior](Remove-VSTeamProcessBehavior.md)
 
-[Set-VSTeamWorkItemType](Set-VSTeamProcessBehavior.md)
+[Set-VSTeamProcessBehavior](Set-VSTeamProcessBehavior.md)

--- a/.docs/Get-VSTeamProcessBehavior.md
+++ b/.docs/Get-VSTeamProcessBehavior.md
@@ -10,13 +10,13 @@
 
 ## Description
 
-In the user interface, WorkItems are shown on Boards. The API refers appearing on a board as a "Behavior".
+In the user interface, WorkItems are shown on boards. The API refers to them as WorkItem and process behaviours.
 
-In settings for a Project based on the "Scrum" process template, for example, under Team Configuration  "Epics", "Features" and/or "Backlog Items" can be selected as "Backlog Navigation Levels" to display, and a fourth board "Tasks" is always used for displaying Sprints.  Bugs can either be displayed either on the Tasks board (as part of the Iteration Backlog in a sprint) or on the Backlog-Items board (as part of the Requirement backlog). Iteration and Requirement are two categories of backlog which only have one board each. The third category of board, Portfolio backlogs, contains Epics, Features and user-defined boards/behaviors
+In settings for a project based on the "Scrum" process template, for example, under team configuration "Epics", "Features" and/or "Backlog items" can be selected as "Backlog Navigation Levels" to display, and a fourth board "Tasks" is always used for displaying Sprints.  Bugs can either be displayed either on the Tasks board (as part of the "Iteration backlog" in a sprint) or on the Backlog Items board (as part of the "requirement backlog"). Iteration and Requirement are two categories of backlog which only have one board. The third category, Portfolio backlogs contains Epics, Features and user-defined boards/behaviors
 
-As well as bugs, other built-in WorkItem types are tied to a particular Board, the Epic type is always on the Epics Board, the Feature type on Features, the Task type on Tasks and (in Scrum-based templates) the Product BackLog Item type on Backlog Items. (In Agile-based templates, the board for the requirement backlog is named "Stories" and the WorkItem type is "User Story", CMMI-Based ones call their requirements backlog "Requirements" and the WorkItem type a "Requirement" and templates based on Basic use a board named "Issues" and the "Issue" workItem type ).
+As well as bugs, other built-in WorkItem types are tied to a particular board, the Epic type is always on the Epics board, the Feature type on Features, the Task type on Tasks and the Product BackLog item Type on Backlog items. (In Agile-based templates, the board for the requirement backlog is named "Stories" and the WorkItems type is User Story, CMMI-Based ones call their requirements backlog "Requirements" and the WorkItem type a Requirement and templates based on Basic use a board named "Issues" and the Issue workItem type ).
 
-Other workitem types -in particular custom-defined ones - are available to add to any of these boards. So a new WorkItem type named "Change" might appear with tasks, with requirements, with features, or on a Portfolio Backlog board of its own. When two or more WorkItem types are available on the same Board, one type is selected as the default for new items added to the Board.
+Other WorkItem types -in particular, custom-defined ones - are available to add to any of these boards. So, a new WorkItem type named "Change" might appear with tasks, with requirements, with features, or on a portfolio board of its own. When two or more WorkItem types are available on the same board, one type is selected as the default for new items added to the board.
 
 Get-VSTeamProcessBehavior lists the boards available in a Process Template. And Get-VSTeamWorkItemBehavior shows the boards an items of a given WorkItem type can appear on and whether that type is the default for that board.
 
@@ -36,13 +36,13 @@ Rank Name          Workitem types       Inherits                        color  D
 0    Ordered                                                                   Enables work items...
 ```
 
-This shows the Backlogs for the the built-in Process Template, "Scrum"
+This shows the backlogs for the the built-in process template, "Scrum"
 
 ## PARAMETERS
 
 ### -ProcessTemplate
 
-The Process Template of interest; if no Template is specified the Template for the current Project will be used.
+The process template of interest; if no template is specified the tTemplate for the current project will be used.
 
 ```yaml
 Type: String

--- a/.docs/Get-VSTeamSetting.md
+++ b/.docs/Get-VSTeamSetting.md
@@ -31,7 +31,7 @@ url                   : https://dev.azure.com/MyOrg/00000000-0000-0000-0000-0000
 _links                : @{self=; project=; team=; teamIterations=; teamFieldValues=; classificationNode=System.Object[]}
 ```
 
-Geting the settings for the default team in the current project returns a single object with all the information.
+Getting the settings for the default team in the current project returns a single object with all the information.
 
 ### Example 2
 
@@ -46,9 +46,9 @@ Microsoft.FeatureCategory      True
 Microsoft.RequirementCategory  True
 ```
 
-This version of the command specifies the Project and Team and gets the BackLog Visibilites, including any that have been added to the Process Template as custom Behaviors.
+This version of the command specifies the project and team and gets the BackLog Visibilites, including any that have been added to the process template as custom behaviors.
 
-### Example 2
+### Example 3
 
 ```powershell
 Get-VSTeamSetting -ProjectName MyProject  -BackLogIteration
@@ -62,7 +62,7 @@ In this case only the Backlog iteration is returned.
 ## PARAMETERS
 
 ### -BackLogIteration
-If specified, only the BackLog Iteration information is returned.
+If specified, only the backlog-iteration information is returned.
 
 ```yaml
 Type: SwitchParameter
@@ -77,7 +77,7 @@ Accept wildcard characters: False
 ```
 
 ### -BackLogVisibilites
-If specified, only a list of the Backlogs (system-defined, and added as custom Process Behaviors) will be returned with "true" or "false" for their visibility state. Note that it is possible to set a custom Backlog as visible without any WorkItem type being associated with it, and it will be filtered out of the GUI interface while in that state.
+If specified, only a list of the Backlogs (system-defined and added as custom process-behaviors) will be returned with "true" or "false" for their visibility state. Note that it is possible to set a custom backlog as visible without any WorkItem type being associated with it, and it will be filtered out of the GUI interface while in that state.
 
 ```yaml
 Type: SwitchParameter
@@ -107,7 +107,7 @@ Accept wildcard characters: False
 ```
 
 ### -DefaultIteration
-If specified, only the Default Iteration information is returned.
+If specified, only the default-iteration information is returned.
 ```yaml
 Type: SwitchParameter
 Parameter Sets: DefaultIteration
@@ -121,7 +121,7 @@ Accept wildcard characters: False
 ```
 
 ### -ProjectName
-The name of the Project whose Team settings are required.
+The name of the project whose team settings are required.
 
 ```yaml
 Type: Object
@@ -136,7 +136,7 @@ Accept wildcard characters: False
 ```
 
 ### -Team
-The name of the Team whose settings should be returned, if no Team is specified the Project's default Team is used.
+The name of the team whose settings should be returned, if no team is specified the project's default team is used.
 
 ```yaml
 Type: String
@@ -151,7 +151,7 @@ Accept wildcard characters: False
 ```
 
 ### -WorkingDays
-If specified returns only the list of working-days for the Team.
+If specified, returns only the list of working-days for the team.
 
 ```yaml
 Type: SwitchParameter
@@ -168,7 +168,6 @@ Accept wildcard characters: False
 ## INPUTS
 
 ## OUTPUTS
-
 
 ## NOTES
 

--- a/.docs/Get-VSTeamSetting.md
+++ b/.docs/Get-VSTeamSetting.md
@@ -1,0 +1,191 @@
+<!-- #include "./common/header.md" -->
+
+# Get-VSTeamSetting
+
+## SYNOPSIS
+
+<!-- #include "./synopsis/Get-VSTeamSetting.md" -->
+
+## SYNTAX
+
+## Description
+
+Returns the settings either for the default team in a project, or for a named team if one is specified. The command can either return all settings as a single object or return the value individually.
+
+## EXAMPLES
+
+### Example 1
+
+```powershell
+Get-VSTeamSetting
+
+backlogIteration      : @{id=00000000-0000-0000-0000-000000000000; name=MyProject; path=;
+   url=https://dev.azure.com/MyOrg/00000000-0000-0000-0000-000000000000/_apis/wit/classificationNodes/Iterations}
+bugsBehavior          : asRequirements
+workingDays           : {monday, tuesday, wednesday, thursday…}
+backlogVisibilities   : @{Microsoft.EpicCategory=False; Microsoft.FeatureCategory=True; Microsoft.RequirementCategory=True}
+defaultIteration      : @{id=00000000-0000-0000-0000-000000000000; name=Sprint 1; path=\Sprint 1;
+   url=https://dev.azure.com/MyOrg/00000000-0000-0000-0000-000000000000/_apis/wit/classificationNodes/Iterations/Sprint%201}
+defaultIterationMacro : @currentIteration
+url                   : https://dev.azure.com/MyOrg/00000000-0000-0000-0000-000000000000/00000000-0000-0000-0000-000000000000/_apis/work/teamsettings
+_links                : @{self=; project=; team=; teamIterations=; teamFieldValues=; classificationNode=System.Object[]}
+```
+
+Geting the settings for the default team in the current project returns a single object with all the information.
+
+
+### Example 2
+
+```powershell
+Get-VSTeamSetting -ProjectName MyProject -Team 'planners' -BackLogVisibilites
+
+Name                          Value
+----                          -----
+Custom.Changes                False
+Microsoft.EpicCategory        False
+Microsoft.FeatureCategory      True
+Microsoft.RequirementCategory  True
+```
+
+This version of the command species the project and team and gets the BackLog Visibilites, including any that have been added to the process as behaviors.
+
+### Example 2
+
+```powershell
+Get-VSTeamSetting -ProjectName MyProject  -BackLogIteration
+
+Name Path                    StructureType HasChildren Id
+---- ----                    ------------- ----------- --
+I3   \MyProject\Iteration\I3 iteration     True        16
+```
+In this case only the Backlog iteration
+
+## PARAMETERS
+
+### -BackLogIteration
+If specified, only the BackLog Iteration information is returned.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: BackLogIteration
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -BackLogVisibilites
+If specified only a list of the Backlogs (system defined, and added as custom process behaviors) will be returned with "true" or "false" for their visibility state. Note that it is possible to set a custom backlog as visible without any WorkItem type being associated with it, and it will be filtered out of the GUI interface while in that state.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: BackLogVisibilites
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -BugsBehavior
+If specified the command will return a value of 'asRequirements' , 'asTasks' or 'off' for "Bugs are managed with requirements", "Bugs are managed with tasks" or "Bugs are not managed on backlogs and boards" respectively.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: BugsBehavior
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -DefaultIteration
+If specified, only the Default Iteration information is returned.
+```yaml
+Type: SwitchParameter
+Parameter Sets: DefaultIteration
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -ProjectName
+The name of the project whose team settings are required.
+
+```yaml
+Type: Object
+Parameter Sets: (All)
+Aliases:
+
+Required: True
+Position: 1
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Team
+The name of the whose settings should be returned, if no team is specified the project's default team is used.
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases: Name
+
+Required: False
+Position: 0
+Default value: None
+Accept pipeline input: True (ByPropertyName)
+Accept wildcard characters: False
+```
+
+### -WorkingDays
+If specified returns only the list of working days for the team.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: WorkingDays
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### CommonParameters
+
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](http://go.microsoft.com/fwlink/?LinkID=113216).
+
+## INPUTS
+
+### System.String
+
+## OUTPUTS
+
+### System.Object
+
+## NOTES
+
+<!-- #include "./common/prerequisites.md" -->
+
+## RELATED LINKS
+
+<!-- #include "./common/related.md" -->
+
+[Set-VSTeamSetting](Set-VSTeamSetting.md)
+
+[Get-VSTeam](Get-VSTeam.md)

--- a/.docs/Get-VSTeamSetting.md
+++ b/.docs/Get-VSTeamSetting.md
@@ -10,7 +10,7 @@
 
 ## Description
 
-Returns the settings either for the default team in a project, or for a named team if one is specified. The command can either return all settings as a single object or return the value individually.
+Returns the settings either for the default team in a project, or for a named team if one is specified. The command can either return all settings as a single object or return a single setting.
 
 ## EXAMPLES
 
@@ -33,7 +33,6 @@ _links                : @{self=; project=; team=; teamIterations=; teamFieldValu
 
 Geting the settings for the default team in the current project returns a single object with all the information.
 
-
 ### Example 2
 
 ```powershell
@@ -47,7 +46,7 @@ Microsoft.FeatureCategory      True
 Microsoft.RequirementCategory  True
 ```
 
-This version of the command species the project and team and gets the BackLog Visibilites, including any that have been added to the process as behaviors.
+This version of the command specifies the Project and Team and gets the BackLog Visibilites, including any that have been added to the Process Template as custom Behaviors.
 
 ### Example 2
 
@@ -58,7 +57,7 @@ Name Path                    StructureType HasChildren Id
 ---- ----                    ------------- ----------- --
 I3   \MyProject\Iteration\I3 iteration     True        16
 ```
-In this case only the Backlog iteration
+In this case only the Backlog iteration is returned.
 
 ## PARAMETERS
 
@@ -78,7 +77,7 @@ Accept wildcard characters: False
 ```
 
 ### -BackLogVisibilites
-If specified only a list of the Backlogs (system defined, and added as custom process behaviors) will be returned with "true" or "false" for their visibility state. Note that it is possible to set a custom backlog as visible without any WorkItem type being associated with it, and it will be filtered out of the GUI interface while in that state.
+If specified, only a list of the Backlogs (system-defined, and added as custom Process Behaviors) will be returned with "true" or "false" for their visibility state. Note that it is possible to set a custom Backlog as visible without any WorkItem type being associated with it, and it will be filtered out of the GUI interface while in that state.
 
 ```yaml
 Type: SwitchParameter
@@ -93,7 +92,7 @@ Accept wildcard characters: False
 ```
 
 ### -BugsBehavior
-If specified the command will return a value of 'asRequirements' , 'asTasks' or 'off' for "Bugs are managed with requirements", "Bugs are managed with tasks" or "Bugs are not managed on backlogs and boards" respectively.
+If specified, the command will return a value of 'asRequirements' , 'asTasks' or 'off' for "Bugs are managed with requirements", "Bugs are managed with tasks" or "Bugs are not managed on backlogs and boards" respectively.
 
 ```yaml
 Type: SwitchParameter
@@ -122,7 +121,7 @@ Accept wildcard characters: False
 ```
 
 ### -ProjectName
-The name of the project whose team settings are required.
+The name of the Project whose Team settings are required.
 
 ```yaml
 Type: Object
@@ -137,7 +136,7 @@ Accept wildcard characters: False
 ```
 
 ### -Team
-The name of the whose settings should be returned, if no team is specified the project's default team is used.
+The name of the Team whose settings should be returned, if no Team is specified the Project's default Team is used.
 
 ```yaml
 Type: String
@@ -152,7 +151,7 @@ Accept wildcard characters: False
 ```
 
 ### -WorkingDays
-If specified returns only the list of working days for the team.
+If specified returns only the list of working-days for the Team.
 
 ```yaml
 Type: SwitchParameter
@@ -166,25 +165,14 @@ Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
-### CommonParameters
-
-This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](http://go.microsoft.com/fwlink/?LinkID=113216).
-
 ## INPUTS
-
-### System.String
 
 ## OUTPUTS
 
-### System.Object
 
 ## NOTES
 
-<!-- #include "./common/prerequisites.md" -->
-
 ## RELATED LINKS
-
-<!-- #include "./common/related.md" -->
 
 [Set-VSTeamSetting](Set-VSTeamSetting.md)
 

--- a/.docs/Get-VSTeamWorkItemBehavior.md
+++ b/.docs/Get-VSTeamWorkItemBehavior.md
@@ -1,10 +1,10 @@
 <!-- #include "./common/header.md" -->
 
-# Get-VSTeamProcessBehavior
+# Get-VSTeamWorkItemBehavior
 
 ## SYNOPSIS
 
-<!-- #include "./synopsis/Get-VSTeamProcessBehavior.md" -->
+<!-- #include "./synopsis/Get-VSTeamWorkItemBehavior.md" -->
 
 ## SYNTAX
 
@@ -25,31 +25,60 @@ Get-VSTeamProcessBehavior lists the boards available in the process template. An
 ### Example 1
 
 ```powershell
-Get-VSTeamProcessBehavior -ProcessTemplate Scrum
-Rank Name          Workitem types       Inherits                        color  Description
----- ----          --------------       --------                        -----  -----------
-40   Epics         Epic                 System.PortfolioBacklogBehavior FF7B00 Epic level ...
-30   Features      Feature              System.PortfolioBacklogBehavior 773B93 Feature level... 
-20   Backlog items Product Backlog Item System.OrderedBehavior          009CCC Requirement level...
-10   Tasks         Task                 System.OrderedBehavior          F2CB1D Task level ...
-0    Portfolio                          System.OrderedBehavior                 Portfolio ...
-0    Ordered                                                                   Enables work items...
+Get-VSTeamWorkItemBehavior -WorkItemType Epic
+
+
+WorkItem Type Behavior ID                              Is Default
+------------- -----------                              ----------
+Epic          Microsoft.VSTS.Scrum.EpicBacklogBehavior True
 ```
 
-This shows the Backlogs for the the built-in Process template, "Scrum"
+This shows the epic type has the "Scrum.EpicBacklogBehavior" - in other words it is on the Epics board of the scrum process, because the current project's process temp is, or is derived from, "Scrum" 
 
+
+### Example 2
+
+```powershell
+Get-VSTeamWorkItemBehavior -ProcessTemplate Scrum5 *
+
+
+WARNING: Bug has no behaviors.
+WARNING: Impediment has no behaviors.
+WARNING: Test Case has no behaviors.
+WARNING: Test Plan has no behaviors.
+WARNING: Test Suite has no behaviors.
+WorkItem Type        Behavior ID                                 Is Default
+-------------        -----------                                 ----------
+Product Backlog Item System.RequirementBacklogBehavior           True
+Feature              Microsoft.VSTS.Scrum.FeatureBacklogBehavior True
+Task                 System.TaskBacklogBehavior                  True
+Epic                 Microsoft.VSTS.Scrum.EpicBacklogBehavior    True
+```
+
+This shows the all the workitem types in the template named scrum 5. Bug, Impediment and the three "Test" types have no associated behavior (of these only Impediment can be assigned to one). Task and Product backlog Item are assigned to system types for the iteration and reqirements backlogs. And Feature and Epic are assigned to portfolio backlogs inherited from the Scrum Process Template. 
 
 ## PARAMETERS
 
 
 ### -ProcessTemplate
 
-The Process template of interest; if not template is specified the template for the current project will be used.
+The Process template of interest; if not template is specified the template for the current project will be used. The value of this parameter will tab complete
 
 ```yaml
 Type: String
 Parameter Sets: Process
 ```
+
+### -
+
+The type of WorkItem type whose details should be retrieved (wild cards are supported).
+
+```yaml
+Type: String
+Parameter Sets: Process
+```
+
+
 
 ## INPUTS
 

--- a/.docs/Get-VSTeamWorkItemBehavior.md
+++ b/.docs/Get-VSTeamWorkItemBehavior.md
@@ -10,15 +10,15 @@
 
 ## Description
 
-In the user interface, WorkItems are shown on boards. The API refers to them as WorkItem and Process Behaviours.
+In the user interface, WorkItems are shown on boards. The API refers to them as WorkItem and process behaviours.
 
-In settings for a project based on the  "Scrum" process template, for example, under team configuration  "Epics", "Features" and/or "Backlog items" can be selected as "Backlog Navigation Levels" to display, and a fourth board "Tasks" is always used for displaying Sprints.  Bugs can either be displayed either on the Tasks board (as part of the "Iteration backlog" in a sprint) or on the Backlog Items board (as part of the "requirement backlog"). Iteration and Requirement are two categories of backlog which only have one board. The third category, Portfolio backlogs contains Epics, Features and user-defined boards/behaviors
+In settings for a project based on the "Scrum" process template, for example, under team configuration "Epics", "Features" and/or "Backlog items" can be selected as "Backlog Navigation Levels" to display, and a fourth board "Tasks" is always used for displaying Sprints.  Bugs can either be displayed either on the Tasks board (as part of the "Iteration backlog" in a sprint) or on the Backlog Items board (as part of the "requirement backlog"). Iteration and Requirement are two categories of backlog which only have one board. The third category, Portfolio backlogs contains Epics, Features and user-defined boards/behaviors
 
-As well as bugs, other built-in WorkItem types are tied to a particular board, the Epic type is always on the Epics board, the Feature type on Features, the Task type on Tasks and the Product BackLog item Type on Backlog items. (In Agile-based templates, the board for the requirement backlog is named "Stories" and the WorkItems type is User Story, CMMI-Based ones call their requirements backlog "Requirements" and the workitem type a Requirement and templates based on Basic use a board named "Issues" and the Issue workItem type ).
+As well as bugs, other built-in WorkItem types are tied to a particular board, the Epic type is always on the Epics board, the Feature type on Features, the Task type on Tasks and the Product BackLog item Type on Backlog items. (In Agile-based templates, the board for the requirement backlog is named "Stories" and the WorkItems type is User Story, CMMI-Based ones call their requirements backlog "Requirements" and the WorkItem type a Requirement and templates based on Basic use a board named "Issues" and the Issue workItem type ).
 
-Other workitem types -in particular custom-defined ones are available to add to any of these boards. So a new workitem type named "Change" might appear with tasks, with requirements, with features, or on a portfolio board of its own. When two or more work item types are available on the same board, one type is selected as the default for new items added to the board.
+Other WorkItem types -in particular, custom-defined ones - are available to add to any of these boards. So, a new WorkItem type named "Change" might appear with tasks, with requirements, with features, or on a portfolio board of its own. When two or more WorkItem types are available on the same board, one type is selected as the default for new items added to the board.
 
-Get-VSTeamProcessBehavior lists the boards available in the process template. And Get-VSTeamWorkItemBehavior shows the boards an Item can appear on and whether it is the default for that board.
+Get-VSTeamProcessBehavior lists the boards available in the process template. And Get-VSTeamWorkItemBehavior shows the boards a WorkItem type can appear on and whether it is the default for that board.
 
 ## EXAMPLES
 
@@ -33,7 +33,7 @@ WorkItem Type Behavior ID                              Is Default
 Epic          Microsoft.VSTS.Scrum.EpicBacklogBehavior True
 ```
 
-This shows the epic type has the "Scrum.EpicBacklogBehavior" - in other words it is on the Epics board of the scrum process, because the current project's process temp is, or is derived from, "Scrum"
+This shows the "Epic" type has the "Scrum.EpicBacklogBehavior" - in other words it is on the "Epics" board of the scrum process, because the current project's process template is, or is derived from, "Scrum"
 
 
 ### Example 2
@@ -55,14 +55,14 @@ Task                 System.TaskBacklogBehavior                  True
 Epic                 Microsoft.VSTS.Scrum.EpicBacklogBehavior    True
 ```
 
-This shows the all the workitem types in the template named scrum 5. Bug, Impediment and the three "Test" types have no associated behavior (of these only Impediment can be assigned to one). Task and Product backlog Item are assigned to system types for the iteration and reqirements backlogs. And Feature and Epic are assigned to portfolio backlogs inherited from the Scrum Process Template.
+This shows the all the WorkItem types in the template named scrum 5. "Bug", "Impediment" and the three "Test" types have no associated behavior (of these only Impediment can be assigned to one). Task and Product backlog Item are assigned to the iteration and requirements backlogs. And Feature and Epic are assigned to portfolio backlogs inherited from the Scrum Process Template.
 
 ## PARAMETERS
 
 
 ### -ProcessTemplate
 
-The Process Template containing the WorkItem types of interest; if no Template is specified, The template for the current Project will be used. The value of this parameter should tab complete.
+The Process Template containing the WorkItem types of interest; if no Template is specified, the template for the current Project will be used. The value of this parameter should tab complete.
 
 ```yaml
 Type: String

--- a/.docs/Get-VSTeamWorkItemBehavior.md
+++ b/.docs/Get-VSTeamWorkItemBehavior.md
@@ -14,11 +14,11 @@ In the user interface, WorkItems are shown on boards. The API refers to them as 
 
 In settings for a project based on the  "Scrum" process template, for example, under team configuration  "Epics", "Features" and/or "Backlog items" can be selected as "Backlog Navigation Levels" to display, and a fourth board "Tasks" is always used for displaying Sprints.  Bugs can either be displayed either on the Tasks board (as part of the "Iteration backlog" in a sprint) or on the Backlog Items board (as part of the "requirement backlog"). Iteration and Requirement are two categories of backlog which only have one board. The third category, Portfolio backlogs contains Epics, Features and user-defined boards/behaviors
 
-As well as bugs, other built-in WorkItem types are tied to a particular board, the Epic type is always on the Epics board, the Feature type on Features, the Task type on Tasks and the Product BackLog item Type on Backlog items. (In Agile-based templates, the board for the requirement backlog is named "Stories" and the WorkItems type is User Story, CMMI-Based ones call their requirements backlog "Requirements" and the workitem type a Requirement and templates based on Basic use a board named "Issues" and the Issue workItem type ). 
+As well as bugs, other built-in WorkItem types are tied to a particular board, the Epic type is always on the Epics board, the Feature type on Features, the Task type on Tasks and the Product BackLog item Type on Backlog items. (In Agile-based templates, the board for the requirement backlog is named "Stories" and the WorkItems type is User Story, CMMI-Based ones call their requirements backlog "Requirements" and the workitem type a Requirement and templates based on Basic use a board named "Issues" and the Issue workItem type ).
 
-Other workitem types -in particular custom-defined ones are available to add to any of these boards. So a new workitem type named "Change" might appear with tasks, with requirements, with features, or on a portfolio board of its own. When two or more work item types are available on the same board, one type is selected as the default for new items added to the board. 
+Other workitem types -in particular custom-defined ones are available to add to any of these boards. So a new workitem type named "Change" might appear with tasks, with requirements, with features, or on a portfolio board of its own. When two or more work item types are available on the same board, one type is selected as the default for new items added to the board.
 
-Get-VSTeamProcessBehavior lists the boards available in the process template. And Get-VSTeamWorkItemBehavior shows the boards an Item can appear on and whether it is the default for that board. 
+Get-VSTeamProcessBehavior lists the boards available in the process template. And Get-VSTeamWorkItemBehavior shows the boards an Item can appear on and whether it is the default for that board.
 
 ## EXAMPLES
 
@@ -33,7 +33,7 @@ WorkItem Type Behavior ID                              Is Default
 Epic          Microsoft.VSTS.Scrum.EpicBacklogBehavior True
 ```
 
-This shows the epic type has the "Scrum.EpicBacklogBehavior" - in other words it is on the Epics board of the scrum process, because the current project's process temp is, or is derived from, "Scrum" 
+This shows the epic type has the "Scrum.EpicBacklogBehavior" - in other words it is on the Epics board of the scrum process, because the current project's process temp is, or is derived from, "Scrum"
 
 
 ### Example 2
@@ -55,47 +55,39 @@ Task                 System.TaskBacklogBehavior                  True
 Epic                 Microsoft.VSTS.Scrum.EpicBacklogBehavior    True
 ```
 
-This shows the all the workitem types in the template named scrum 5. Bug, Impediment and the three "Test" types have no associated behavior (of these only Impediment can be assigned to one). Task and Product backlog Item are assigned to system types for the iteration and reqirements backlogs. And Feature and Epic are assigned to portfolio backlogs inherited from the Scrum Process Template. 
+This shows the all the workitem types in the template named scrum 5. Bug, Impediment and the three "Test" types have no associated behavior (of these only Impediment can be assigned to one). Task and Product backlog Item are assigned to system types for the iteration and reqirements backlogs. And Feature and Epic are assigned to portfolio backlogs inherited from the Scrum Process Template.
 
 ## PARAMETERS
 
 
 ### -ProcessTemplate
 
-The Process template of interest; if not template is specified the template for the current project will be used. The value of this parameter will tab complete
+The Process Template containing the WorkItem types of interest; if no Template is specified, The template for the current Project will be used. The value of this parameter should tab complete.
 
 ```yaml
 Type: String
 Parameter Sets: Process
 ```
 
-### -
+### -WorkItemType
 
-The type of WorkItem type whose details should be retrieved (wild cards are supported).
+The WorkItem type(s) whose details should be retrieved (wild cards are supported).
 
 ```yaml
 Type: String
 Parameter Sets: Process
 ```
-
-
 
 ## INPUTS
 
-### System.String
-
 ## OUTPUTS
 
-### System.Object
-
 ## NOTES
-<!-- #include "./common/prerequisites.md" -->
 
 ## RELATED LINKS
 
-<!-- #include "./common/related.md" -->
-[Add-VSTeamWorkItemType](Add-VSTeamProcessBehavior.md)
+[Set-VSTeamWorkItemBehavior](Set-VSTeamWorkItemBehavior.md)
 
-[Remove-VSTeamWorkItemType](Remove-VSTeamProcessBehavior.md)
+[Get-VSTeamProcessBehavior](Get-VSTeamProcessBehavior.md)
 
-[Set-VSTeamWorkItemType](Set-VSTeamProcessBehavior.md)
+[Get-VSTeamWorkItemType](Get-VSTeamWorkItemType.md)

--- a/.docs/Get-VSTeamWorkItemIconList.md
+++ b/.docs/Get-VSTeamWorkItemIconList.md
@@ -1,0 +1,28 @@
+<!-- #include "./common/header.md" -->
+
+# Get-VSTeamWorkItemIconList
+
+## SYNOPSIS
+<!-- #include "./synopsis/Get-VSTeamWorkItemIconList.md" -->
+
+## SYNTAX
+
+## DESCRIPTION
+
+<!-- #include "./synopsis/Get-VSTeamWorkItemIconList.md" -->
+
+## PARAMETERS
+
+### CommonParameters
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](http://go.microsoft.com/fwlink/?LinkID=113216).
+
+## INPUTS
+
+### None
+
+## OUTPUTS
+
+### System.Object
+## NOTES
+
+## RELATED LINKS

--- a/.docs/Get-VSTeamWorkItemIconList.md
+++ b/.docs/Get-VSTeamWorkItemIconList.md
@@ -13,8 +13,6 @@
 
 ## PARAMETERS
 
-### CommonParameters
-This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](http://go.microsoft.com/fwlink/?LinkID=113216).
 
 ## INPUTS
 

--- a/.docs/Get-VSTeamWorkItemType.md
+++ b/.docs/Get-VSTeamWorkItemType.md
@@ -20,9 +20,46 @@
 Get-VSTeamWorkItemType -ProjectName test -WorkItemType 'Code Review Response'
 ```
 
-This command gets a single work item type.
+This command gets a single work item type from the named project.
+
+### Example 2
+
+```powershell
+Get-VSTeamWorkItemType -ProcessTemplate Basic
+```
+
+This command gets a list of the WorkItems available to projects which use the 'Basic' Template
+
+### Example 3
+
+```powershell
+Get-VSTeamProcess scr* | Get-VSTeamWorkItemType -WorkItemType pro* | Format-Table name,processTemplate
+
+name                 ProcessTemplate
+----                 ---------------
+Product Backlog Item Scrum
+Product Backlog Item Scrum2
+Product Backlog Item Scrum4
+```
+
+The first command in the pipeline gets the process templates with names which match SCR*, in this example 
+these are "Scrum", "Scrum2" and "Scrum4". The command second finds WorkItem-Types in those processes 
+which match "pro*", (each process has a "Product Backlog item" work item type) and the third command 
+shows a table of Type-name and the process-template which has that type.
+
 
 ## PARAMETERS
+
+<!-- #include "./params/projectName.md" -->
+
+### -ProcessTemplate
+
+The Process holding the WorkItems of interest.
+
+```yaml
+Type: String
+Parameter Sets: Process
+```
 
 ### WorkItemType
 
@@ -32,8 +69,6 @@ The type of work item to retrieve.
 Type: String
 Parameter Sets: ByType
 ```
-
-<!-- #include "./params/projectName.md" -->
 
 ## INPUTS
 
@@ -54,3 +89,8 @@ This causes issues with the ConvertFrom-Json CmdLet.  Therefore, all "": are rep
 ## RELATED LINKS
 
 <!-- #include "./common/related.md" -->
+[Add-VSTeamWorkItemType](Get-VSTeamWorkItemType.md)
+
+[Set-VSTeamWorkItemType](Set-VSTeamWorkItemType.md)
+
+[Remove-VSTeamWorkItemType](Remove-VSTeamWorkItemType.md)

--- a/.docs/Get-VSTeamWorkItemType.md
+++ b/.docs/Get-VSTeamWorkItemType.md
@@ -28,7 +28,7 @@ This command gets a single WorkItem type from the named project.
 Get-VSTeamWorkItemType -ProcessTemplate Basic
 ```
 
-This command gets a list of the WorkItems available to projects which use the 'Basic' Template
+This command gets a list of the WorkItems available to projects which use the 'Basic' Template.
 
 ### Example 3
 
@@ -42,9 +42,9 @@ Product Backlog Item Scrum2
 Product Backlog Item Scrum4
 ```
 
-The first command in the pipeline gets the process templates with names which match SCR*, in this example 
-these are "Scrum", "Scrum2" and "Scrum4". The command second finds WorkItem-Types in those processes 
-which match "pro*", (each process has a "Product Backlog item" WorkItem type) and the third command 
+The first command in the pipeline gets the process templates with names which match SCR*, in this example
+these are "Scrum", "Scrum2" and "Scrum4". The second command  finds WorkItem-Types in those processes
+which match "pro*", (each process has a "Product Backlog item" WorkItem type) and the third command
 shows a table of Type-name and the process-template which has that type.
 
 
@@ -52,7 +52,7 @@ shows a table of Type-name and the process-template which has that type.
 
 ### -Expand
 
-If specified the WorkItems returned will have behavior and/or layout and/or state information attached.
+If specified, the WorkItem type information returned will have behavior, layout and/or state information attached, depending on the value of the parameter.
 
 ```yaml
 Type: String[]
@@ -60,7 +60,7 @@ Parameter Sets: Process
 Accepted values: 'behaviors','layout','states'
 ```
 
-### --NotHidden
+### -NotHidden
 
 Excludes WorkItem Types which are marked as hidden.
 
@@ -76,7 +76,7 @@ Parameter Sets: (All)
 
 ### -ProcessTemplate
 
-The Process holding the WorkItem types of interest. 
+The Process template holding the WorkItem type(s) of interest.
 Note that if ProcessTemplate is specified it is still possible to provide a ProjectName parameter, but it will be ignored.
 
 ```yaml
@@ -85,8 +85,7 @@ Parameter Sets: Process
 ```
 
 ### WorkItemType
-
-The type of WorkItem type whose details should be retrieved (wild cards are supported).
+The WorkItem type whose details should be retrieved (wild cards are supported).
 
 ```yaml
 Type: String
@@ -112,7 +111,7 @@ This causes issues with the ConvertFrom-Json CmdLet.  Therefore, all "": are rep
 ## RELATED LINKS
 
 <!-- #include "./common/related.md" -->
-[Add-VSTeamWorkItemType](Get-VSTeamWorkItemType.md)
+[Add-VSTeamWorkItemType](Add-VSTeamWorkItemType.md)
 
 [Set-VSTeamWorkItemType](Set-VSTeamWorkItemType.md)
 

--- a/.docs/Get-VSTeamWorkItemType.md
+++ b/.docs/Get-VSTeamWorkItemType.md
@@ -106,11 +106,9 @@ The JSON returned has empty named items i.e.
 "": "To Do"
 This causes issues with the ConvertFrom-Json CmdLet.  Therefore, all "": are replaced with "_end":
 
-<!-- #include "./common/prerequisites.md" -->
 
 ## RELATED LINKS
 
-<!-- #include "./common/related.md" -->
 [Add-VSTeamWorkItemType](Add-VSTeamWorkItemType.md)
 
 [Set-VSTeamWorkItemType](Set-VSTeamWorkItemType.md)

--- a/.docs/Get-VSTeamWorkItemType.md
+++ b/.docs/Get-VSTeamWorkItemType.md
@@ -28,7 +28,7 @@ This command gets a single WorkItem type from the named project.
 Get-VSTeamWorkItemType -ProcessTemplate Basic
 ```
 
-This command gets a list of the WorkItems available to projects which use the 'Basic' Template.
+This command gets a list of the WorkItem types available to projects which use the 'Basic' Template.
 
 ### Example 3
 
@@ -43,9 +43,9 @@ Product Backlog Item Scrum4
 ```
 
 The first command in the pipeline gets the process templates with names which match SCR*, in this example
-these are "Scrum", "Scrum2" and "Scrum4". The second command  finds WorkItem-Types in those processes
+these are "Scrum", "Scrum2" and "Scrum4". The second command finds WorkItem types in those processes
 which match "pro*", (each process has a "Product Backlog item" WorkItem type) and the third command
-shows a table of Type-name and the process-template which has that type.
+shows a table of type-name and the process-template which has that type.
 
 
 ## PARAMETERS

--- a/.docs/Get-VSTeamWorkItemType.md
+++ b/.docs/Get-VSTeamWorkItemType.md
@@ -20,7 +20,7 @@
 Get-VSTeamWorkItemType -ProjectName test -WorkItemType 'Code Review Response'
 ```
 
-This command gets a single work item type from the named project.
+This command gets a single WorkItem type from the named project.
 
 ### Example 2
 
@@ -44,17 +44,40 @@ Product Backlog Item Scrum4
 
 The first command in the pipeline gets the process templates with names which match SCR*, in this example 
 these are "Scrum", "Scrum2" and "Scrum4". The command second finds WorkItem-Types in those processes 
-which match "pro*", (each process has a "Product Backlog item" work item type) and the third command 
+which match "pro*", (each process has a "Product Backlog item" WorkItem type) and the third command 
 shows a table of Type-name and the process-template which has that type.
 
 
 ## PARAMETERS
 
+### -Expand
+
+If specified the WorkItems returned will have behavior and/or layout and/or state information attached.
+
+```yaml
+Type: String[]
+Parameter Sets: Process
+Accepted values: 'behaviors','layout','states'
+```
+
+### --NotHidden
+
+Excludes WorkItem Types which are marked as hidden.
+
+```yaml
+Type: SwitchParameter
+Required: false
+Position: Named
+Accept pipeline input: false
+Parameter Sets: (All)
+```
+
 <!-- #include "./params/projectName.md" -->
 
 ### -ProcessTemplate
 
-The Process holding the WorkItems of interest.
+The Process holding the WorkItem types of interest. 
+Note that if ProcessTemplate is specified it is still possible to provide a ProjectName parameter, but it will be ignored.
 
 ```yaml
 Type: String
@@ -63,7 +86,7 @@ Parameter Sets: Process
 
 ### WorkItemType
 
-The type of work item to retrieve.
+The type of WorkItem type whose details should be retrieved (wild cards are supported).
 
 ```yaml
 Type: String

--- a/.docs/Remove-VSTeamProcess.md
+++ b/.docs/Remove-VSTeamProcess.md
@@ -1,16 +1,16 @@
 <!-- #include "./common/header.md" -->
 
-# Set-VSTeamProcess
+# Remove-VSTeamProcess
 
 ## SYNOPSIS
 
-<!-- #include "./synopsis/Set-VSTeamProcess.md" -->
+<!-- #include "./synopsis/Remove-VSTeamProcess.md" -->
 
 ## SYNTAX
 
 ## DESCRIPTION
 
-<!-- #include "./synopsis/Set-VSTeamProcess.md" -->
+<!-- #include "./synopsis/Remove-VSTeamProcess.md" -->
 
 ## EXAMPLES
 
@@ -36,7 +36,7 @@ Prompts you for confirmation before running the cmdlet. By default this command 
 
 
 ### -ProcessTemplate
-The name of the process template which is to be deleted
+The name of the process template which is to be deleted.
 
 ```yaml
 Type: Object

--- a/.docs/Remove-VSTeamProcess.md
+++ b/.docs/Remove-VSTeamProcess.md
@@ -1,0 +1,65 @@
+<!-- #include "./common/header.md" -->
+
+# Set-VSTeamProcess
+
+## SYNOPSIS
+
+<!-- #include "./synopsis/Set-VSTeamProcess.md" -->
+
+## SYNTAX
+
+## DESCRIPTION
+
+<!-- #include "./synopsis/Set-VSTeamProcess.md" -->
+
+## EXAMPLES
+
+### Example 1
+
+```PowerShell
+Remove-VSTeamProcess -Process Agile2     
+
+Confirm
+Are you sure you want to perform this action?
+Performing the operation "DELETE Devops Process template" on target "Agile2".
+[Y] Yes [A] Yes to All [N] No [L] No to All [S] Suspend [?] Help (default is "Yes"): y:
+```
+
+This deletes the custom process "Agile2"; because -Force was not specified, a confirmation prompt is shown.
+
+## PARAMETERS
+
+### -Confirm
+Prompts you for confirmation before running the cmdlet. By default this command requires confirmation so this parameter is only needed if $ConfirmPreference has been changed.
+
+<!-- #include "./params/force.md" -->
+
+
+### -ProcessTemplate
+The name of the process template which is to be deleted
+
+```yaml
+Type: Object
+Parameter Sets: (All)
+Aliases: Name
+
+Required: True
+Position: Named
+Default value: None
+Accept pipeline input: True (ByPropertyName)
+Accept wildcard characters: False
+```
+
+<!-- #include "./params/whatif.md" -->
+
+## INPUTS
+
+## OUTPUTS
+
+## NOTES
+
+## RELATED LINKS
+
+[Add-VSTeamProcess](Add-VSTeamProcess.md)
+
+[Get-VSTeamProcess](Get-VSTeamProcess.md)

--- a/.docs/Remove-VSTeamProcessBehavior.md
+++ b/.docs/Remove-VSTeamProcessBehavior.md
@@ -17,9 +17,9 @@
 ### Example 1
 
 ```powershell
-Set-VSTeamProcessBehavior -ProcessTemplate Scrum5 -Name "Change Requests" 
+Set-VSTeamProcessBehavior -ProcessTemplate Scrum5 -Name "Change Requests"
 ```
-Removes a portfolio backlog from the scrum5 processs template (note that the only custom behaviors on custom templates can be removed). 
+Removes a Portfolio Backlog from the "scrum5" Processs Template (note that the only custom Behaviors on custom Templates can be removed).
 
 ## PARAMETERS
 
@@ -45,29 +45,15 @@ Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
-
-
 <!-- #include "./params/whatIf.md" -->
-
-### CommonParameters
-
-This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](http://go.microsoft.com/fwlink/?LinkID=113216).
 
 ## INPUTS
 
-### System.String
-
 ## OUTPUTS
-
-### System.Object
 
 ## NOTES
 
-<!-- #include "./common/prerequisites.md" -->
-
 ## RELATED LINKS
-
-<!-- #include "./common/related.md" -->
 [Add-VSTeamProcessBehavior](Add-VSTeamProcessBehavior.md)
 
 [Get-VSTeamProcessBehavior](Get-VSTeamProcessBehavior.md)

--- a/.docs/Remove-VSTeamProcessBehavior.md
+++ b/.docs/Remove-VSTeamProcessBehavior.md
@@ -1,0 +1,75 @@
+<!-- #include "./common/header.md" -->
+
+# Remove-VSTeamProcessBehavior
+
+## SYNOPSIS
+
+<!-- #include "./synopsis/Remove-VSTeamProcessBehavior.md" -->
+
+## SYNTAX
+
+## Description
+
+<!-- #include "./synopsis/Remove-VSTeamProcessBehavior.md" -->
+
+## EXAMPLES
+
+### Example 1
+
+```powershell
+Set-VSTeamProcessBehavior -ProcessTemplate Scrum5 -Name "Change Requests" 
+```
+Removes a portfolio backlog from the scrum5 processs template (note that the only custom behaviors on custom templates can be removed). 
+
+## PARAMETERS
+
+### -Confirm
+
+Prompts you for confirmation before running the cmdlet. Normally the command will prompt for confirmation and -Confirm is only needed if \$ConfirmPreference has been changed.
+
+<!-- #include "./params/force.md" -->
+
+### -Name
+
+Current name of the behavior / backlog
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: 2
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+
+
+<!-- #include "./params/whatIf.md" -->
+
+### CommonParameters
+
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](http://go.microsoft.com/fwlink/?LinkID=113216).
+
+## INPUTS
+
+### System.String
+
+## OUTPUTS
+
+### System.Object
+
+## NOTES
+
+<!-- #include "./common/prerequisites.md" -->
+
+## RELATED LINKS
+
+<!-- #include "./common/related.md" -->
+[Add-VSTeamProcessBehavior](Add-VSTeamProcessBehavior.md)
+
+[Get-VSTeamProcessBehavior](Get-VSTeamProcessBehavior.md)
+
+[Set-VSTeamProcessBehavior](Set-VSTeamProcessBehavior.md)

--- a/.docs/Remove-VSTeamWorkItemType.md
+++ b/.docs/Remove-VSTeamWorkItemType.md
@@ -10,9 +10,9 @@
 
 ## Description
 
-Removes a custom work item type, or reverts an inherited work item type back to the built-in Type.
+Removes a custom WorkItem type or reverts an inherited WorkItem type back to the built-in Type.
 
-If the type is a system type (as all work item types in built-in Process templates are) then an error will be thrown.
+If the type is a system type (as all WorkItem types in built-in Process templates are) then an error will be thrown.
 
 ## EXAMPLES
 
@@ -22,16 +22,8 @@ If the type is a system type (as all work item types in built-in Process templat
 Remove-VSTeamWorkItemType -ProcessTemplate Scrum5 -WorkItemType ChangeRequest
 ```
 
-Remove-VSTeamWorkItemType -ProcessTemplate Scrum5 -WorkItemType ChangeRequest.
+Removes the custom WorkItem type named "ChangeRequest" from the custom process template named "Scrum5"
 
-### Example 2
-
-```powershell
-Set-VSTeamWorkItemType -ProcessTemplate Scrum5 -WorkItemType ChangeRequest -Icon icon_parachute -color Blue -Description "For requests from customers"
-```
-
-Modifies the custom process "Scrum5", changing a user-defined work item type "ChangeRequest" to use
-a blue parachute icon and update its description..
 ## PARAMETERS
 
 ### -Confirm
@@ -58,7 +50,7 @@ Accept wildcard characters: False
 
 ### -WorkItemType
 
-The name of the work item type to be removed or reverted. If the WorkItem type is a system type (for example if had been changed but has already been reverted), then an error will be thrown.
+The name of the WorkItem type to be removed or reverted. If the WorkItem type is a system type (for example if had been changed but has already been reverted), then an error will be thrown.
 
 The built-in system types cannot be deleted, but can be disabled with Set-VSTeamWorkItemType.
 

--- a/.docs/Remove-VSTeamWorkItemType.md
+++ b/.docs/Remove-VSTeamWorkItemType.md
@@ -10,7 +10,7 @@
 
 ## Description
 
-Removes a custom work item type, or reverts an inherited work item type back to the built-in Type. 
+Removes a custom work item type, or reverts an inherited work item type back to the built-in Type.
 
 If the type is a system type (as all work item types in built-in Process templates are) then an error will be thrown.
 
@@ -103,10 +103,6 @@ Default value: None
 Accept pipeline input: False
 Accept wildcard characters: False
 ```
-
-### CommonParameters
-
-This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](http://go.microsoft.com/fwlink/?LinkID=113216).
 
 ## INPUTS
 

--- a/.docs/Remove-VSTeamWorkItemType.md
+++ b/.docs/Remove-VSTeamWorkItemType.md
@@ -34,7 +34,6 @@ Modifies the custom process "Scrum5", changing a user-defined work item type "Ch
 a blue parachute icon and update its description..
 ## PARAMETERS
 
-
 ### -Confirm
 
 Prompts you for confirmation before running the cmdlet. Normally the command will prompt for confirmation and -Confirm is only needed if \$ConfirmPreference has been changed.
@@ -51,40 +50,11 @@ Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
-<!-- #include "./params/force.md" -->
+<!-- #include "./params/Force.md" -->
 
-### -ProcessTemplate
+<!-- #include "./params/whatif.md" -->
 
-The process template to modify. Note that the built-in templates ("Scrum", "Agile" etc.) cannot be modified, only custom templates (derived from the built-in ones) can be changed.
-
-```yaml
-Type: Object
-Parameter Sets: (All)
-Aliases:
-
-Required: False
-Position: 0
-Default value: None
-Accept pipeline input: False
-Accept wildcard characters: False
-```
-
-### -WhatIf
-
-Shows what would happen if the cmdlet runs.
-The cmdlet is not run.
-
-```yaml
-Type: SwitchParameter
-Parameter Sets: (All)
-Aliases: wi
-
-Required: False
-Position: Named
-Default value: None
-Accept pipeline input: False
-Accept wildcard characters: False
-```
+<!-- #include "./params/processTemplate.md" -->
 
 ### -WorkItemType
 
@@ -106,19 +76,12 @@ Accept wildcard characters: False
 
 ## INPUTS
 
-### System.String
-
 ## OUTPUTS
-
-### System.Object
 
 ## NOTES
 
-<!-- #include "./common/prerequisites.md" -->
-
 ## RELATED LINKS
 
-<!-- #include "./common/related.md" -->
 [Add-VSTeamWorkItemType](Add-VSTeamWorkItemType.md)
 
 [Get-VSTeamWorkItemType](Get-VSTeamWorkItemType.md)

--- a/.docs/Remove-VSTeamWorkItemType.md
+++ b/.docs/Remove-VSTeamWorkItemType.md
@@ -1,0 +1,130 @@
+<!-- #include "./common/header.md" -->
+
+# Remove-VSTeamWorkItemType
+
+## SYNOPSIS
+
+<!-- #include "./synopsis/Remove-VSTeamWorkItemType.md" -->
+
+## SYNTAX
+
+## Description
+
+Removes a custom work item type, or reverts an inherited work item type back to the built-in Type. 
+
+If the type is a system type (as all work item types in built-in Process templates are) then an error will be thrown.
+
+## EXAMPLES
+
+### Example 1
+
+```powershell
+Remove-VSTeamWorkItemType -ProcessTemplate Scrum5 -WorkItemType ChangeRequest
+```
+
+Remove-VSTeamWorkItemType -ProcessTemplate Scrum5 -WorkItemType ChangeRequest.
+
+### Example 2
+
+```powershell
+Set-VSTeamWorkItemType -ProcessTemplate Scrum5 -WorkItemType ChangeRequest -Icon icon_parachute -color Blue -Description "For requests from customers"
+```
+
+Modifies the custom process "Scrum5", changing a user-defined work item type "ChangeRequest" to use
+a blue parachute icon and update its description..
+## PARAMETERS
+
+
+### -Confirm
+
+Prompts you for confirmation before running the cmdlet. Normally the command will prompt for confirmation and -Confirm is only needed if \$ConfirmPreference has been changed.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: (All)
+Aliases: cf
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+<!-- #include "./params/force.md" -->
+
+### -ProcessTemplate
+
+The process template to modify. Note that the built-in templates ("Scrum", "Agile" etc.) cannot be modified, only custom templates (derived from the built-in ones) can be changed.
+
+```yaml
+Type: Object
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: 0
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -WhatIf
+
+Shows what would happen if the cmdlet runs.
+The cmdlet is not run.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: (All)
+Aliases: wi
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -WorkItemType
+
+The name of the work item type to be removed or reverted. If the WorkItem type is a system type (for example if had been changed but has already been reverted), then an error will be thrown.
+
+The built-in system types cannot be deleted, but can be disabled with Set-VSTeamWorkItemType.
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases: Name
+
+Required: True
+Position: 1
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### CommonParameters
+
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](http://go.microsoft.com/fwlink/?LinkID=113216).
+
+## INPUTS
+
+### System.String
+
+## OUTPUTS
+
+### System.Object
+
+## NOTES
+
+<!-- #include "./common/prerequisites.md" -->
+
+## RELATED LINKS
+
+<!-- #include "./common/related.md" -->
+[Add-VSTeamWorkItemType](Add-VSTeamWorkItemType.md)
+
+[Get-VSTeamWorkItemType](Get-VSTeamWorkItemType.md)
+
+[Set-VSTeamWorkItemType](Remove-VSTeamWorkItemType.md)

--- a/.docs/Set-VSTeamProcess.md
+++ b/.docs/Set-VSTeamProcess.md
@@ -30,7 +30,7 @@ Name  Enabled Default Description
 Agile True    True    This template is flexible and will work great for most teams...
 ```
 
-This commands sets the built-in process "Agile" as the default process, and prompts the user to confirm the action.
+This command sets the built-in process "Agile" as the default process, and prompts the user to confirm the action.
 
 ### Example 2
 
@@ -43,7 +43,7 @@ Basic False   False   This template is flexible for any process...
 ```
 
 The first command in the pipeline gets built-in process "Basic", and the second disables it without waiting for confirmation.
-The Get- command could take a wildcard and return multiple matching processes, which would cause all to be disabled.
+The Get- command could take a wildcard and return multiple matching processes, which would cause them all to be disabled.
 
 ### Example 3
 
@@ -62,7 +62,7 @@ This renames a project to remove the space from its name, and gives it a new des
 
 ### -AsDefault
 
-Makes a process the default for new projects in the Organization
+Makes a process the default for new projects in the organization
 
 ```yaml
 Type: SwitchParameter
@@ -92,7 +92,7 @@ Accept wildcard characters: False
 ```
 ### -Description
 
-A new description for the new process
+A new description for the new process.
 
 ```yaml
 Type: String
@@ -108,7 +108,7 @@ Accept wildcard characters: False
 
 ### -Disabled
 
-Disables a process; built-in processes cannot be deleted.
+Disables a process; built-in processes cannot be deleted but can be disabled.
 
 ```yaml
 Type: SwitchParameter
@@ -124,7 +124,7 @@ Accept wildcard characters: False
 
 ### -Enabled
 
-Re-enables a disabled Process
+Re-enables a disabled process.
 
 ```yaml
 Type: SwitchParameter
@@ -142,7 +142,7 @@ Accept wildcard characters: False
 
 ### -NewName
 
-Allows the Process to be renamed
+Allows the process to be renamed.
 
 ```yaml
 Type: String

--- a/.docs/Set-VSTeamProcess.md
+++ b/.docs/Set-VSTeamProcess.md
@@ -42,7 +42,7 @@ Name  Enabled Default Description
 Basic False   False   This template is flexible for any process...
 ```
 
-The first command in the pipeline gets built-in process "Basic", and the second disables it without waiting for confirmation. 
+The first command in the pipeline gets built-in process "Basic", and the second disables it without waiting for confirmation.
 The Get- command could take a wildcard and return multiple matching processes, which would cause all to be disabled.
 
 ### Example 3
@@ -77,7 +77,7 @@ Accept wildcard characters: False
 ```
 
 ### -Confirm
-Prompts you for confirmation before running the cmdlet. By default this command requires confirmation so this parameter is only needed if $ConfirmPreference has been changed. 
+Prompts you for confirmation before running the cmdlet. By default this command requires confirmation so this parameter is only needed if $ConfirmPreference has been changed.
 
 ```yaml
 Type: SwitchParameter
@@ -157,7 +157,7 @@ Accept wildcard characters: False
 ```
 
 ### -ProcessTemplate
-The current name of the process template which is to be modified. 
+The current name of the process template which is to be modified.
 
 ```yaml
 Type: Object
@@ -179,10 +179,8 @@ Accept wildcard characters: False
 
 ## NOTES
 
-<!-- #include "./common/prerequisites.md" -->
-
 ## RELATED LINKS
 
-<!-- #include "./common/related.md" -->
+[Add-VSTeamProcess](Add-VSTeamProcess.md)
 
-[Set-VSTeamWorkItemType](Set-VSTeamWorkItemType.md)
+[Get-VSTeamProcess](Get-VSTeamProcess.md)

--- a/.docs/Set-VSTeamProcess.md
+++ b/.docs/Set-VSTeamProcess.md
@@ -1,0 +1,188 @@
+<!-- #include "./common/header.md" -->
+
+# Set-VSTeamProcess
+
+## SYNOPSIS
+
+<!-- #include "./synopsis/Set-VSTeamProcess" -->
+
+## SYNTAX
+
+## DESCRIPTION
+
+<!-- #include "./synopsis/Set-VSTeamProcess" -->
+
+## EXAMPLES
+
+### Example 1
+
+```PowerShell
+Set-VSTeamProcess -name Agile -AsDefault
+
+Confirm
+Are you sure you want to perform this action?
+Performing the operation "Update Devops Process" on target "Agile".
+[Y] Yes [A] Yes to All [N] No [L] No to All [S] Suspend [?] Help (default is "Yes"): y
+
+
+Name  Enabled Default Description
+----  ------- ------- -----------
+Agile True    True    This template is flexible and will work great for most teams...
+```
+
+This commands sets the built-in process "Agile" as the default process, and prompts the user to confirm the action.
+
+### Example 2
+
+```PowerShell
+Get-VSTeamProcess -Name Basic | Set-VSTeamProcess -Disabled -Force
+
+Name  Enabled Default Description
+----  ------- ------- -----------
+Basic False   False   This template is flexible for any process...
+```
+
+The first command in the pipeline gets built-in process "Basic", and the second disables it without waiting for confirmation. 
+The Get- command could take a wildcard and return multiple matching processes, which would cause all to be disabled.
+
+### Example 3
+
+```PowerShell
+PS C:\> Set-VSTeamProcess -ProcessTemplate 'Basic J' -NewName 'Basic-J' -Description 'Template for the Mysterious J Project' -Force
+
+
+Name    Enabled Default Description
+----    ------- ------- -----------
+Basic-J True    False   Template for the Mysterious J Project
+```
+
+This renames a project to remove the space from its name, and gives it a new description.
+
+## PARAMETERS
+
+### -AsDefault
+
+Makes a process the default for new projects in the Organization
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: LeaveAlone, Show
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Confirm
+Prompts you for confirmation before running the cmdlet. By default this command requires confirmation so this parameter is only needed if $ConfirmPreference has been changed. 
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: (All)
+Aliases: cf
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+### -Description
+
+A new description for the new process
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Disabled
+
+Disables a process; built-in processes cannot be deleted.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: Hide
+Aliases:
+
+Required: True
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Enabled
+
+Re-enables a disabled Process
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: Show
+Aliases:
+
+Required: True
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+<!-- #include "./params/force.md" -->
+
+### -NewName
+
+Allows the Process to be renamed
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -ProcessTemplate
+The current name of the process template which is to be modified. 
+
+```yaml
+Type: Object
+Parameter Sets: (All)
+Aliases: Name
+
+Required: True
+Position: Named
+Default value: None
+Accept pipeline input: True (ByPropertyName)
+Accept wildcard characters: False
+```
+
+<!-- #include "./params/whatif.md" -->
+
+## INPUTS
+
+## OUTPUTS
+
+## NOTES
+
+<!-- #include "./common/prerequisites.md" -->
+
+## RELATED LINKS
+
+<!-- #include "./common/related.md" -->
+
+[Set-VSTeamWorkItemType](Set-VSTeamWorkItemType.md)

--- a/.docs/Set-VSTeamProcess.md
+++ b/.docs/Set-VSTeamProcess.md
@@ -184,3 +184,5 @@ Accept wildcard characters: False
 [Add-VSTeamProcess](Add-VSTeamProcess.md)
 
 [Get-VSTeamProcess](Get-VSTeamProcess.md)
+
+[Remove-VSTeamProcess](Remove-VSTeamProcess.md)

--- a/.docs/Set-VSTeamProcess.md
+++ b/.docs/Set-VSTeamProcess.md
@@ -4,13 +4,13 @@
 
 ## SYNOPSIS
 
-<!-- #include "./synopsis/Set-VSTeamProcess" -->
+<!-- #include "./synopsis/Set-VSTeamProcess.md" -->
 
 ## SYNTAX
 
 ## DESCRIPTION
 
-<!-- #include "./synopsis/Set-VSTeamProcess" -->
+<!-- #include "./synopsis/Set-VSTeamProcess.md" -->
 
 ## EXAMPLES
 

--- a/.docs/Set-VSTeamProcessBehavior.md
+++ b/.docs/Set-VSTeamProcessBehavior.md
@@ -10,10 +10,8 @@
 
 ## Description
 
-Modifies a Portfolio backlog (a.k.a behavior) in a Process Template. 
-
-Note (1) the built-in Process templates (Scrum, Agile etc.) do not allow their backlogs to be customized, this is only allowed for custom processes. 
-
+Modifies a Portfolio backlog (a.k.a behavior) in a Process Template.
+Note (1) the built-in Process templates (Scrum, Agile etc.) do not allow their backlogs to be customized, this is only allowed for custom processes.
 Note (2) System behaviors include a description, but this cannot be changed or set for custom behaviors.
 
 ## EXAMPLES
@@ -28,13 +26,13 @@ Rank Name            Workitem types Inherits                        color  Descr
 ---- ----            -------------- --------                        -----  -----------
 50   Change Requests                System.PortfolioBacklogBehavior 0000ff
 ```
-Changes a portfolio backlog in the scrum5 processs template (note that the built-in templates, like "Scrum" cannot be changed, only user-defined ones - like scrum5 in this case - can have new backlogs). 
+Changes a portfolio backlog in the scrum5 processs template (note that the built-in templates, like "Scrum" cannot be changed, only user-defined ones - like scrum5 in this case - can have new backlogs).
 
 ## PARAMETERS
 
 ### -Color
 
-Sets the the icon color for the backlog. The input value can be the name of a color name like "Red" or "Aqua" or a hex value for red, green and blue parts. Color names should tab complete. If no Color is provided, mid gray is used.
+Sets the the icon color for the backlog. The input value can be the name of a color like "Red" or "Aqua" or a hex value for red, green and blue parts. Color names should tab complete. If no color is provided, mid gray is used.
 
 ```yaml
 Type: Object
@@ -71,7 +69,6 @@ Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
-
 ### -NewName
 
 Replacement name for the behavior / backlog
@@ -88,10 +85,9 @@ Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
-
 ### -ProcessTemplate
 
-The process template to modify. Note that the built-in templates ("Scrum", "Agile" etc.) cannot be modified, only custom templates (derived from the built-in ones) can be changed.
+The Process Template to modify. Note that the built-in Templates ("Scrum", "Agile" etc.) cannot be modified, only custom templates (derived from the built-in ones) can be changed.
 
 ```yaml
 Type: Object
@@ -107,25 +103,14 @@ Accept wildcard characters: False
 
 <!-- #include "./params/whatIf.md" -->
 
-### CommonParameters
-
-This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](http://go.microsoft.com/fwlink/?LinkID=113216).
-
 ## INPUTS
-
-### System.String
 
 ## OUTPUTS
 
-### System.Object
-
 ## NOTES
-
-<!-- #include "./common/prerequisites.md" -->
 
 ## RELATED LINKS
 
-<!-- #include "./common/related.md" -->
 [Add-VSTeamProcessBehavior](Add-VSTeamProcessBehavior.md)
 
 [Get-VSTeamProcessBehavior](Get-VSTeamProcessBehavior.md)

--- a/.docs/Set-VSTeamProcessBehavior.md
+++ b/.docs/Set-VSTeamProcessBehavior.md
@@ -1,0 +1,130 @@
+<!-- #include "./common/header.md" -->
+
+# Set-VSTeamProcessBehavior
+
+## SYNOPSIS
+
+<!-- #include "./synopsis/Set-VSTeamProcessBehavior.md" -->
+
+## SYNTAX
+
+## Description
+
+Modifies a backlog (a.k.a behavior) in a Process Template. Note that the built-in Process templates (Scrum, Agile etc.) do not allow their backlogs to be customized, this is only allowed for custom processes. 
+Note that System behaviors include a description, but this cannot be changed or set for custom behaviors.
+
+## EXAMPLES
+
+### Example 1
+
+```powershell
+Set-VSTeamProcessBehavior -ProcessTemplate Scrum5 -Name "Change Requests" -Color Blue
+
+
+Rank Name            Workitem types Inherits                        color  Description
+---- ----            -------------- --------                        -----  -----------
+50   Change Requests                System.PortfolioBacklogBehavior 0000ff
+```
+Changes a portfolio backlog in the scrum5 processs template (note that the built-in templates, like "Scrum" cannot be changed, only user-defined ones - like scrum5 in this case - can have new backlogs). 
+
+## PARAMETERS
+
+### -Color
+
+Sets the the icon color for the backlog. The input value can be the name of a color name like "Red" or "Aqua" or a hex value for red, green and blue parts. Color names should tab complete. If no Color is provided, mid gray is used.
+
+```yaml
+Type: Object
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: 3
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Confirm
+
+Prompts you for confirmation before running the cmdlet. Normally the command will prompt for confirmation and -Confirm is only needed if \$ConfirmPreference has been changed.
+
+<!-- #include "./params/force.md" -->
+
+
+### -Name
+
+Current name of the behavior / backlog
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: 2
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+
+### -NewName
+
+Replacement name for the behavior / backlog
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: 2
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+
+### -ProcessTemplate
+
+The process template to modify. Note that the built-in templates ("Scrum", "Agile" etc.) cannot be modified, only custom templates (derived from the built-in ones) can be changed.
+
+```yaml
+Type: Object
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: 0
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+<!-- #include "./params/whatIf.md" -->
+
+### CommonParameters
+
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](http://go.microsoft.com/fwlink/?LinkID=113216).
+
+## INPUTS
+
+### System.String
+
+## OUTPUTS
+
+### System.Object
+
+## NOTES
+
+<!-- #include "./common/prerequisites.md" -->
+
+## RELATED LINKS
+
+<!-- #include "./common/related.md" -->
+[Add-VSTeamProcessBehavior](Add-VSTeamProcessBehavior.md)
+
+[Get-VSTeamProcessBehavior](Get-VSTeamProcessBehavior.md)
+
+[Remove-VSTeamProcessBehavior](Remove-VSTeamProcessBehavior.md)

--- a/.docs/Set-VSTeamProcessBehavior.md
+++ b/.docs/Set-VSTeamProcessBehavior.md
@@ -10,8 +10,11 @@
 
 ## Description
 
-Modifies a backlog (a.k.a behavior) in a Process Template. Note that the built-in Process templates (Scrum, Agile etc.) do not allow their backlogs to be customized, this is only allowed for custom processes. 
-Note that System behaviors include a description, but this cannot be changed or set for custom behaviors.
+Modifies a Portfolio backlog (a.k.a behavior) in a Process Template. 
+
+Note (1) the built-in Process templates (Scrum, Agile etc.) do not allow their backlogs to be customized, this is only allowed for custom processes. 
+
+Note (2) System behaviors include a description, but this cannot be changed or set for custom behaviors.
 
 ## EXAMPLES
 

--- a/.docs/Set-VSTeamSetting.md
+++ b/.docs/Set-VSTeamSetting.md
@@ -10,10 +10,9 @@
 
 ## Description
 
-Modifies the settings either for the default team in a project, or for a named team if one is specified. Teams can be piped into the command.  Depending on parameters passed it can set the Default and Backlog iterations, the bug behavior (handled as tasks, handled as requirements, or not handled through boards) working days, the team name and the team description
+Modifies the settings either for the default team in a project, or for a named team, if one is specified. Teams can be piped into the command.  Depending on parameters passed, it can set the Default and Backlog Iterations, the Bug Behavior (handled as tasks, handled as requirements, or not handled through boards) Working Days, the Team Name and the Team Description.
 
 ## EXAMPLES
-
 
 ### Example 1
 
@@ -31,7 +30,8 @@ Working Days                  monday, tuesday, wednesday, thursday, friday
 Default Iteration             Muddy
 Backlog Iteration             CY2020
 ```
-This command modifies the team named "Planning Team" in named project, setting  the iteration for Calendar Year 2020, half 2 which is the parent for short sprints over 6 months, sets bugs to be handled as tasks and reveals the Epics backlog using its display name.
+
+This command modifies the team named "Planning Team" in a named project, setting the iteration for Calendar Year 2020, half 2 which is the parent for short sprints, sets Bugs to be handled-as-tasks and reveals the Epics Backlog (using its display name).
 
 ### Example 2
 
@@ -40,14 +40,14 @@ $it = Get-VSTeamIteration
 $settings = Get-VSTeam -Name "planning team" | Set-VSTeamSetting -BacklogIteration $it -BackLogVisibilites @{'Microsoft.EpicCategory'=$false} -raw
 
 ```
-The first line finds defaukt iteration for the current project.
-The second line has a pipeline of two commands - the first finds the team named "Planning Team" in the current project, and the second sets the iteration which was found as the backlog iteration and hides the epics category using its reference name and retuns the updated settings as a single object.
+The first line finds default iteration for the current project.
+The second line has a pipeline of two commands - the first finds the team named "Planning Team" in the current project, and the second sets the iteration which was found in the previous line to be the backlog iteration and hides the Epics Backlog (using its reference name). Instead of return as set of key/value pairs, this version retuns the updated settings as a single object.
 
 
 ## PARAMETERS
 
 ### -BackLogIteration
-The new BackLog Iteration, this can be given the iteration's Path, ID, GUID identifier or an object returned by Get-VSTeamIteration.
+The new BackLog Iteration for the Team, this can be given the as iteration's Path, ID, GUID-identifier or as an object returned by Get-VSTeamIteration.
 
 ```yaml
 Type: Object
@@ -62,7 +62,7 @@ Accept wildcard characters: False
 ```
 
 ### -BackLogVisibilites
-A hash table where the keys are Backlogs - either by display name like "Epics" or the refernce name like "Microsoft.EpicCategory" - and the values are true or false. The backlogs listed will be hidden or revealed based on the value. If text is used instead of a boolean "False" or "No" will be treated as false (hide) and all other non-empty values will be treated as true (show). Any backlogs not included will be left unchanged
+A hash-table where the keys are Backlogs - either by display name like "Epics" or the refernce name like "Microsoft.EpicCategory" - and the values are true or false. The backlogs listed will be hidden or revealed based on the value. If text is used instead of a boolean, "False" or "No" will be treated as false (hide) and all other non-empty values will be treated as true (show). Any backlogs not included in the hash-table will be left unchanged.
 
 ```yaml
 Type: Hashtable
@@ -75,7 +75,6 @@ Default value: None
 Accept pipeline input: False
 Accept wildcard characters: False
 ```
-
 
 ### -BugsBehavior
 Set to 'asRequirements' , 'asTasks' or 'off' for "Bugs are managed with requirements", "Bugs are managed with tasks" or "Bugs are not managed on backlogs and boards" respectively.
@@ -93,9 +92,8 @@ Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
-
 ### -DefaultIteration
-The new Default Iteration  , this can be given the iteration's Path, ID, GUID identifier or an object returned by Get-VSTeamIteration
+The new Default Iteration for the Team , this can be given the iteration's Path, ID, GUID-identifier, or as an object returned by Get-VSTeamIteration
 ```yaml
 Type: Object
 Parameter Sets: (All)
@@ -108,9 +106,8 @@ Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
-
 ### -Description
-A new description for the team
+A new description for the Team.
 
 ```yaml
 Type: String
@@ -125,7 +122,7 @@ Accept wildcard characters: False
 ```
 
 ### -NewName
-A replacement name for the team
+A replacement name for the team.
 
 ```yaml
 Type: String
@@ -140,7 +137,7 @@ Accept wildcard characters: False
 ```
 
 ### -ProjectName
-The project containing the team to modified.
+The Project containing the team to modified.
 
 ```yaml
 Type: Object
@@ -155,7 +152,7 @@ Accept wildcard characters: False
 ```
 
 ### -RawOutput
-If specied returns the object sent back in response to the set request. If not specified as series of name/value pairs a returned for each setting.
+If specied, returns the object sent back from the server in response to the set request. If not specified, settings are returned as a series of name/value pairs.
 
 ```yaml
 Type: SwitchParameter
@@ -170,7 +167,7 @@ Accept wildcard characters: False
 ```
 
 ### -Team
-The name of the whose settings should be modified, if no team is specified the project's default team is used. The team can be piped into the command, and doing so will override an value set for projectname.
+The name of the Team whose settings should be modified. If not specified, the project's default team is used. The Team can be piped into the command, and doing so will override any value set for Projectname.
 
 ```yaml
 Type: Object
@@ -184,9 +181,8 @@ Accept pipeline input: True (ByValue)
 Accept wildcard characters: False
 ```
 
-
 ### -WorkingDays
-An undated list of the list of working days for the team. Note the full list must be given, "saturday" alone removes the other days.
+An updated list of the list of working-days for the team. Note the full list must be given, "saturday" alone removes the other days.
 
 ```yaml
 Type: String[]
@@ -201,24 +197,12 @@ Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
-### CommonParameters
-
-This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](http://go.microsoft.com/fwlink/?LinkID=113216).
-
 ## INPUTS
-
-### System.String
 
 ## OUTPUTS
 
-### System.Object
-
 ## NOTES
 
-<!-- #include "./common/prerequisites.md" -->
-
 ## RELATED LINKS
-
-<!-- #include "./common/related.md" -->
 
 [Get-VSTeamSetting](Get-VSTeamSetting.md)

--- a/.docs/Set-VSTeamSetting.md
+++ b/.docs/Set-VSTeamSetting.md
@@ -1,0 +1,224 @@
+<!-- #include "./common/header.md" -->
+
+# Set-VSTeamSetting
+
+## SYNOPSIS
+
+<!-- #include "./synopsis/Set-VSTeamSetting.md" -->
+
+## SYNTAX
+
+## Description
+
+Modifies the settings either for the default team in a project, or for a named team if one is specified. Teams can be piped into the command.  Depending on parameters passed it can set the Default and Backlog iterations, the bug behavior (handled as tasks, handled as requirements, or not handled through boards) working days, the team name and the team description
+
+## EXAMPLES
+
+
+### Example 1
+
+```powershell
+Set-VSTeamSetting -ProjectName MyProj -Team 'Planning Team'  -BugsBehavior asTasks -BackLogVisibilites @{Epics=$true} -BacklogIteration CY2020-H2
+
+Name                          Value
+----                          -----
+Microsoft.EpicCategory        Visible
+Custom.Fails                  Hidden
+Microsoft.FeatureCategory     Visible
+Microsoft.RequirementCategory Visible
+Bug display mode              asTasks
+Working Days                  monday, tuesday, wednesday, thursday, friday
+Default Iteration             Muddy
+Backlog Iteration             CY2020
+```
+This command modifies the team named "Planning Team" in named project, setting  the iteration for Calendar Year 2020, half 2 which is the parent for short sprints over 6 months, sets bugs to be handled as tasks and reveals the Epics backlog using its display name.
+
+### Example 2
+
+```powershell
+$it = Get-VSTeamIteration
+$settings = Get-VSTeam -Name "planning team" | Set-VSTeamSetting -BacklogIteration $it -BackLogVisibilites @{'Microsoft.EpicCategory'=$false} -raw
+
+```
+The first line finds defaukt iteration for the current project.
+The second line has a pipeline of two commands - the first finds the team named "Planning Team" in the current project, and the second sets the iteration which was found as the backlog iteration and hides the epics category using its reference name and retuns the updated settings as a single object.
+
+
+## PARAMETERS
+
+### -BackLogIteration
+The new BackLog Iteration, this can be given the iteration's Path, ID, GUID identifier or an object returned by Get-VSTeamIteration.
+
+```yaml
+Type: Object
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -BackLogVisibilites
+A hash table where the keys are Backlogs - either by display name like "Epics" or the refernce name like "Microsoft.EpicCategory" - and the values are true or false. The backlogs listed will be hidden or revealed based on the value. If text is used instead of a boolean "False" or "No" will be treated as false (hide) and all other non-empty values will be treated as true (show). Any backlogs not included will be left unchanged
+
+```yaml
+Type: Hashtable
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+
+### -BugsBehavior
+Set to 'asRequirements' , 'asTasks' or 'off' for "Bugs are managed with requirements", "Bugs are managed with tasks" or "Bugs are not managed on backlogs and boards" respectively.
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+Accepted values: asRequirements, asTasks, off
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+
+### -DefaultIteration
+The new Default Iteration  , this can be given the iteration's Path, ID, GUID identifier or an object returned by Get-VSTeamIteration
+```yaml
+Type: Object
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+
+### -Description
+A new description for the team
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -NewName
+A replacement name for the team
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -ProjectName
+The project containing the team to modified.
+
+```yaml
+Type: Object
+Parameter Sets: (All)
+Aliases:
+
+Required: True
+Position: 1
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -RawOutput
+If specied returns the object sent back in response to the set request. If not specified as series of name/value pairs a returned for each setting.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Team
+The name of the whose settings should be modified, if no team is specified the project's default team is used. The team can be piped into the command, and doing so will override an value set for projectname.
+
+```yaml
+Type: Object
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: 0
+Default value: None
+Accept pipeline input: True (ByValue)
+Accept wildcard characters: False
+```
+
+
+### -WorkingDays
+An undated list of the list of working days for the team. Note the full list must be given, "saturday" alone removes the other days.
+
+```yaml
+Type: String[]
+Parameter Sets: (All)
+Aliases:
+Accepted values: monday, tuesday, wednesday, thursday, friday, saturday, sunday
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### CommonParameters
+
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](http://go.microsoft.com/fwlink/?LinkID=113216).
+
+## INPUTS
+
+### System.String
+
+## OUTPUTS
+
+### System.Object
+
+## NOTES
+
+<!-- #include "./common/prerequisites.md" -->
+
+## RELATED LINKS
+
+<!-- #include "./common/related.md" -->
+
+[Get-VSTeamSetting](Get-VSTeamSetting.md)

--- a/.docs/Set-VSTeamSetting.md
+++ b/.docs/Set-VSTeamSetting.md
@@ -41,13 +41,13 @@ $settings = Get-VSTeam -Name "planning team" | Set-VSTeamSetting -BacklogIterati
 
 ```
 The first line finds default iteration for the current project.
-The second line has a pipeline of two commands - the first finds the team named "Planning Team" in the current project, and the second sets the iteration which was found in the previous line to be the backlog iteration and hides the Epics Backlog (using its reference name). Instead of return as set of key/value pairs, this version retuns the updated settings as a single object.
+The second line has a pipeline of two commands - the first finds the team named "Planning Team" in the current project, and the second sets the iteration which was found in the previous line to be the team's backlog iteration and hides the Epics Backlog (using its reference name). Instead of returning a set of key/value pairs, this version returns the updated settings as a single object in $Settings for later use.
 
 
 ## PARAMETERS
 
 ### -BackLogIteration
-The new BackLog Iteration for the Team, this can be given the as iteration's Path, ID, GUID-identifier or as an object returned by Get-VSTeamIteration.
+The new backlog iteration for the team, this can be given the as iteration's Path, ID, GUID-identifier or as an object returned by Get-VSTeamIteration.
 
 ```yaml
 Type: Object
@@ -62,7 +62,7 @@ Accept wildcard characters: False
 ```
 
 ### -BackLogVisibilites
-A hash-table where the keys are Backlogs - either by display name like "Epics" or the refernce name like "Microsoft.EpicCategory" - and the values are true or false. The backlogs listed will be hidden or revealed based on the value. If text is used instead of a boolean, "False" or "No" will be treated as false (hide) and all other non-empty values will be treated as true (show). Any backlogs not included in the hash-table will be left unchanged.
+A hash-table where the keys are backlogs - either by display name like "Epics" or the reference name like "Microsoft.EpicCategory" - and the values are true or false depending on whether the the backlog should be visible or not.. If text is used instead of a Boolean, "False" or "No" will be treated as false (hide) and all other non-empty values will be treated as true (show). Any backlogs not included in the hash-table will be left unchanged.
 
 ```yaml
 Type: Hashtable
@@ -93,7 +93,7 @@ Accept wildcard characters: False
 ```
 
 ### -DefaultIteration
-The new Default Iteration for the Team , this can be given the iteration's Path, ID, GUID-identifier, or as an object returned by Get-VSTeamIteration
+The new default iteration for the team, this can be given the iteration's Path, ID, GUID-identifier, or as an object returned by Get-VSTeamIteration
 ```yaml
 Type: Object
 Parameter Sets: (All)
@@ -107,7 +107,7 @@ Accept wildcard characters: False
 ```
 
 ### -Description
-A new description for the Team.
+A new description for the team.
 
 ```yaml
 Type: String
@@ -137,7 +137,7 @@ Accept wildcard characters: False
 ```
 
 ### -ProjectName
-The Project containing the team to modified.
+The project containing the team to modified.
 
 ```yaml
 Type: Object
@@ -152,7 +152,7 @@ Accept wildcard characters: False
 ```
 
 ### -RawOutput
-If specied, returns the object sent back from the server in response to the set request. If not specified, settings are returned as a series of name/value pairs.
+If specified, returns the object sent back from the server in response to the set request. If not specified, settings are returned as a series of name/value pairs.
 
 ```yaml
 Type: SwitchParameter
@@ -167,7 +167,7 @@ Accept wildcard characters: False
 ```
 
 ### -Team
-The name of the Team whose settings should be modified. If not specified, the project's default team is used. The Team can be piped into the command, and doing so will override any value set for Projectname.
+The name of the Team whose settings should be modified. If not specified, the project's default team is used. The Team can be piped into the command and doing so will override any value set for Projectname.
 
 ```yaml
 Type: Object

--- a/.docs/Set-VSTeamWorkItemBehavior.md
+++ b/.docs/Set-VSTeamWorkItemBehavior.md
@@ -10,9 +10,11 @@
 
 ## Description
 
-Modifies the Portfolio backlog (a.k.a behavior) associated with a WorkItem type in a custom Process Template. Associating a type with a Board allows WorkItems of that type to be added to the Board. When a Board has more than one associated type, one of the types is nominated as the default for new WorkItems.
+Modifies the Portfolio backlog (a.k.a behavior) associated with a WorkItem type in a custom process template. Associating a type with a board allows WorkItems of that type to be added to the board. When a Board has more than one associated type, one of the types is nominated as the default for new WorkItems.
+
 Note (1) System-defined Backlogs have WorkItem types associated with them which cannot be removed.
-Note (2) The first WorkItem type added to a custom Backlog from the UI will be set as the default automatically. When adding the first one from the commandline this needs to be explicitly set.
+
+Note (2) The first WorkItem type added to a custom Backlog from the UI will be set as the default automatically. When adding the first one from the command-line this needs to be explicitly set.
 
 ## EXAMPLES
 
@@ -39,7 +41,7 @@ This command adds the "Impediment" WorkItem type to the "Epics" Board in the cus
  Set-VSTeamWorkItemBehavior -ProcessTemplate Scrum5 -WorkItemType Impediment -Remove -force
 
 ```
-This undoes the previous example, without pausing for confirmation. Note removing the default WorkItem type from the behavior will promote another type to be the default for new WorkItems. To explicitly promote a non-default WorkItem type to be the default, it must be removed and re-added.
+This undoes the previous example, without pausing for confirmation. Note that removing the default WorkItem type from the behavior will promote another type to be the default for new WorkItems. To explicitly promote a non-default WorkItem type to be the default, it must be removed and re-added.
 
 ## PARAMETERS
 
@@ -82,7 +84,7 @@ Accept wildcard characters: False
 ```
 
 ### -IsDefault
-If specified when adding a behavior, makes that type the Board's default for new items. Note that this can only be specified when adding a behavior.
+If specified when adding a behavior, makes that type the board's default for new items. Note that this can only be specified when adding a behavior.
 
 ```yaml
 Type: SwitchParameter
@@ -97,7 +99,7 @@ Accept wildcard characters: False
 ```
 
 ### -Remove
-If specified, removes any existing behavior from the WorkItem type. This is necessary before moving a custom type from one board to another, or promoting an item which is attached to one board to be the default for new WorkItems on that board.
+If specified, removes any existing behavior from the WorkItem type. This is necessary before moving a custom type from one board to another or when promoting an item which is attached to one board to be the default for new WorkItems on that board.
 
 ```yaml
 Type: SwitchParameter
@@ -112,7 +114,7 @@ Accept wildcard characters: False
 ```
 
 ### -WorkItemType
-The name of the WorkItem type to modify. Behaviors cannot be set for Bug, or for pre-exisitng Test types; and the WorkItem types bound to the system-created boards cannot removed from them; although other items can be added to these boards as their default type and the system-created WorkItem types can be disabled preventing items of those types being created.
+The name of the WorkItem type to modify. Behaviors cannot be set for Bug, or for pre-exisitng Test types; and the WorkItem types bound to the system-created boards cannot removed from them; although other items can be added to these boards as their default type and the system-created WorkItem types can be disabled to prevent items of those types being created.
 
 ```yaml
 Type: String

--- a/.docs/Set-VSTeamWorkItemBehavior.md
+++ b/.docs/Set-VSTeamWorkItemBehavior.md
@@ -10,9 +10,9 @@
 
 ## Description
 
-Modifies a the Portfolio backlog (a.k.a behavior) associated with a WorkItem type in a custom Process Template. This allows an item to be added to board (as its default item or not), or removed from the board.
-Note (1) System-defined backlogs have WorkItem types associated with them which cannot be removed.
-Note (2) The first item added to a custom backlog from the UI will be set as the default, this needs to be specified explicitly when adding items from the commandline.
+Modifies the Portfolio backlog (a.k.a behavior) associated with a WorkItem type in a custom Process Template. Associating a type with a Board allows WorkItems of that type to be added to the Board. When a Board has more than one associated type, one of the types is nominated as the default for new WorkItems.
+Note (1) System-defined Backlogs have WorkItem types associated with them which cannot be removed.
+Note (2) The first WorkItem type added to a custom Backlog from the UI will be set as the default automatically. When adding the first one from the commandline this needs to be explicitly set.
 
 ## EXAMPLES
 
@@ -30,7 +30,7 @@ ProcessTemplate WorkItemType Behavior                                 IsDefault
 --------------- ------------ --------                                 ---------
 Scrum5          Impediment   Microsoft.VSTS.Scrum.EpicBacklogBehavior     False
 ```
-This command addes the Impediment WorkItem type to the Epics board in the custom process template named "Scrum5". It leaves the default workitem type as "Epic". The -Force switch has not been specified so the command prompts for confirmation
+This command adds the "Impediment" WorkItem type to the "Epics" Board in the custom Process Template named "Scrum5". It leaves the default type for new WorkItems as "Epic". The -Force switch has not been specified, so the command prompts for confirmation.
 
 
 ### Example 2
@@ -39,10 +39,9 @@ This command addes the Impediment WorkItem type to the Epics board in the custom
  Set-VSTeamWorkItemBehavior -ProcessTemplate Scrum5 -WorkItemType Impediment -Remove -force
 
 ```
-This undoes the previous example without pausing for confirmation. Note removing the default WorkItem type from the behavior will promote another to be the default. To promote a non-default WorkItem type to be the default it must be removed and re-added.
+This undoes the previous example, without pausing for confirmation. Note removing the default WorkItem type from the behavior will promote another type to be the default for new WorkItems. To explicitly promote a non-default WorkItem type to be the default, it must be removed and re-added.
 
 ## PARAMETERS
-
 
 ### -Confirm
 
@@ -50,10 +49,9 @@ Prompts you for confirmation before running the cmdlet. Normally the command wil
 
 <!-- #include "./params/force.md" -->
 
-
 ### -Behavior
 
-Current name of the behavior / backlog. Either the display name or the reference name may be used.
+Current name of the Behavior / Backlog. Either the display name or the reference name may be used.
 
 ```yaml
 Type: String
@@ -69,7 +67,7 @@ Accept wildcard characters: False
 
 ### -ProcessTemplate
 
-The process template to modify containing the WorkItem type to be updated. Note that the built-in templates ("Scrum", "Agile" etc.) cannot be modified, only custom templates (derived from the built-in ones) can be changed.
+The Process Template containing the WorkItem type to be updated. Note that the built-in templates ("Scrum", "Agile" etc.) cannot be modified, only custom templates (derived from the built-in ones) can be changed.
 
 ```yaml
 Type: Object
@@ -84,7 +82,7 @@ Accept wildcard characters: False
 ```
 
 ### -IsDefault
-If specified when adding a behavior to a WorkItem type, makes that type the default for new items added on the board in question. Note that this can only be specified when adding a behavior.
+If specified when adding a behavior, makes that type the Board's default for new items. Note that this can only be specified when adding a behavior.
 
 ```yaml
 Type: SwitchParameter
@@ -98,9 +96,8 @@ Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
-
 ### -Remove
-If specified removes any existing behavior from the WorkItem type. This is necessary before moving a custom type from one board to another, or promoting an item which is attached to one board to be the default for that board.
+If specified, removes any existing behavior from the WorkItem type. This is necessary before moving a custom type from one board to another, or promoting an item which is attached to one board to be the default for new WorkItems on that board.
 
 ```yaml
 Type: SwitchParameter
@@ -115,7 +112,7 @@ Accept wildcard characters: False
 ```
 
 ### -WorkItemType
-The name of the WorkItem type to modify. Behaviors cannot be set for Bug, or for pre-exisitng Test types, and the WorkItem types bound to the system-created boards cannot removed from them; although other items can be added as the default and the system-created types can be be set to disabled.
+The name of the WorkItem type to modify. Behaviors cannot be set for Bug, or for pre-exisitng Test types; and the WorkItem types bound to the system-created boards cannot removed from them; although other items can be added to these boards as their default type and the system-created WorkItem types can be disabled preventing items of those types being created.
 
 ```yaml
 Type: String
@@ -131,25 +128,14 @@ Accept wildcard characters: False
 
 <!-- #include "./params/whatIf.md" -->
 
-### CommonParameters
-
-This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](http://go.microsoft.com/fwlink/?LinkID=113216).
-
 ## INPUTS
-
-### System.String
 
 ## OUTPUTS
 
-### System.Object
-
 ## NOTES
-
-<!-- #include "./common/prerequisites.md" -->
 
 ## RELATED LINKS
 
-<!-- #include "./common/related.md" -->
 [Get-Set-VSTeamWorkItemBehavior](Get-Set-VSTeamWorkItemBehavior.md)
 
 [Get-VSTeamProcessBehavior](Get-VSTeamProcessBehavior.md)

--- a/.docs/Set-VSTeamWorkItemBehavior.md
+++ b/.docs/Set-VSTeamWorkItemBehavior.md
@@ -1,0 +1,153 @@
+<!-- #include "./common/header.md" -->
+
+# Set-VSTeamWorkItemBehavior
+
+## SYNOPSIS
+
+<!-- #include "./synopsis/Set-VSTeamWorkItemBehavior.md" -->
+
+## SYNTAX
+
+## Description
+
+Modifies a the Portfolio backlog (a.k.a behavior) associated with a WorkItem type in a custom Process Template. This allows an item to be added to board (as its default item or not), or removed from the board. 
+
+## EXAMPLES
+
+### Example 1
+
+```powershell
+ Set-VSTeamWorkItemBehavior -ProcessTemplate Scrum5 -WorkItemType Impediment -Behavior Epics
+
+Confirm
+Are you sure you want to perform this action?
+Performing the operation "Modify Scrum5 to update definition of workitem type" on target "Impediment".
+[Y] Yes [A] Yes to All [N] No [L] No to All [S] Suspend [?] Help (default is "Yes"): y
+
+ProcessTemplate WorkItemType Behavior                                 IsDefault
+--------------- ------------ --------                                 ---------
+Scrum5          Impediment   Microsoft.VSTS.Scrum.EpicBacklogBehavior     False
+```
+This command addes the Impediment WorkItem type to the Epics board in the custom process template named "Scrum5". It leaves the default workitem type as "Epic". The -Force switch has not been specified so the command prompts for confirmation
+
+
+### Example 2
+
+```powershell
+ Set-VSTeamWorkItemBehavior -ProcessTemplate Scrum5 -WorkItemType Impediment -Remove -force
+
+```
+This undoes the previous example without pausing for confirmation. Note removing the default WorkItem type from the behavior will promote another to be the default. To promote a non-default WorkItem type to be the default it must be removed and re-added.
+
+## PARAMETERS
+
+
+### -Confirm
+
+Prompts you for confirmation before running the cmdlet. Normally the command will prompt for confirmation and -Confirm is only needed if \$ConfirmPreference has been changed.
+
+<!-- #include "./params/force.md" -->
+
+
+### -Behavior
+
+Current name of the behavior / backlog. Either the display name or the reference name may be used.
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: 2
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -ProcessTemplate
+
+The process template to modify containing the WorkItem type to be updated. Note that the built-in templates ("Scrum", "Agile" etc.) cannot be modified, only custom templates (derived from the built-in ones) can be changed.
+
+```yaml
+Type: Object
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: 0
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -IsDefault
+If specified when adding a behavior to a WorkItem type, makes that type the default for new items added on the board in question. Note that this can only be specified when adding a behavior.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: AddOrSet
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+
+### -Remove
+If specified removes any existing behavior from the WorkItem type. This is necessary before moving a custom type from one board to another, or promoting an item which is attached to one board to be the default for that board.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: Delete
+Aliases:
+
+Required: True
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -WorkItemType
+The name of the WorkItem type to modify. Behaviors cannot be set for Bug, or for pre-exisitng Test types, and the WorkItem types bound to the system-created boards cannot removed from them; although other items can be added as the default and the system-created types can be be set to disabled.  
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: True
+Position: 0
+Default value: None
+Accept pipeline input: True (ByPropertyName)
+Accept wildcard characters: False
+```
+
+<!-- #include "./params/whatIf.md" -->
+
+### CommonParameters
+
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](http://go.microsoft.com/fwlink/?LinkID=113216).
+
+## INPUTS
+
+### System.String
+
+## OUTPUTS
+
+### System.Object
+
+## NOTES
+
+<!-- #include "./common/prerequisites.md" -->
+
+## RELATED LINKS
+
+<!-- #include "./common/related.md" -->
+[Get-Set-VSTeamWorkItemBehavior](Get-Set-VSTeamWorkItemBehavior.md)
+
+[Get-VSTeamProcessBehavior](Get-VSTeamProcessBehavior.md)

--- a/.docs/Set-VSTeamWorkItemBehavior.md
+++ b/.docs/Set-VSTeamWorkItemBehavior.md
@@ -10,7 +10,9 @@
 
 ## Description
 
-Modifies a the Portfolio backlog (a.k.a behavior) associated with a WorkItem type in a custom Process Template. This allows an item to be added to board (as its default item or not), or removed from the board. 
+Modifies a the Portfolio backlog (a.k.a behavior) associated with a WorkItem type in a custom Process Template. This allows an item to be added to board (as its default item or not), or removed from the board.
+Note (1) System-defined backlogs have WorkItem types associated with them which cannot be removed.
+Note (2) The first item added to a custom backlog from the UI will be set as the default, this needs to be specified explicitly when adding items from the commandline.
 
 ## EXAMPLES
 
@@ -113,7 +115,7 @@ Accept wildcard characters: False
 ```
 
 ### -WorkItemType
-The name of the WorkItem type to modify. Behaviors cannot be set for Bug, or for pre-exisitng Test types, and the WorkItem types bound to the system-created boards cannot removed from them; although other items can be added as the default and the system-created types can be be set to disabled.  
+The name of the WorkItem type to modify. Behaviors cannot be set for Bug, or for pre-exisitng Test types, and the WorkItem types bound to the system-created boards cannot removed from them; although other items can be added as the default and the system-created types can be be set to disabled.
 
 ```yaml
 Type: String

--- a/.docs/Set-VSTeamWorkItemType.md
+++ b/.docs/Set-VSTeamWorkItemType.md
@@ -183,10 +183,6 @@ Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
-### CommonParameters
-
-This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](http://go.microsoft.com/fwlink/?LinkID=113216).
-
 ## INPUTS
 
 ### System.String

--- a/.docs/Set-VSTeamWorkItemType.md
+++ b/.docs/Set-VSTeamWorkItemType.md
@@ -1,0 +1,209 @@
+<!-- #include "./common/header.md" -->
+
+# Set-VSTeamWorkItemType
+
+## SYNOPSIS
+
+<!-- #include "./synopsis/Set-VSTeamWorkItemType.md" -->
+
+## SYNTAX
+
+## Description
+
+Modifies an existing work item type in a custom process; where the work item type is a built-in type, like "Bug",
+the original item is preserved and a new inherited version is created.
+It is possible to change the Description, Icon, Icon Color, and to enable or disable the work item type
+
+## EXAMPLES
+
+### Example 1
+
+```powershell
+Set-VSTeamWorkItemType -ProcessTemplate Scrum5 -WorkItemType Impediment -Disabled
+```
+
+Modifies the custom process "Scrum5", disabling the built in work item type "Impediment".
+
+### Example 2
+
+```powershell
+Set-VSTeamWorkItemType -ProcessTemplate Scrum5 -WorkItemType ChangeRequest -Icon icon_parachute -color Blue -Description "For requests from customers"
+```
+
+Modifies the custom process "Scrum5", changing a user-defined work item type "ChangeRequest" to use
+a blue parachute icon and update its description..
+## PARAMETERS
+
+### -Color
+
+Changes the the icon color. The input value can be the name of a color name like "Red" or "Aqua" or
+a hex value for red, green and blue parts. Color names should tab complete.
+
+```yaml
+Type: Object
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: 3
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Confirm
+
+Prompts you for confirmation before running the cmdlet. Normally the command will prompt for confirmation and -Confirm is only needed if \$ConfirmPreference has been changed.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: (All)
+Aliases: cf
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Description
+
+Long text description of the the work item type.
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: 2
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Disabled
+
+If specified, disables the work item so that it can not be selected for new items.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: Hide
+Aliases:
+
+Required: True
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Enabled
+
+If specified, enables a work item which was previously disabled.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: Show
+Aliases:
+
+Required: True
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+<!-- #include "./params/force.md" -->
+
+### -Icon
+
+One of the predefined icons for work item types. Possible values should tab complete and
+if the name omits the leading "Icon\_" it will be added automatically.
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: 4
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -ProcessTemplate
+
+The process template to modify. Note that the built-in templates ("Scrum", "Agile" etc.) cannot be modified, only custom templates (derived from the built-in ones) can be changed.
+
+```yaml
+Type: Object
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: 0
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -WhatIf
+
+Shows what would happen if the cmdlet runs.
+The cmdlet is not run.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: (All)
+Aliases: wi
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -WorkItemType
+
+The name of the work item type to be modified.
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases: Name
+
+Required: True
+Position: 1
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### CommonParameters
+
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](http://go.microsoft.com/fwlink/?LinkID=113216).
+
+## INPUTS
+
+### System.String
+
+## OUTPUTS
+
+### System.Object
+
+## NOTES
+
+<!-- #include "./common/prerequisites.md" -->
+
+## RELATED LINKS
+
+<!-- #include "./common/related.md" -->
+[Add-VSTeamWorkItemType](Add-VSTeamWorkItemType.md)
+
+[Get-VSTeamWorkItemType](Get-VSTeamWorkItemType.md)
+
+[Remove-VSTeamWorkItemType](Remove-VSTeamWorkItemType.md)

--- a/.docs/Set-VSTeamWorkItemType.md
+++ b/.docs/Set-VSTeamWorkItemType.md
@@ -66,10 +66,17 @@ Default value: None
 Accept pipeline input: False
 Accept wildcard characters: False
 ```
+<!-- #include "./params/Force.md" -->
+
+<!-- #include "./params/whatif.md" -->
+
+<!-- #include "./params/processTemplate.md" -->
+
+<!-- #include "./params/workItemType.md" -->
 
 ### -Description
 
-Long text description of the the work item type.
+Long text description of the WorkItem type.
 
 ```yaml
 Type: String
@@ -85,7 +92,7 @@ Accept wildcard characters: False
 
 ### -Disabled
 
-If specified, disables the work item so that it can not be selected for new items.
+If specified, disables the WorkItem type so that it can not be selected for new items.
 
 ```yaml
 Type: SwitchParameter
@@ -101,7 +108,7 @@ Accept wildcard characters: False
 
 ### -Enabled
 
-If specified, enables a work item which was previously disabled.
+If specified, enables a WorkItem type which was previously disabled.
 
 ```yaml
 Type: SwitchParameter
@@ -114,8 +121,6 @@ Default value: None
 Accept pipeline input: False
 Accept wildcard characters: False
 ```
-
-<!-- #include "./params/force.md" -->
 
 ### -Icon
 
@@ -134,70 +139,14 @@ Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
-### -ProcessTemplate
-
-The process template to modify. Note that the built-in templates ("Scrum", "Agile" etc.) cannot be modified, only custom templates (derived from the built-in ones) can be changed.
-
-```yaml
-Type: Object
-Parameter Sets: (All)
-Aliases:
-
-Required: False
-Position: 0
-Default value: None
-Accept pipeline input: False
-Accept wildcard characters: False
-```
-
-### -WhatIf
-
-Shows what would happen if the cmdlet runs.
-The cmdlet is not run.
-
-```yaml
-Type: SwitchParameter
-Parameter Sets: (All)
-Aliases: wi
-
-Required: False
-Position: Named
-Default value: None
-Accept pipeline input: False
-Accept wildcard characters: False
-```
-
-### -WorkItemType
-
-The name of the work item type to be modified.
-
-```yaml
-Type: String
-Parameter Sets: (All)
-Aliases: Name
-
-Required: True
-Position: 1
-Default value: None
-Accept pipeline input: False
-Accept wildcard characters: False
-```
-
 ## INPUTS
-
-### System.String
 
 ## OUTPUTS
 
-### System.Object
-
 ## NOTES
-
-<!-- #include "./common/prerequisites.md" -->
 
 ## RELATED LINKS
 
-<!-- #include "./common/related.md" -->
 [Add-VSTeamWorkItemType](Add-VSTeamWorkItemType.md)
 
 [Get-VSTeamWorkItemType](Get-VSTeamWorkItemType.md)

--- a/.docs/Set-VSTeamWorkItemType.md
+++ b/.docs/Set-VSTeamWorkItemType.md
@@ -10,9 +10,9 @@
 
 ## Description
 
-Modifies an existing work item type in a custom process; where the work item type is a built-in type, like "Bug",
-the original item is preserved and a new inherited version is created.
-It is possible to change the Description, Icon, Icon Color, and to enable or disable the work item type
+Modifies an existing WorkItem type in a custom process; where the WorkItem type is a built-in type, like "Bug",
+the original item is preserved, and a new inherited version is created.
+It is possible to change the Description, Icon, Icon Color, and to enable or disable the WorkItem type
 
 ## EXAMPLES
 
@@ -22,7 +22,7 @@ It is possible to change the Description, Icon, Icon Color, and to enable or dis
 Set-VSTeamWorkItemType -ProcessTemplate Scrum5 -WorkItemType Impediment -Disabled
 ```
 
-Modifies the custom process "Scrum5", disabling the built in work item type "Impediment".
+Modifies the custom process "Scrum5", disabling the built-in WorkItem type "Impediment".
 
 ### Example 2
 
@@ -30,13 +30,14 @@ Modifies the custom process "Scrum5", disabling the built in work item type "Imp
 Set-VSTeamWorkItemType -ProcessTemplate Scrum5 -WorkItemType ChangeRequest -Icon icon_parachute -color Blue -Description "For requests from customers"
 ```
 
-Modifies the custom process "Scrum5", changing a user-defined work item type "ChangeRequest" to use
-a blue parachute icon and update its description..
+Modifies the custom process "Scrum5", changing a user-defined WorkItem type "ChangeRequest" to use
+a blue parachute icon and update its description.
+
 ## PARAMETERS
 
 ### -Color
 
-Changes the the icon color. The input value can be the name of a color name like "Red" or "Aqua" or
+Changes the  icon color. The input value can be the name of a color name like "Red" or "Aqua" or
 a hex value for red, green and blue parts. Color names should tab complete.
 
 ```yaml
@@ -92,7 +93,7 @@ Accept wildcard characters: False
 
 ### -Disabled
 
-If specified, disables the WorkItem type so that it can not be selected for new items.
+If specified, disables the WorkItem type so that it cannot be selected for new items.
 
 ```yaml
 Type: SwitchParameter
@@ -124,7 +125,7 @@ Accept wildcard characters: False
 
 ### -Icon
 
-One of the predefined icons for work item types. Possible values should tab complete and
+One of the predefined icons for WorkItem types. Possible values should tab complete and
 if the name omits the leading "Icon\_" it will be added automatically.
 
 ```yaml

--- a/.docs/Unlock-VSTeamWorkItemType.md
+++ b/.docs/Unlock-VSTeamWorkItemType.md
@@ -1,0 +1,68 @@
+<!-- #include "./common/header.md" -->
+
+# Unlock-VSTeamWorkItemType
+
+## SYNOPSIS
+
+<!-- #include "./synopsis/Unlock-VSTeamWorkItemType.md" -->
+
+## SYNTAX
+
+## Description
+
+Takes a WorkItem type and if its customation field implies a custom or inherited type simply returns it.
+If it is a (locked) system type, creates a inherted type based on it, and returns the new type, optionally expanding the layout/states or behaviors.
+
+## PARAMETERS
+
+### -Expand
+
+If specified, the WorkItem type information returned after unlocking will have behavior, layout and/or state information attached, depending on the value of the parameter.
+If not specified the WorkItemType returned after unlocking will be simply be the result of the API call to create an inherited item.
+Has no effect if the item is already unlocked
+
+```yaml
+Type: String[]
+Parameter Sets: Process
+Accepted values: 'behaviors','layout','states'
+```
+
+<!-- #include "./params/forcegroup.md" -->
+
+### -WorkItemType
+
+An object representing the WorkItemType which should be unlocked (and may already be)
+
+```yaml
+Type: Object
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: 0
+Default value: None
+Accept pipeline input: True
+Accept wildcard characters: False
+```
+
+
+## INPUTS
+
+### System.String
+
+## OUTPUTS
+
+### System.Object
+
+## NOTES
+
+<!-- #include "./common/prerequisites.md" -->
+
+## RELATED LINKS
+
+<!-- #include "./common/related.md" -->
+[Add-VSTeamWorkItemType](Add-VSTeamWorkItemType.md)
+
+[Get-VSTeamWorkItemType](Get-VSTeamWorkItemType.md)
+
+[Remove-VSTeamWorkItemType](Remove-VSTeamWorkItemType.md)

--- a/.docs/Unlock-VSTeamWorkItemType.md
+++ b/.docs/Unlock-VSTeamWorkItemType.md
@@ -19,7 +19,7 @@ If it is a (locked) system type, creates a inherted type based on it, and return
 
 If specified, the WorkItem type information returned after unlocking will have behavior, layout and/or state information attached, depending on the value of the parameter.
 If not specified the WorkItemType returned after unlocking will be simply be the result of the API call to create an inherited item.
-Has no effect if the item is already unlocked
+Has no effect if the item is already unlocked.
 
 ```yaml
 Type: String[]
@@ -45,7 +45,6 @@ Accept pipeline input: True
 Accept wildcard characters: False
 ```
 
-
 ## INPUTS
 
 ### System.String
@@ -56,11 +55,8 @@ Accept wildcard characters: False
 
 ## NOTES
 
-<!-- #include "./common/prerequisites.md" -->
-
 ## RELATED LINKS
 
-<!-- #include "./common/related.md" -->
 [Add-VSTeamWorkItemType](Add-VSTeamWorkItemType.md)
 
 [Get-VSTeamWorkItemType](Get-VSTeamWorkItemType.md)

--- a/.docs/Unlock-VSTeamWorkItemType.md
+++ b/.docs/Unlock-VSTeamWorkItemType.md
@@ -10,15 +10,15 @@
 
 ## Description
 
-Takes a WorkItem type and if its customation field implies a custom or inherited type simply returns it.
-If it is a (locked) system type, creates a inherted type based on it, and returns the new type, optionally expanding the layout/states or behaviors.
+Takes a WorkItem type and if its customization field implies a custom or inherited type, simply returns it.
+If it is a (locked) system type, creates a inherted type based on it, and returns the new type, optionally expanding the layout, states, or behaviors.
 
 ## PARAMETERS
 
 ### -Expand
 
 If specified, the WorkItem type information returned after unlocking will have behavior, layout and/or state information attached, depending on the value of the parameter.
-If not specified the WorkItemType returned after unlocking will be simply be the result of the API call to create an inherited item.
+If not specified, the WorkItemType returned after unlocking will be simply be the result of the API call to create an inherited item.
 Has no effect if the item is already unlocked.
 
 ```yaml
@@ -31,7 +31,7 @@ Accepted values: 'behaviors','layout','states'
 
 ### -WorkItemType
 
-An object representing the WorkItemType which should be unlocked (and may already be)
+An object representing the WorkItemType which should be unlocked (and may already be).
 
 ```yaml
 Type: Object

--- a/.docs/params/processTemplate.md
+++ b/.docs/params/processTemplate.md
@@ -1,0 +1,17 @@
+### -ProcessTemplate
+
+The process template where the desired change should occur.
+Note that the built-in templates ("Scrum", "Agile" etc.) cannot be modified, only custom templates (derived from the built-in ones) can be changed.
+
+
+```yaml
+Type: Object
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: True (ByPropertyName)
+Accept wildcard characters: False
+```

--- a/.docs/params/workItemType.md
+++ b/.docs/params/workItemType.md
@@ -1,6 +1,5 @@
 ### -WorkItemType
-
-The name of the work item type to be modified.
+The name of the WorkItem type to be modified.
 
 ```yaml
 Type: Object

--- a/.docs/params/workItemType.md
+++ b/.docs/params/workItemType.md
@@ -1,0 +1,15 @@
+### -WorkItemType
+
+The name of the work item type to be modified.
+
+```yaml
+Type: Object
+Parameter Sets: (All)
+Aliases:
+
+Required: True
+Position: 0
+Default value: None
+Accept pipeline input: True (ByPropertyName)
+Accept wildcard characters: False
+```

--- a/.docs/synopsis/Add-VSTeamProcess.md
+++ b/.docs/synopsis/Add-VSTeamProcess.md
@@ -1,0 +1,1 @@
+Adds a process, descended from an existing one, like 'Scrum' or 'Agile', to an organization.

--- a/.docs/synopsis/Add-VSTeamProcessBehavior.md
+++ b/.docs/synopsis/Add-VSTeamProcessBehavior.md
@@ -1,0 +1,1 @@
+Adds a new behavior (a.k.a. Backlog) to a custom process template.

--- a/.docs/synopsis/Add-VSTeamWorkItemType.md
+++ b/.docs/synopsis/Add-VSTeamWorkItemType.md
@@ -1,0 +1,1 @@
+Adds a new work item type to a custom process template.

--- a/.docs/synopsis/Add-VSTeamWorkItemType.md
+++ b/.docs/synopsis/Add-VSTeamWorkItemType.md
@@ -1,1 +1,1 @@
-Adds a new work item type to a custom process template.
+Adds a new WorkItem type to a custom process template.

--- a/.docs/synopsis/Connect-VSTeam.md
+++ b/.docs/synopsis/Connect-VSTeam.md
@@ -1,0 +1,1 @@
+Connects and sets the default project, working with saved account, personal access token and project name. 

--- a/.docs/synopsis/Get-VSTeamProcessBehavior.md
+++ b/.docs/synopsis/Get-VSTeamProcessBehavior.md
@@ -1,0 +1,1 @@
+Gets a list of Behaviors (a.k.a "Backlog levels" or "Boards") for a Process Template

--- a/.docs/synopsis/Get-VSTeamSetting.md
+++ b/.docs/synopsis/Get-VSTeamSetting.md
@@ -1,0 +1,1 @@
+Returns the settings for Bug behavior, visible boards and iterations for a project team.

--- a/.docs/synopsis/Get-VSTeamSetting.md
+++ b/.docs/synopsis/Get-VSTeamSetting.md
@@ -1,1 +1,1 @@
-Returns the settings for Bug behavior, visible boards and iterations for a project team.
+Returns the settings for Bug behavior, visible boards, and iterations for a project team.

--- a/.docs/synopsis/Get-VSTeamWorkItemBehavior.md
+++ b/.docs/synopsis/Get-VSTeamWorkItemBehavior.md
@@ -1,0 +1,1 @@
+Gets the Behavior (a.k.a "Backlog levels" or "Boards") for associated with a workitem type, if any.

--- a/.docs/synopsis/Get-VSTeamWorkItemIconList.md
+++ b/.docs/synopsis/Get-VSTeamWorkItemIconList.md
@@ -1,0 +1,1 @@
+Returns a list of Icons which can be displayed for different WorkItem types in the web UI.

--- a/.docs/synopsis/Get-VSTeamWorkItemType.md
+++ b/.docs/synopsis/Get-VSTeamWorkItemType.md
@@ -1,1 +1,1 @@
-Gets a list of all Work Item Types or a single work item type.
+Gets a list of all WorkItem Types or a single WorkItem type.

--- a/.docs/synopsis/Remove-VSTeamProcess.md
+++ b/.docs/synopsis/Remove-VSTeamProcess.md
@@ -1,0 +1,1 @@
+Removes a custom process template. Attepting to remove an system one , like 'Scrum' or 'Agile', has no effect..

--- a/.docs/synopsis/Remove-VSTeamProcess.md
+++ b/.docs/synopsis/Remove-VSTeamProcess.md
@@ -1,1 +1,1 @@
-Removes a custom process template. Attepting to remove an system one , like 'Scrum' or 'Agile', has no effect..
+Removes a custom process template. Attepting to remove an system one , like 'Scrum' or 'Agile', has no effect.

--- a/.docs/synopsis/Remove-VSTeamProcessBehavior.md
+++ b/.docs/synopsis/Remove-VSTeamProcessBehavior.md
@@ -1,0 +1,1 @@
+Removes a custom behavior (a.k.a. Backlog) from a custom process template.

--- a/.docs/synopsis/Remove-VSTeamWorkItemType.md
+++ b/.docs/synopsis/Remove-VSTeamWorkItemType.md
@@ -1,1 +1,1 @@
-Removes a custom work item type from custom process template.
+Removes a custom WorkItem type from custom process template.

--- a/.docs/synopsis/Remove-VSTeamWorkItemType.md
+++ b/.docs/synopsis/Remove-VSTeamWorkItemType.md
@@ -1,0 +1,1 @@
+Removes a custom work item type from custom process template.

--- a/.docs/synopsis/Set-VSTeamProcess.md
+++ b/.docs/synopsis/Set-VSTeamProcess.md
@@ -1,0 +1,1 @@
+Modifies an existing process template, like 'Scrum' or 'Agile', or one which has been custom defined.

--- a/.docs/synopsis/Set-VSTeamProcessBehavior.md
+++ b/.docs/synopsis/Set-VSTeamProcessBehavior.md
@@ -1,0 +1,1 @@
+Modifies a behavior (a.k.a. Backlog) in a custom process template.

--- a/.docs/synopsis/Set-VSTeamSetting.md
+++ b/.docs/synopsis/Set-VSTeamSetting.md
@@ -1,1 +1,1 @@
-Modifies the settings for Bug behavior, visible boards, iterations displayname and description for a project team.
+Modifies the Bug-behavior, visible boards, iterations, display-name and description configured for a project team.

--- a/.docs/synopsis/Set-VSTeamSetting.md
+++ b/.docs/synopsis/Set-VSTeamSetting.md
@@ -1,0 +1,1 @@
+Modifies the settings for Bug behavior, visible boards, iterations displayname and description for a project team.

--- a/.docs/synopsis/Set-VSTeamWorkItemBehavior.md
+++ b/.docs/synopsis/Set-VSTeamWorkItemBehavior.md
@@ -1,0 +1,1 @@
+Modifies the behavior (associated Backlog) of a WorkItem Type in a custom process template.

--- a/.docs/synopsis/Set-VSTeamWorkItemType.md
+++ b/.docs/synopsis/Set-VSTeamWorkItemType.md
@@ -1,0 +1,1 @@
+Modifies an existing work item type in a custom process template.

--- a/.docs/synopsis/Unlock-VSTeamWorkItemType.md
+++ b/.docs/synopsis/Unlock-VSTeamWorkItemType.md
@@ -1,0 +1,1 @@
+If a WorkItem Type has customization of "System" creates an inherited WorkItem type from it. Otherwise returns it unchanged.

--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,8 @@ Source/Public/vsteam.public.ps1
 Source/Private/vsteam.private.ps1
 Source/Classes/vsteam.classes.ps1
 /dist
+/Notes
+/ExtraScripts
 test-results.xml
 coverage.xml
 .editorconfig

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,31 @@
 # Changelog
 
+## J.H. O'Neill @ 3rd October 2020
+1.  To support tab completion for (e.g.) icon color  in `Add-VSTeamWorkItemType`:  **added class** `ColorCompleter` in file `Source\Classes\Completer\ColorCompleter.cs`. 
+    I can't find way to use the conventional `KnownColor` class in single new C# class which will build for both Windows PowerShell 5 and PowerShell Core, so I've worked round it by getting the static properties of `System.Drawing.Color`.
+2.  To support use of Hex Red/green/blue attributes for colors (e.g icon color): **added class** `ColorTransformToHexAttribute` in file `Source\Classes\Attribute\ColorTransformToHexAttribute.cs`. 
+    If the parameter is given an object of type `System.Drawing.Color`, it coverts it to "aabbcc" for hex r,g,b values. If the parameter is a string in form "#aabbcc", the transformer strips the hash, if it is a string which isn't in "aabbcc" form, it tries to convert to a color and from the color to its hex string e.g the user tab-completes to "Red" which becomes "ff0000" and if the user enters "randomtext" it converts to "000000"
+3.  To support (e.g.) Population of an icon cache: **added function** `Get-VSTeamWorkIconList` in file `Source\Public\Get-VSTeamWorkItemIconList`
+4.  To support icon completion and validation: **added class** `IconCache` in file `Source\Classes\Cache\IconCache.cs`. This largely copied from `ProjectCache`
+5.  To support icon completion (e.g. in in `Add-VSTeamWorkItemType): **added class** `IconCompleter` in file `Source\Classes\Completer\IconCompleter.cs`. This is based on `ProjectCompleter`
+6.  To support transformation of shortened icon-names from `name` to `icon_name` format and support the validation of icon names, (e.g. in in `Add-VSTeamWorkItemType): **added class** `IconTransformAttribute`in file `Source\Classes\Attribute\IconTransformAttribute.cs`. 
+7. To support project-independent operations on Process-templates (e.g Add-VsTeamWorkItemType), **changed class** `vsteam_lib.Versions`,  **added property** `DefaultProcess` property and corresponding environment variable `TEAM_PROCESS` - `process` is patterned after `project`.
+8.  **Changed function** `Set-VSTeamDefaultProject` 
+    * *Fixed* an apparant bug in where process level environment variable `TEAM_PROJECT` and `[vsteam_lib.Versions]::DefaultProject` were only set on Windows.
+    * *Updated*  to store current project's process in `TEAM_PROCESS` and `[vsteam_lib.Versions]::DefaultProcess`
+    * *Updated tests* `Set-VSTeamDefaultProject.Tests.ps1` and `Get-VSTeamAgent.Tests.ps1` to mock the additional API call used to look-up the project's template.  
+9.  To support changes to Process Templates themselves **changed class** `vsteam_lib.Process` **added property** `ReferenceName` 
+10. **Changed function** `Get-VSTeamWorkItemType`. 
+    * Fixed a BUG: Only WorkitemTypes for the current project are cached and for validation, so requesting a workitem from a different project will fail if that type is not in the current project. As a by product now support wildcards for selecting workitem types, entering an invalid name runs the command without any output instead of causing an error. 
+    * Added support for getting the workitem-types from a Process-template as well as from a project. When getting from a process-template, or from the default project whose template is know, add a property named `ProcessTemplate` to the objects so that piping into another function with that name as a `ValueFromPipelineByPropertyName` parameter can use it. 
+    * Added an alias property named `WorkItemType` as an alias for `Name`, also for `ValueFromPipelineByPropertyName` support
+    * Added a property named "hidden" when getting a list of workitem types for a project so picklists can remove hidden types.
+    * Fixed test which was breaking workitem-type sample data by converting it to JSON when it is known to fail to convert, it now just reads the text file and leaves the section at the comment `# This call returns JSON with "": which causes the ConvertFrom-Json to fail`  to do its thing!
+    * Added functional test for -Process Template option. 
+    * Added examples and parameter description to help. 
+11.  For WorkItemType operations, **added function** a private/helper `_getProcessTemplateUrl` in file `common.ps1` to get/set the urls of templates in a script level hash table (to reduce API calls to get ID from a name.) In a previous version I set a URL property on the processs object - this has been dropped. 
+12. **Added functions**  `Add-VSTeamWorkItemType`, `Set-VSTeamWorkItemType`, `Remove-VSTeamWorkItemType` with associated help and tests.
+
 ## 7.1.1
 
 Fixed bug in Test-VSTeamYamlPipeline by adding a Pipelines version value.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Changelog
 ## J.H. O'Neill @ 7rd October 2020
-1.  Added Commands Add- and Set- -VSTeamProcess. Add- creates a process template based on a pre-existing one, Set- enables/disables, sets as the default for new projects and changes the name / description. 
+1.  Added Commands Add- and Set- -VSTeamProcess. Add- creates a process template based on a pre-existing one, Set- enables/disables, sets  the default for new projects and changes the name / description. 
+2. Added Commands Get- Set- Add- Remove -VSTeamProcessBehavior and a format XML file for process behaviors.
+3. Added Commands Get- Set- -VSTeamWorkItemBehavior and a format XML file  for WorkItem behaviors.
 
 ## J.H. O'Neill @ 3rd October 2020
 1.  To support tab completion for (e.g.) icon color  in `Add-VSTeamWorkItemType`:  **added class** `ColorCompleter` in file `Source\Classes\Completer\ColorCompleter.cs`. 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,7 +28,7 @@
     * Added functional test for -Process Template option.
     * Added examples and parameter description to help.
 1. For WorkItemType operations, **added function** a private/helper `_getProcessTemplateUrl` in file `common.ps1` to get/set the urls of templates in a script level hash table (to reduce API calls to get ID from a name.) In a previous version I set a URL property on the processs object - this has been dropped.
-1. **Added functions**  `Add-VSTeamWorkItemType`, `Set-VSTeamWorkItemType`, `Remove-VSTeamWorkItemType` with associated help and tests.
+1. **Added functions**  `Add-VSTeamWorkItemType`, `Set-VSTeamWorkItemType`, `Remove-VSTeamWorkItemType`, `Unlock-VSTeamWorkItemType` with associated help and tests.
 1. Ensured tests which mock Get-VSTeamProcess clear the process cache (otherwise the processes they return will not be used to validate the Process parameter during the test,)
 1. Ensured tests which call Set-VSTeamProject load and mock Get-VSTeamProcess.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@
 12.  For WorkItemType operations, **added function** a private/helper `_getProcessTemplateUrl` in file `common.ps1` to get/set the urls of templates in a script level hash table (to reduce API calls to get ID from a name.) In a previous version I set a URL property on the processs object - this has been dropped.
 13. **Added functions**  `Add-VSTeamWorkItemType`, `Set-VSTeamWorkItemType`, `Remove-VSTeamWorkItemType` with associated help and tests.
 14.  Ensured tests which mock Get-VSTeamProcess clear the process cache (otherwise the processes they return will not be used to validate the Process parameter during the test,)
+15.  Ensured tests which call Set-VSTeamProject load and mock Get-VSTeamProcess.
 
 ## 7.1.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,33 +1,34 @@
 # Changelog
 
 ## J.H. O'Neill @ 3rd October 2020
-1.  To support tab completion for (e.g.) icon color  in `Add-VSTeamWorkItemType`:  **added class** `ColorCompleter` in file `Source\Classes\Completer\ColorCompleter.cs`. 
+1.  To support tab completion for (e.g.) icon color  in `Add-VSTeamWorkItemType`:  **added class** `ColorCompleter` in file `Source\Classes\Completer\ColorCompleter.cs`.
     I can't find way to use the conventional `KnownColor` class in single new C# class which will build for both Windows PowerShell 5 and PowerShell Core, so I've worked round it by getting the static properties of `System.Drawing.Color`.
-2.  To support use of Hex Red/green/blue attributes for colors (e.g icon color): **added class** `ColorTransformToHexAttribute` in file `Source\Classes\Attribute\ColorTransformToHexAttribute.cs`. 
+2.  To support use of Hex Red/green/blue attributes for colors (e.g icon color): **added class** `ColorTransformToHexAttribute` in file `Source\Classes\Attribute\ColorTransformToHexAttribute.cs`.
     If the parameter is given an object of type `System.Drawing.Color`, it coverts it to "aabbcc" for hex r,g,b values. If the parameter is a string in form "#aabbcc", the transformer strips the hash, if it is a string which isn't in "aabbcc" form, it tries to convert to a color and from the color to its hex string e.g the user tab-completes to "Red" which becomes "ff0000" and if the user enters "randomtext" it converts to "000000"
 3.  To support (e.g.) Population of an icon cache: **added function** `Get-VSTeamWorkIconList` in file `Source\Public\Get-VSTeamWorkItemIconList`
 4.  To support icon completion and validation: **added class** `IconCache` in file `Source\Classes\Cache\IconCache.cs`. This largely copied from `ProjectCache`
 5.  To support icon completion (e.g. in in `Add-VSTeamWorkItemType): **added class** `IconCompleter` in file `Source\Classes\Completer\IconCompleter.cs`. This is based on `ProjectCompleter`
-6.  To support transformation of shortened icon-names from `name` to `icon_name` format and support the validation of icon names, (e.g. in in `Add-VSTeamWorkItemType): **added class** `IconTransformAttribute`in file `Source\Classes\Attribute\IconTransformAttribute.cs`. 
+6.  To support transformation of shortened icon-names from `name` to `icon_name` format and support the validation of icon names, (e.g. in in `Add-VSTeamWorkItemType): **added class** `IconTransformAttribute`in file `Source\Classes\Attribute\IconTransformAttribute.cs`.
 7. To support project-independent operations on Process-templates (e.g Add-VsTeamWorkItemType), **changed class** `vsteam_lib.Versions`,  **added property** `DefaultProcess` property and corresponding environment variable `TEAM_PROCESS` - `process` is patterned after `project`.
-8.  **Changed function** `Set-VSTeamDefaultProject` 
+8.  **Changed function** `Set-VSTeamDefaultProject`
     * *Fixed* an apparant bug in where process level environment variable `TEAM_PROJECT` and `[vsteam_lib.Versions]::DefaultProject` were only set on Windows.
     * *Updated*  to store current project's process in `TEAM_PROCESS` and `[vsteam_lib.Versions]::DefaultProcess`
-    * *Updated tests* `Set-VSTeamDefaultProject.Tests.ps1` and `Get-VSTeamAgent.Tests.ps1` to mock the additional API call used to look-up the project's template.  
-9.  To support changes to Process Templates themselves **changed class** `vsteam_lib.Process` **added property** `ReferenceName` 
-10. **Changed function** `Get-VSTeamWorkItemType`. 
-    * Fixed a BUG: Only WorkItemTypes for the current project are cached and for validation, so requesting a WorkItem from a different project will fail if that type is not in the current project. As a by product now support wildcards for selecting WorkItem types, entering an invalid name runs the command without any output instead of causing an error. 
-    * Added support for getting the WorkItem types from a Process-template as well as from a project. When getting from a process-template, or from the default project whose template is known, add a property named `ProcessTemplate` to the objects so that piping into another function with that name as a `ValueFromPipelineByPropertyName` parameter can use it. 
+    * *Updated tests* `Set-VSTeamDefaultProject.Tests.ps1` and `Get-VSTeamAgent.Tests.ps1` to mock the additional API call used to look-up the project's template.
+9.  To support changes to Process Templates themselves **changed class** `vsteam_lib.Process` **added property** `ReferenceName`, and to make it easier to find the template for a project **added property** projects.
+10. **Changed function** `Get-VSTeamProcess`, **add switch** `expandprojects`. If specified populates the newly add projects property in (9)
+11. **Changed function** `Get-VSTeamWorkItemType`.
+    * Fixed a BUG: Only WorkItemTypes for the current project are cached and for validation, so requesting a WorkItem from a different project will fail if that type is not in the current project. As a by product now support wildcards for selecting WorkItem types, entering an invalid name runs the command without any output instead of causing an error.
+    * Added support for getting the WorkItem types from a Process-template as well as from a project. When getting from a process-template, or from the default project whose template is known, add a property named `ProcessTemplate` to the objects so that piping into another function with that name as a `ValueFromPipelineByPropertyName` parameter can use it.
     * Added an alias property named `WorkItemType` as an alias for `Name`, also for `ValueFromPipelineByPropertyName` support
     * Added a property named "hidden" when getting a list of WorkItem types for a project so picklists can remove hidden types.
     * Added a switch parameter -NotHidden to return only visible WorkItem Types
     * Added an expand parameter to get state, behavior and/or layout information
     * Fixed test which was breaking WorkItem type sample data by converting it to JSON when it is known to fail to convert, it now just reads the text file and leaves the section at the comment `# This call returns JSON with "": which causes the ConvertFrom-Json to fail`  to do its thing!
-    * Added functional test for -Process Template option. 
-    * Added examples and parameter description to help. 
-11.  For WorkItemType operations, **added function** a private/helper `_getProcessTemplateUrl` in file `common.ps1` to get/set the urls of templates in a script level hash table (to reduce API calls to get ID from a name.) In a previous version I set a URL property on the processs object - this has been dropped. 
-12. **Added functions**  `Add-VSTeamWorkItemType`, `Set-VSTeamWorkItemType`, `Remove-VSTeamWorkItemType` with associated help and tests.
-13.  Ensured tests which mock Get-VSTeamProcess clear the process cache (otherwise the processes they return will not be used to validate the Process parameter during the test,)
+    * Added functional test for -Process Template option.
+    * Added examples and parameter description to help.
+12.  For WorkItemType operations, **added function** a private/helper `_getProcessTemplateUrl` in file `common.ps1` to get/set the urls of templates in a script level hash table (to reduce API calls to get ID from a name.) In a previous version I set a URL property on the processs object - this has been dropped.
+13. **Added functions**  `Add-VSTeamWorkItemType`, `Set-VSTeamWorkItemType`, `Remove-VSTeamWorkItemType` with associated help and tests.
+14.  Ensured tests which mock Get-VSTeamProcess clear the process cache (otherwise the processes they return will not be used to validate the Process parameter during the test,)
 
 ## 7.1.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,15 +16,18 @@
     * *Updated tests* `Set-VSTeamDefaultProject.Tests.ps1` and `Get-VSTeamAgent.Tests.ps1` to mock the additional API call used to look-up the project's template.  
 9.  To support changes to Process Templates themselves **changed class** `vsteam_lib.Process` **added property** `ReferenceName` 
 10. **Changed function** `Get-VSTeamWorkItemType`. 
-    * Fixed a BUG: Only WorkitemTypes for the current project are cached and for validation, so requesting a workitem from a different project will fail if that type is not in the current project. As a by product now support wildcards for selecting workitem types, entering an invalid name runs the command without any output instead of causing an error. 
-    * Added support for getting the workitem-types from a Process-template as well as from a project. When getting from a process-template, or from the default project whose template is know, add a property named `ProcessTemplate` to the objects so that piping into another function with that name as a `ValueFromPipelineByPropertyName` parameter can use it. 
+    * Fixed a BUG: Only WorkItemTypes for the current project are cached and for validation, so requesting a WorkItem from a different project will fail if that type is not in the current project. As a by product now support wildcards for selecting WorkItem types, entering an invalid name runs the command without any output instead of causing an error. 
+    * Added support for getting the WorkItem types from a Process-template as well as from a project. When getting from a process-template, or from the default project whose template is known, add a property named `ProcessTemplate` to the objects so that piping into another function with that name as a `ValueFromPipelineByPropertyName` parameter can use it. 
     * Added an alias property named `WorkItemType` as an alias for `Name`, also for `ValueFromPipelineByPropertyName` support
-    * Added a property named "hidden" when getting a list of workitem types for a project so picklists can remove hidden types.
-    * Fixed test which was breaking workitem-type sample data by converting it to JSON when it is known to fail to convert, it now just reads the text file and leaves the section at the comment `# This call returns JSON with "": which causes the ConvertFrom-Json to fail`  to do its thing!
+    * Added a property named "hidden" when getting a list of WorkItem types for a project so picklists can remove hidden types.
+    * Added a switch parameter -NotHidden to return only visible WorkItem Types
+    * Added an expand parameter to get state, behavior and/or layout information
+    * Fixed test which was breaking WorkItem type sample data by converting it to JSON when it is known to fail to convert, it now just reads the text file and leaves the section at the comment `# This call returns JSON with "": which causes the ConvertFrom-Json to fail`  to do its thing!
     * Added functional test for -Process Template option. 
     * Added examples and parameter description to help. 
 11.  For WorkItemType operations, **added function** a private/helper `_getProcessTemplateUrl` in file `common.ps1` to get/set the urls of templates in a script level hash table (to reduce API calls to get ID from a name.) In a previous version I set a URL property on the processs object - this has been dropped. 
 12. **Added functions**  `Add-VSTeamWorkItemType`, `Set-VSTeamWorkItemType`, `Remove-VSTeamWorkItemType` with associated help and tests.
+13.  Ensured tests which mock Get-VSTeamProcess clear the process cache (otherwise the processes they return will not be used to validate the Process parameter during the test,)
 
 ## 7.1.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,6 @@
 # Changelog
+## J.H. O'Neill @ 7rd October 2020
+1.  Added Commands Add- and Set- -VSTeamProcess. Add- creates a process template based on a pre-existing one, Set- enables/disables, sets as the default for new projects and changes the name / description. 
 
 ## J.H. O'Neill @ 3rd October 2020
 1.  To support tab completion for (e.g.) icon color  in `Add-VSTeamWorkItemType`:  **added class** `ColorCompleter` in file `Source\Classes\Completer\ColorCompleter.cs`. 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,11 @@
 # Changelog
 ## J.H. O'Neill @ 12th October 2020
-1.  Added Commands Add- and Set- -VSTeamProcess. Add- creates a process template based on a pre-existing one, Set- enables/disables, sets  the default for new projects and changes the name / description.
-2.  Added Commands Get- Set- Add- Remove -VSTeamProcessBehavior and a format XML file for process behaviors. (a.k.a boards)
-3.  Added Commands Get- Set- -VSTeamWorkItemBehavior and a format XML file  for WorkItem behaviors - which link WorkItemTypes to boards.
-4.  Changed command `Get-VSTeamIteration` adding a switch -Expand to return all the iterations returned by the -Depth option, rather than one with a children node where each element may have children.
-5.  Added Commmands Get- and Set- -VSTeamSetting - to allow bug behavior and visibile boards (and things set with them) to be set.
+1.  Added Commands Add-, Remove- and Set- -VSTeamProcess. Add- creates a process template based on a pre-existing one, Set- enables/disables, sets  the default for new projects and changes the name / description. Remove deletes custom ones (system ones can't be deleted.)
+1. Changed command `Get-VSTeamProcess` to allow multiple names to be passed.
+1.  Added Commands Get- Set- Add- Remove -VSTeamProcessBehavior and a format XML file for process behaviors. (a.k.a boards)
+1.  Added Commands Get- Set- -VSTeamWorkItemBehavior and a format XML file  for WorkItem behaviors - which link WorkItemTypes to boards.
+1.  Changed command `Get-VSTeamIteration` adding a switch -Expand to return all the iterations returned by the -Depth option, rather than one with a children node where each element may have children.
+1.  Added Commmands Get- and Set- -VSTeamSetting - to allow bug behavior and visibile boards (and things set with them) to be set.
 
 ## 7.2.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,10 @@
 # Changelog
-## J.H. O'Neill @ 7rd October 2020
-1.  Added Commands Add- and Set- -VSTeamProcess. Add- creates a process template based on a pre-existing one, Set- enables/disables, sets  the default for new projects and changes the name / description. 
-2. Added Commands Get- Set- Add- Remove -VSTeamProcessBehavior and a format XML file for process behaviors.
-3. Added Commands Get- Set- -VSTeamWorkItemBehavior and a format XML file  for WorkItem behaviors.
+## J.H. O'Neill @ 12th October 2020
+1.  Added Commands Add- and Set- -VSTeamProcess. Add- creates a process template based on a pre-existing one, Set- enables/disables, sets  the default for new projects and changes the name / description.
+2.  Added Commands Get- Set- Add- Remove -VSTeamProcessBehavior and a format XML file for process behaviors. (a.k.a boards)
+3.  Added Commands Get- Set- -VSTeamWorkItemBehavior and a format XML file  for WorkItem behaviors - which link WorkItemTypes to boards.
+4.  Changed command `Get-VSTeamIteration` adding a switch -Expand to return all the iterations returned by the -Depth option, rather than one with a children node where each element may have children.
+5.  Added Commmands Get- and Set- -VSTeamSetting - to allow bug behavior and visibile boards (and things set with them) to be set.
 
 ## J.H. O'Neill @ 3rd October 2020
 1.  To support tab completion for (e.g.) icon color  in `Add-VSTeamWorkItemType`:  **added class** `ColorCompleter` in file `Source\Classes\Completer\ColorCompleter.cs`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@
 1. **Added functions**  `Add-VSTeamWorkItemType`, `Set-VSTeamWorkItemType`, `Remove-VSTeamWorkItemType`, `Unlock-VSTeamWorkItemType` with associated help and tests.
 1. Ensured tests which mock Get-VSTeamProcess clear the process cache (otherwise the processes they return will not be used to validate the Process parameter during the test,)
 1. Ensured tests which call Set-VSTeamProject load and mock Get-VSTeamProcess.
+1. Modified validator for process templates to allow multiple template names to be validated (where function can't support multiple names count should be validated.)
 
 ## 7.1.2
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,9 +20,10 @@
     * Fixed a BUG: Only WorkItemTypes for the current project are cached and for validation, so requesting a WorkItem from a different project will fail if that type is not in the current project. As a by product now support wildcards for selecting WorkItem types, entering an invalid name runs the command without any output instead of causing an error.
     * Added support for getting the WorkItem types from a Process-template as well as from a project. When getting from a process-template, or from the default project whose template is known, add a property named `ProcessTemplate` to the objects so that piping into another function with that name as a `ValueFromPipelineByPropertyName` parameter can use it.
     * Added an alias property named `WorkItemType` as an alias for `Name`, also for `ValueFromPipelineByPropertyName` support
-    * Added a property named "hidden" when getting a list of WorkItem types for a project so picklists can remove hidden types.
+    * Added a property named "hidden" when getting a list of WorkItem types for a project, so picklists can remove hidden types.
     * Added a switch parameter -NotHidden to return only visible WorkItem Types
     * Added an expand parameter to get state, behavior and/or layout information
+    * Now allow the workitemtype parameter to be a wildcard or multiple strings. (e.g. Get-VSTeamWorkItemType bug,feature)
     * Fixed test which was breaking WorkItem type sample data by converting it to JSON when it is known to fail to convert, it now just reads the text file and leaves the section at the comment `# This call returns JSON with "": which causes the ConvertFrom-Json to fail`  to do its thing!
     * Added functional test for -Process Template option.
     * Added examples and parameter description to help.

--- a/Source/Classes/Attribute/ColorTransformToHexAttribute.cs
+++ b/Source/Classes/Attribute/ColorTransformToHexAttribute.cs
@@ -1,0 +1,33 @@
+﻿using System.Diagnostics.CodeAnalysis;
+using System.Management.Automation;
+using System.Drawing;
+using System.Text.RegularExpressions;
+namespace vsteam_lib
+{
+   public class ColorTransformToHexAttribute : ArgumentTransformationAttribute {
+      [ExcludeFromCodeCoverage]
+      public override object Transform(EngineIntrinsics engineIntrinsics, object InputData) {
+         try {
+            if (InputData is string) {
+               string s = (string)InputData;
+               Regex sixHexDigits = new Regex(@"^#?([\da-f]{6})$",RegexOptions.IgnoreCase);
+               if (sixHexDigits.Match(s).Success ) {
+                  InputData = sixHexDigits.Replace(s,"$1");
+               }
+               else {
+                  InputData =  Color.FromName(s);
+               }                
+            }
+            if (InputData is Color) {
+               Color c = (Color)InputData;
+               InputData = (string.Format("{0:x2}{1:x2}{2:x2}",c.R, c.G, c.B) );
+            }
+         }
+         catch {
+            throw (new ParameterBindingException((InputData as string) + " could not be transformed into a color.") ); 
+         }
+
+         return (InputData);
+      }
+   }
+}

--- a/Source/Classes/Attribute/IconTransformAttribute.cs
+++ b/Source/Classes/Attribute/IconTransformAttribute.cs
@@ -1,0 +1,33 @@
+﻿using System.Diagnostics.CodeAnalysis;
+using System.Management.Automation;
+using System.Text.RegularExpressions;
+using System.Linq;
+namespace vsteam_lib
+{
+   public class IconTransformAttribute : ArgumentTransformationAttribute {
+      [ExcludeFromCodeCoverage]
+      public override object Transform(EngineIntrinsics engineIntrinsics, object InputData) {
+          
+            string s = (InputData as string).ToLower();
+            if (! string.IsNullOrEmpty(s))
+            {
+               Regex iconSomething = new Regex(@"^icon_\w+");
+               if (!iconSomething.IsMatch(s)) 
+               { 
+                  s = "icon_" + s;
+               }
+               var iconList = IconCache.GetCurrent(false);
+            
+               if (iconList.Count() > 1 && ! iconList.Contains(s) ) 
+               {
+                  throw (new ValidationMetadataException(s + " is not a valid icon name.") );
+               }
+               else
+               {
+                  return s;
+               }
+            }
+            return InputData;
+      }
+   }
+}

--- a/Source/Classes/Attribute/ProcessTemplateValidateAttribute.cs
+++ b/Source/Classes/Attribute/ProcessTemplateValidateAttribute.cs
@@ -1,9 +1,35 @@
-﻿using System.Collections.Generic;
-
+﻿using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
+using System.Management.Automation;
 namespace vsteam_lib
 {
    public class ProcessTemplateValidateAttribute : BaseValidateArgumentsAttribute
    {
       internal override IEnumerable<string> GetValues() => ProcessTemplateCache.GetCurrent();
+
+      protected override void Validate(object arguments, EngineIntrinsics engineIntrinsics)
+      {
+         if (string.IsNullOrEmpty(arguments?.ToString()))
+         {
+            return;
+         }
+
+         if (arguments is object[])
+         {
+            IEnumerable enumerable = arguments as IEnumerable;
+            foreach (var item in enumerable)
+            {
+                Validate(item,engineIntrinsics);
+            }
+            return;
+         }
+
+         var cache = ProcessTemplateCache.GetCurrent();
+         if (cache.Count() > 0 && cache.All(s => string.Compare(arguments.ToString(), s, true) != 0))
+         {
+            throw new ValidationMetadataException($"'{arguments}' is invalid");
+         }
+      }
    }
 }

--- a/Source/Classes/Cache/IconCache.cs
+++ b/Source/Classes/Cache/IconCache.cs
@@ -1,0 +1,34 @@
+﻿using System.Collections.Generic;
+using System.Management.Automation;
+
+namespace vsteam_lib
+{
+   /// <summary>
+   /// Cache project names to reduce the number of
+   /// rest APIs calls needed for parameter completion / validation 
+   /// </summary>
+   public static class IconCache
+   {
+      public static void Invalidate() => Cache.Invalidate();
+      internal static bool HasCacheExpired => Cache.HasCacheExpired;
+      internal static InternalCache Cache { get; } = new InternalCache("Get-VSTeamWorkItemIconList", "ID", false);
+      public static void Update(IEnumerable<string> list, int minutesToExpire = 240) => Cache.Update(list, minutesToExpire);
+
+      /// <summary>
+      /// There are times we need to force an update of the cache
+      /// even if it has not expired yet. This will be true when we
+      /// add a new project.
+      /// </summary>
+      /// <param name="forceUpdate"></param>
+      /// <returns></returns>
+      public static IEnumerable<string> GetCurrent(bool forceUpdate)
+      {
+         if (HasCacheExpired || forceUpdate)
+         {
+            Update(null);
+         }
+
+         return Cache.Values;
+      }
+   }
+}

--- a/Source/Classes/Cache/IconCache.cs
+++ b/Source/Classes/Cache/IconCache.cs
@@ -1,10 +1,9 @@
 ﻿using System.Collections.Generic;
-using System.Management.Automation;
 
 namespace vsteam_lib
 {
    /// <summary>
-   /// Cache project names to reduce the number of
+   /// Cache Icons for work items to reduce the number of
    /// rest APIs calls needed for parameter completion / validation 
    /// </summary>
    public static class IconCache
@@ -16,8 +15,7 @@ namespace vsteam_lib
 
       /// <summary>
       /// There are times we need to force an update of the cache
-      /// even if it has not expired yet. This will be true when we
-      /// add a new project.
+      /// even if it has not expired yet. 
       /// </summary>
       /// <param name="forceUpdate"></param>
       /// <returns></returns>

--- a/Source/Classes/Cache/InternalCache.cs
+++ b/Source/Classes/Cache/InternalCache.cs
@@ -46,9 +46,8 @@ namespace vsteam_lib
       internal void Update(IEnumerable<string> list, int minutesToExpire = 1)
       {
          this.MinutesToExpire = minutesToExpire;
-
-         // If a list is passed in use it. If not call Get-VSTeamProcess
-         if (null == list)
+         // If a list is passed in use it. If not, call the command we were given, provided we're logged on
+         if (null == list && !string.IsNullOrEmpty(Versions.Account))
          {
             if (this._requiresProject)
             {
@@ -77,7 +76,6 @@ namespace vsteam_lib
                                 .Invoke<string>();
             }
          }
-
          this.PreFill(list);
       }
 
@@ -91,9 +89,9 @@ namespace vsteam_lib
             {
                this.Values.Add(item);
             }
+            /// Only set the time stamp if a list was passed.
+            this._timeStamp = Math.Round(DateTime.UtcNow.TimeOfDay.TotalMinutes);
          }
-
-         this._timeStamp = Math.Round(DateTime.UtcNow.TimeOfDay.TotalMinutes);
       }
 
       internal IEnumerable<string> GetCurrent()

--- a/Source/Classes/Completer/ColorCompleter.cs
+++ b/Source/Classes/Completer/ColorCompleter.cs
@@ -1,0 +1,41 @@
+﻿using System.Management.Automation.Language;
+using System.Drawing;
+using System.Reflection;
+using System.Collections;
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+using System.Globalization;
+using System.Management.Automation;
+
+namespace vsteam_lib
+{
+    public class ColorCompleter  : IArgumentCompleter
+    {
+      [ExcludeFromCodeCoverage]
+      public ColorCompleter() : base() { }
+        public  IEnumerable<CompletionResult> CompleteArgument(string commandName, string parameterName, string wordToComplete, CommandAst commandAst, IDictionary fakeBoundParameters) 
+        {
+            var values = new List<CompletionResult>();
+            List<string> colorlist = new List<string>();
+            foreach (PropertyInfo p in typeof(Color).GetProperties() ) {
+                if (p.PropertyType == typeof(Color)) {
+                    colorlist.Add(p.Name);
+                }
+            }
+            SelectValues(wordToComplete, colorlist, values);
+            return values;
+        }
+        /// following module style.
+        protected static void SelectValues(string wordToComplete, IEnumerable<string> words, List<CompletionResult> values)
+        {
+             foreach (var word in words)
+            {
+                if (string.IsNullOrEmpty(wordToComplete) || word.StartsWith(wordToComplete, true, CultureInfo.InvariantCulture))
+                {
+                    // Only wrap in single quotes if they have a space. 
+                    values.Add(new CompletionResult(word.Contains(" ") ? $"'{word}'" : word));
+                }
+            }
+        }
+    }
+}

--- a/Source/Classes/Completer/IconCompleter.cs
+++ b/Source/Classes/Completer/IconCompleter.cs
@@ -1,0 +1,38 @@
+﻿using System.Collections;
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+using System.Management.Automation;
+using System.Management.Automation.Abstractions;
+using System.Management.Automation.Language;
+
+namespace vsteam_lib
+{
+   public class IconCompleter : BaseCompleter
+   {
+      /// <summary>
+      /// This constructor is used when running in a PowerShell session. It cannot be
+      /// loaded in a unit test.
+      /// </summary>
+      [ExcludeFromCodeCoverage]
+      public IconCompleter() : base() { }
+
+      /// <summary>
+      /// This constructor is used during unit testings
+      /// </summary>
+      /// <param name="powerShell">fake instance of IPowerShell used for testing</param>
+      public IconCompleter(IPowerShell powerShell) : base(powerShell) { }
+
+      public override IEnumerable<CompletionResult> CompleteArgument(string commandName,
+                                                                     string parameterName,
+                                                                     string wordToComplete,
+                                                                     CommandAst commandAst,
+                                                                     IDictionary fakeBoundParameters)
+      {
+         var values = new List<CompletionResult>();
+
+         SelectValues(wordToComplete, IconCache.GetCurrent(false), values);
+
+         return values;
+      }
+   }
+}

--- a/Source/Classes/Provider/Leaf.cs
+++ b/Source/Classes/Provider/Leaf.cs
@@ -24,6 +24,7 @@ namespace vsteam_lib.Provider
       public Leaf(PSObject obj, string name, string id, string projectName) : base(name)
       {
          Common.MoveProperties(this, obj);
+
          this.Id = id;
          this.InternalObject = obj;
          this.ProjectName = projectName;

--- a/Source/Classes/Provider/Leaf.cs
+++ b/Source/Classes/Provider/Leaf.cs
@@ -24,7 +24,6 @@ namespace vsteam_lib.Provider
       public Leaf(PSObject obj, string name, string id, string projectName) : base(name)
       {
          Common.MoveProperties(this, obj);
-
          this.Id = id;
          this.InternalObject = obj;
          this.ProjectName = projectName;

--- a/Source/Classes/Provider/Process.cs
+++ b/Source/Classes/Provider/Process.cs
@@ -1,4 +1,6 @@
-﻿using System.Management.Automation;
+﻿using System.Collections.Generic;
+using System.Linq;
+using System.Management.Automation;
 using System.Xml.Serialization;
 using vsteam_lib.Provider;
 
@@ -15,11 +17,13 @@ namespace vsteam_lib
       public string Type { get; set; }
       public string ProcessTemplate => this.Name;
       public string ParentProcessTypeId { get; set; }
-      public string[] Projects { get; set; }
+      public IEnumerable<string> Projects { get; }
 
       public Process(PSObject obj) :
          base(obj, obj.GetValue("name"), obj.GetValue("id"), null)
       {
+         this.Projects = obj.GetValue<object[]>("Projects")?.Select(o => o.ToString()).ToArray();
+
          // Depending on what API was used you might get and ID or a TypeId back.
          // If you get a TypeId you need to set the ID now
          if (string.IsNullOrEmpty(this.Id))

--- a/Source/Classes/Provider/Process.cs
+++ b/Source/Classes/Provider/Process.cs
@@ -15,6 +15,7 @@ namespace vsteam_lib
       public string Type { get; set; }
       public string ProcessTemplate => this.Name;
       public string ParentProcessTypeId { get; set; }
+      public string[] Projects { get; set; }
 
       public Process(PSObject obj) :
          base(obj, obj.GetValue("name"), obj.GetValue("id"), null)

--- a/Source/Classes/Provider/Process.cs
+++ b/Source/Classes/Provider/Process.cs
@@ -8,6 +8,7 @@ namespace vsteam_lib
    {
       public string TypeId { get; set; }
       public string Description { get; set; }
+      public string ReferenceName { get; set; }
       public bool IsEnabled { get; set; }
       public bool IsDefault { get; set; }
       [XmlAttribute("customizationType")]

--- a/Source/Classes/Versions.cs
+++ b/Source/Classes/Versions.cs
@@ -125,6 +125,8 @@ namespace vsteam_lib
       [ExcludeFromCodeCoverage]
       public static string DefaultTimeout { get; set; } = System.Environment.GetEnvironmentVariable("TEAM_TIMEOUT");
       [ExcludeFromCodeCoverage]
+      public static string DefaultProcess { get; set; } = System.Environment.GetEnvironmentVariable("TEAM_PROCESS");
+      [ExcludeFromCodeCoverage]
       public static string DefaultProject { get; set; } = System.Environment.GetEnvironmentVariable("TEAM_PROJECT");
       [ExcludeFromCodeCoverage]
       public static string Version { get; set; } = System.Environment.GetEnvironmentVariable("TEAM_VERSION") ?? "TFS2017";

--- a/Source/Private/common.ps1
+++ b/Source/Private/common.ps1
@@ -966,3 +966,25 @@ function _getDescriptorForACL {
 
    return $descriptor
 }
+
+$script:processTypeIds = @{}
+function _getProcessTemplateUrl {
+   Param (
+      [Parameter(Mandatory=$true,position=0)]
+      $ProcessTemplate
+   )
+   if ($script:processTypeIds[$ProcessTemplate]) {
+         return ((_getInstance) + "/_apis/work/processes/" + $script:processTypeIds[$ProcessTemplate] )
+   }
+   else {
+      $p = Get-VSTeamProcess $ProcessTemplate
+      if ($p -and $p.psobject.properties['typeID']) {
+         $script:processTypeIds[$ProcessTemplate] = $p.typeid
+         return ((_getInstance) + "/_apis/work/processes/" + $p.typeid )
+      }
+      elseif ($p -and $p.psobject.properties['Id']) {
+         $script:processTypeIds[$ProcessTemplate] = $p.Id
+         return ((_getInstance) + "/_apis/work/processes/" + $p.Id )
+      }
+   }
+}

--- a/Source/Public/Add-VSTeamProcess.ps1
+++ b/Source/Public/Add-VSTeamProcess.ps1
@@ -1,0 +1,52 @@
+function Add-VSTeamProcess {
+   [cmdletbinding(SupportsShouldProcess=$true)]
+   param(
+      [parameter(Mandatory = $true)]
+      [Alias('Name')]
+      [string] $ProcessName,
+
+      [string] $Description,
+
+      [string] $ReferenceName,
+
+      [parameter(Mandatory = $true)]
+      [vsteam_lib.ProcessTemplateValidateAttribute()]
+      [ArgumentCompleter([vsteam_lib.ProcessTemplateCompleter])]
+      $ParentProcessName,
+
+      [switch]$Force
+   )
+
+   $parentProcess = Get-VSTeamProcess -Name $ParentProcessName
+   if (-not $parentProcess) { Write-Warning "Couldn't turn '$ParentProcessName' into a process GUID."; return   }
+ 
+   $body          =  @{ 'parentProcessTypeId'  = $parentProcess.id
+                        'name'                 = $ProcessName
+   }
+   if ($ReferenceName) {$body['referenceName'] = $ReferenceName}
+   if ($Description)   {$body['description']   = $Description  }
+
+   $commonArgs = @{
+      Method      = "Post"
+      NoProject   = $true
+      Area        = 'work'
+      Resource    = 'processes'
+      Version     = _getApiVersion Processes
+      ContentType = "application/json" 
+      Body        = ConvertTo-Json  $body
+   }
+    if ($Force -or $PSCmdlet.ShouldProcess($ProcessName,'Create New Process')) {
+      # Call the REST API
+      $resp = _callAPI @commonArgs
+
+      if ($resp.psobject.Properties.name -notcontains 'typeid') {
+         Write-Warning 'The server did not return an ID for a newly created process. '
+      }
+      else {
+         [vsteam_lib.ProcessTemplateCache]::Invalidate()
+         
+         return [vsteam_lib.Process]::new($resp)
+      }
+      
+   }
+}

--- a/Source/Public/Add-VSTeamProcess.ps1
+++ b/Source/Public/Add-VSTeamProcess.ps1
@@ -19,7 +19,7 @@ function Add-VSTeamProcess {
 
    $parentProcess = Get-VSTeamProcess -Name $ParentProcessName
    if (-not $parentProcess) { Write-Warning "Couldn't turn '$ParentProcessName' into a process GUID."; return   }
- 
+
    $body          =  @{ 'parentProcessTypeId'  = $parentProcess.id
                         'name'                 = $ProcessName
    }
@@ -32,10 +32,9 @@ function Add-VSTeamProcess {
       Area        = 'work'
       Resource    = 'processes'
       Version     = _getApiVersion Processes
-      ContentType = "application/json" 
       Body        = ConvertTo-Json  $body
    }
-    if ($Force -or $PSCmdlet.ShouldProcess($ProcessName,'Create New Process')) {
+   if ($Force -or $PSCmdlet.ShouldProcess($ProcessName,'Create New Process')) {
       # Call the REST API
       $resp = _callAPI @commonArgs
 
@@ -44,9 +43,9 @@ function Add-VSTeamProcess {
       }
       else {
          [vsteam_lib.ProcessTemplateCache]::Invalidate()
-         
+
          return [vsteam_lib.Process]::new($resp)
       }
-      
+
    }
 }

--- a/Source/Public/Add-VSTeamProcessBehavior.ps1
+++ b/Source/Public/Add-VSTeamProcessBehavior.ps1
@@ -17,30 +17,32 @@ function Add-VSTeamProcessBehavior {
       [switch]$Force
    )
    Process {
-      $url = _getProcessTemplateUrl $ProcessTemplate
-      if (-not $url) {Write-Warning "Could not convert '$ProcessTemplate' into a process template"; return}
-      else           {$Params = @{url = "$url/behaviors?api-version=" + (_getApiVersion Processes) } }
+      foreach ($p in $ProcessTemplate) {
+         $url = _getProcessTemplateUrl $p
+         if (-not $url) {Write-Warning "Could not convert '$p' into a process template"; return}
+         else           {$Params = @{url = "$url/behaviors?api-version=" + (_getApiVersion Processes) } }
 
-      $resp0  = (_callApi @params).value
-      if ($resp0.name -contains $Name) {Write-Warning "'$Name' already exists!" ; return}
+         $resp0  = (_callApi @params).value
+         if ($resp0.name -contains $Name) {Write-Warning "'$Name' already exists!" ; continue}
 
-      $params['body'] = ConvertTo-Json @{
-         name          = $Name
-         color         = $Color
-         inherits      = 'System.PortfolioBacklogBehavior' # this is the only supported one
-         referenceName = "Custom.$Name"  #or you can have a custom.guid
-      }
+         $params['body'] = ConvertTo-Json @{
+            name          = $Name
+            color         = $Color
+            inherits      = 'System.PortfolioBacklogBehavior' # this is the only supported one
+            referenceName = "Custom.$Name"  #or you can have a custom.guid
+         }
 
-      if ($Force -or  $PSCmdlet.ShouldProcess($ProcessTemplate,"Add behavior named '$Name' to process")) {
-         #Call the Rest API
-         $resp = _callAPI @params -method 'Post'
+         if ($Force -or  $PSCmdlet.ShouldProcess($p,"Add behavior named '$Name' to process")) {
+            #Call the Rest API
+            $resp = _callAPI @params -method 'Post'
 
-         # Apply a Type Name so we can use custom format view and custom type extensions
-         # and add the processTemplate name so it can become a parameter when the object is piped into other functions
-         $resp.psobject.TypeNames.Insert(0,'vsteam_lib.Processbehavior')
-         Add-Member -InputObject $resp -MemberType NoteProperty -Name ProcessTemplate -Value $ProcessTemplate
+            # Apply a Type Name so we can use custom format view and custom type extensions
+            # and add the processTemplate name so it can become a parameter when the object is piped into other functions
+            $resp.psobject.TypeNames.Insert(0,'vsteam_lib.Processbehavior')
+            Add-Member -InputObject $resp -MemberType NoteProperty -Name ProcessTemplate -Value $p
 
-         return $resp
+            Write-Output $resp
+         }
       }
    }
 }

--- a/Source/Public/Add-VSTeamProcessBehavior.ps1
+++ b/Source/Public/Add-VSTeamProcessBehavior.ps1
@@ -12,11 +12,12 @@ function Add-VSTeamProcessBehavior {
 
       [ArgumentCompleter([vsteam_lib.ColorCompleter])]
       [vsteam_lib.ColorTransformToHexAttribute()]
-      [String]$Color = "808080"
+      [String]$Color = "808080",
 
+      [switch]$Force
    )
    Process {
-      $url = _getProcessTemplateUrl $ProcessTemplate 
+      $url = _getProcessTemplateUrl $ProcessTemplate
       if (-not $url) {Write-Warning "Could not convert '$ProcessTemplate' into a process template"; return}
       else           {$Params = @{url = "$url/behaviors?api-version=" + (_getApiVersion Processes) } }
 
@@ -30,16 +31,16 @@ function Add-VSTeamProcessBehavior {
          referenceName = "Custom.$Name"  #or you can have a custom.guid
       }
 
-      if ($PSCmdlet.ShouldProcess($ProcessTemplate,"Add behavior named '$Name' to process")) {
+      if ($Force -or  $PSCmdlet.ShouldProcess($ProcessTemplate,"Add behavior named '$Name' to process")) {
          #Call the Rest API
-         $resp = _callAPI @params -method Post  -ContentType "application/json" 
-         
+         $resp = _callAPI @params -method 'Post'
+
          # Apply a Type Name so we can use custom format view and custom type extensions
          # and add the processTemplate name so it can become a parameter when the object is piped into other functions
          $resp.psobject.TypeNames.Insert(0,'vsteam_lib.Processbehavior')
          Add-Member -InputObject $resp -MemberType NoteProperty -Name ProcessTemplate -Value $ProcessTemplate
 
-         return $resp 
+         return $resp
       }
    }
 }

--- a/Source/Public/Add-VSTeamProcessBehavior.ps1
+++ b/Source/Public/Add-VSTeamProcessBehavior.ps1
@@ -1,0 +1,45 @@
+function Add-VSTeamProcessBehavior {
+   [CmdletBinding(SupportsShouldProcess=$true)]
+   param (
+      [Parameter(ValueFromPipelineByPropertyName=$true,Position=1)]
+      [vsteam_lib.ProcessTemplateValidateAttribute()]
+      [ArgumentCompleter([vsteam_lib.ProcessTemplateCompleter])]
+      $ProcessTemplate = $env:TEAM_PROCESS,
+
+      [Parameter(Mandatory=$true,Position=1)]
+      [string]
+      $Name,
+
+      [ArgumentCompleter([vsteam_lib.ColorCompleter])]
+      [vsteam_lib.ColorTransformToHexAttribute()]
+      [String]$Color = "808080"
+
+   )
+   Process {
+      $url = _getProcessTemplateUrl $ProcessTemplate 
+      if (-not $url) {Write-Warning "Could not convert '$ProcessTemplate' into a process template"; return}
+      else           {$Params = @{url = "$url/behaviors?api-version=" + (_getApiVersion Processes) } }
+
+      $resp0  = (_callApi @params).value
+      if ($resp0.name -contains $Name) {Write-Warning "'$Name' already exists!" ; return}
+
+      $params['body'] = ConvertTo-Json @{
+         name          = $Name
+         color         = $Color
+         inherits      = 'System.PortfolioBacklogBehavior' # this is the only supported one
+         referenceName = "Custom.$Name"  #or you can have a custom.guid
+      }
+
+      if ($PSCmdlet.ShouldProcess($ProcessTemplate,"Add behavior named '$Name' to process")) {
+         #Call the Rest API
+         $resp = _callAPI @params -method Post  -ContentType "application/json" 
+         
+         # Apply a Type Name so we can use custom format view and custom type extensions
+         # and add the processTemplate name so it can become a parameter when the object is piped into other functions
+         $resp.psobject.TypeNames.Insert(0,'vsteam_lib.Processbehavior')
+         Add-Member -InputObject $resp -MemberType NoteProperty -Name ProcessTemplate -Value $ProcessTemplate
+
+         return $resp 
+      }
+   }
+}

--- a/Source/Public/Add-VSTeamWorkItemType.ps1
+++ b/Source/Public/Add-VSTeamWorkItemType.ps1
@@ -1,11 +1,12 @@
 function Add-VSTeamWorkItemType {
    [cmdletbinding(SupportsShouldProcess=$true)]
    param(
+      [Parameter(Position=0, ValueFromPipelineByPropertyName = $true)]
       [vsteam_lib.ProcessTemplateValidateAttribute()]
       [ArgumentCompleter([vsteam_lib.ProcessTemplateCompleter])]
       $ProcessTemplate = $env:TEAM_PROCESS,
 
-      [parameter(Mandatory = $true)]
+      [parameter(Mandatory = $true,Position=1)]
       [Alias('Name')]
       [string] $WorkItemType,
 

--- a/Source/Public/Add-VSTeamWorkItemType.ps1
+++ b/Source/Public/Add-VSTeamWorkItemType.ps1
@@ -21,36 +21,38 @@ function Add-VSTeamWorkItemType {
       [string]$Icon = 'icon_asterisk'
    )
    process {
-      $url =  _getProcessTemplateUrl $ProcessTemplate
-      if ($url) {$url += "/workitemtypes?api-version=" + (_getApiVersion Processes)}
-      else      {Write-Warning "Could not convert '$ProcessTemplate' into a process template"; return}
+      #Allow additions to more than one ProcessTemplate
+      foreach ($pt in $ProcessTemplate) {
+         $url =  _getProcessTemplateUrl $pt
+         if ($url) {$url += "/workitemtypes?api-version=" + (_getApiVersion Processes)}
+         else      {Write-Warning "Could not convert '$pt' into a process template"; return}
 
-      $body  = @{
-         name  = $WorkItemType
-         color = $Color
-         icon  = $Icon
-      }
-      if ($Description)  {$body['description'] =$Description }
-
-      if ($PSCmdlet.ShouldProcess($ProcessTemplate, "Add workitem '$WorkItemType' to process template"))  {
-         # Call the Rest API. _callAPi displays errors for the user and throws,
-         # if this happens half way through adding to mulitple process templates
-         # don't stop with some done and some not.
-         try {
-            $resp = _callapi -Url $url -method  Post -body (ConvertTo-Json $body) -ErrorAction Stop
+         $body  = @{
+            name  = $WorkItemType
+            color = $Color
+            icon  = $Icon
          }
-         catch {
-            Write-Warning "An error occured trying to add a workitem type to Process template '$ProcessTemplate'"
-            return
+         if ($Description)  {$body['description'] =$Description }
+
+         if ($PSCmdlet.ShouldProcess($pt, "Add workitem '$WorkItemType' to process template"))  {
+            # Call the Rest API. _callAPi displays errors for the user and throws,
+            # if this happens half way through adding to mulitple process templates
+            # don't stop with some done and some not.
+            try {
+               $resp = _callapi -Url $url -method  Post -body (ConvertTo-Json $body) -ErrorAction Stop
+            }
+            catch {
+               Write-Warning "An error occured trying to add a workitem type to Process template '$pt'"
+               continue
+            }
+            if ($pt -eq $env:TEAM_PROCESS) {[vsteam_lib.WorkItemTypeCache]::Invalidate()}
+
+            $resp.PSObject.TypeNames.Insert(0, 'vsteam_lib.WorkItemType')
+            Add-Member -InputObject $resp -MemberType AliasProperty -Name WorkItemType    -Value "name"
+            Add-Member -InputObject $resp -MemberType NoteProperty  -Name ProcessTemplate -Value $pt
+
+            Write-Output $resp
          }
-         if ($ProcessTemplate -eq $env:TEAM_PROCESS) {[vsteam_lib.WorkItemTypeCache]::Invalidate()}
-
-         $resp.PSObject.TypeNames.Insert(0, 'vsteam_lib.WorkItemType')
-         Add-Member -InputObject $resp -MemberType AliasProperty -Name WorkItemType    -Value "name"
-         Add-Member -InputObject $resp -MemberType NoteProperty  -Name ProcessTemplate -Value $ProcessTemplate
-
-         return $resp
-
       }
    }
 }

--- a/Source/Public/Add-VSTeamWorkItemType.ps1
+++ b/Source/Public/Add-VSTeamWorkItemType.ps1
@@ -1,25 +1,3 @@
-$script:processTypeIds = @{}
-function _getProcessTemplateUrl {
-   Param (
-      [Parameter(Mandatory=$true,position=0)]
-      $ProcessTemplate
-   )
-   if ($script:processTypeIds[$ProcessTemplate]) {
-         return ((_getInstance) + "/_apis/work/processes/" + $script:processTypeIds[$ProcessTemplate] )
-   }
-   else {
-      $p = Get-VSTeamProcess $ProcessTemplate
-      if ($p -and $p.psobject.properties['typeID']) {
-         $script:processTypeIds[$ProcessTemplate] = $p.typeid
-         return ((_getInstance) + "/_apis/work/processes/" + $p.typeid )
-      }
-      elseif ($p -and $p.psobject.properties['Id']) {
-         $script:processTypeIds[$ProcessTemplate] = $p.Id
-         return ((_getInstance) + "/_apis/work/processes/" + $p.Id )
-      }
-   }
-}
-
 function Add-VSTeamWorkItemType {
    [cmdletbinding(SupportsShouldProcess=$true)]
    param(
@@ -45,14 +23,14 @@ function Add-VSTeamWorkItemType {
    $url =  _getProcessTemplateUrl $ProcessTemplate
    if ($url) {$url += "/workitemtypes?api-version=" + (_getApiVersion Processes)}
    else      {Write-Warning "Could not convert '$ProcessTemplate' into a process template"; return}
-   
+
    $body  = @{
       name  = $WorkItemType
-      color = $Color 
+      color = $Color
       icon  = $Icon
    }
    if ($Description)  {$body['description'] =$Description }
-   
+
    if ($PSCmdlet.ShouldProcess($ProcessTemplate, "Add workitem '$WorkItemType' to process template"))  {
       $resp = _callapi -Url $url -method  Post  -ContentType "application/json" -body (ConvertTo-Json $body) -erroraction stop
       if ($resp) {

--- a/Source/Public/Add-VSTeamWorkItemType.ps1
+++ b/Source/Public/Add-VSTeamWorkItemType.ps1
@@ -32,7 +32,7 @@ function Add-VSTeamWorkItemType {
    if ($Description)  {$body['description'] =$Description }
 
    if ($PSCmdlet.ShouldProcess($ProcessTemplate, "Add workitem '$WorkItemType' to process template"))  {
-      $resp = _callapi -Url $url -method  Post  -ContentType "application/json" -body (ConvertTo-Json $body) -erroraction stop
+      $resp = _callapi -Url $url -method  Post -body (ConvertTo-Json $body) -ErrorAction Stop
       if ($resp) {
          if ($ProcessTemplate -eq $env:TEAM_PROCESS) {[vsteam_lib.WorkItemTypeCache]::Invalidate()}
 

--- a/Source/Public/Add-VSTeamWorkItemType.ps1
+++ b/Source/Public/Add-VSTeamWorkItemType.ps1
@@ -20,28 +20,29 @@ function Add-VSTeamWorkItemType {
       [ArgumentCompleter([vsteam_lib.IconCompleter])]
       [string]$Icon = 'icon_asterisk'
    )
+   process {
+      $url =  _getProcessTemplateUrl $ProcessTemplate
+      if ($url) {$url += "/workitemtypes?api-version=" + (_getApiVersion Processes)}
+      else      {Write-Warning "Could not convert '$ProcessTemplate' into a process template"; return}
 
-   $url =  _getProcessTemplateUrl $ProcessTemplate
-   if ($url) {$url += "/workitemtypes?api-version=" + (_getApiVersion Processes)}
-   else      {Write-Warning "Could not convert '$ProcessTemplate' into a process template"; return}
+      $body  = @{
+         name  = $WorkItemType
+         color = $Color
+         icon  = $Icon
+      }
+      if ($Description)  {$body['description'] =$Description }
 
-   $body  = @{
-      name  = $WorkItemType
-      color = $Color
-      icon  = $Icon
-   }
-   if ($Description)  {$body['description'] =$Description }
+      if ($PSCmdlet.ShouldProcess($ProcessTemplate, "Add workitem '$WorkItemType' to process template"))  {
+         $resp = _callapi -Url $url -method  Post -body (ConvertTo-Json $body) -ErrorAction Stop
+         if ($resp) {
+            if ($ProcessTemplate -eq $env:TEAM_PROCESS) {[vsteam_lib.WorkItemTypeCache]::Invalidate()}
 
-   if ($PSCmdlet.ShouldProcess($ProcessTemplate, "Add workitem '$WorkItemType' to process template"))  {
-      $resp = _callapi -Url $url -method  Post -body (ConvertTo-Json $body) -ErrorAction Stop
-      if ($resp) {
-         if ($ProcessTemplate -eq $env:TEAM_PROCESS) {[vsteam_lib.WorkItemTypeCache]::Invalidate()}
+            $resp.PSObject.TypeNames.Insert(0, 'vsteam_lib.WorkItemType')
+            Add-Member -InputObject $resp -MemberType AliasProperty -Name WorkItemType    -Value "name"
+            Add-Member -InputObject $resp -MemberType NoteProperty  -Name ProcessTemplate -Value $ProcessTemplate
 
-         $resp.PSObject.TypeNames.Insert(0, 'vsteam_lib.WorkItemType')
-         Add-Member -InputObject $resp -MemberType AliasProperty -Name WorkItemType    -Value "name"
-         Add-Member -InputObject $resp -MemberType NoteProperty  -Name ProcessTemplate -Value $ProcessTemplate
-
-         return $resp
+            return $resp
+         }
       }
    }
 }

--- a/Source/Public/Add-VSTeamWorkItemType.ps1
+++ b/Source/Public/Add-VSTeamWorkItemType.ps1
@@ -1,0 +1,68 @@
+$script:processTypeIds = @{}
+function _getProcessTemplateUrl {
+   Param (
+      [Parameter(Mandatory=$true,position=0)]
+      $ProcessTemplate
+   )
+   if ($script:processTypeIds[$ProcessTemplate]) {
+         return ((_getInstance) + "/_apis/work/processes/" + $script:processTypeIds[$ProcessTemplate] )
+   }
+   else {
+      $p = Get-VSTeamProcess $ProcessTemplate
+      if ($p -and $p.psobject.properties['typeID']) {
+         $script:processTypeIds[$ProcessTemplate] = $p.typeid
+         return ((_getInstance) + "/_apis/work/processes/" + $p.typeid )
+      }
+      elseif ($p -and $p.psobject.properties['Id']) {
+         $script:processTypeIds[$ProcessTemplate] = $p.Id
+         return ((_getInstance) + "/_apis/work/processes/" + $p.Id )
+      }
+   }
+}
+
+function Add-VSTeamWorkItemType {
+   [cmdletbinding(SupportsShouldProcess=$true)]
+   param(
+      [vsteam_lib.ProcessTemplateValidateAttribute()]
+      [ArgumentCompleter([vsteam_lib.ProcessTemplateCompleter])]
+      $ProcessTemplate = $env:TEAM_PROCESS,
+
+      [parameter(Mandatory = $true)]
+      [Alias('Name')]
+      [string] $WorkItemType,
+
+      [string] $Description,
+
+      [ArgumentCompleter([vsteam_lib.ColorCompleter])]
+      [vsteam_lib.ColorTransformToHexAttribute()]
+      $Color = '000000',
+
+      [vsteam_lib.IconTransformAttribute()]
+      [ArgumentCompleter([vsteam_lib.IconCompleter])]
+      [string]$Icon = 'icon_asterisk'
+   )
+
+   $url =  _getProcessTemplateUrl $ProcessTemplate
+   if ($url) {$url += "/workitemtypes?api-version=" + (_getApiVersion Processes)}
+   else      {Write-Warning "Could not convert '$ProcessTemplate' into a process template"; return}
+   
+   $body  = @{
+      name  = $WorkItemType
+      color = $Color 
+      icon  = $Icon
+   }
+   if ($Description)  {$body['description'] =$Description }
+   
+   if ($PSCmdlet.ShouldProcess($ProcessTemplate, "Add workitem '$WorkItemType' to process template"))  {
+      $resp = _callapi -Url $url -method  Post  -ContentType "application/json" -body (ConvertTo-Json $body) -erroraction stop
+      if ($resp) {
+         if ($ProcessTemplate -eq $env:TEAM_PROCESS) {[vsteam_lib.WorkItemTypeCache]::Invalidate()}
+
+         $resp.PSObject.TypeNames.Insert(0, 'vsteam_lib.WorkItemType')
+         Add-Member -InputObject $resp -MemberType AliasProperty -Name WorkItemType    -Value "name"
+         Add-Member -InputObject $resp -MemberType NoteProperty  -Name ProcessTemplate -Value $ProcessTemplate
+
+         return $resp
+      }
+   }
+}

--- a/Source/Public/Connect-VSTeam.ps1
+++ b/Source/Public/Connect-VSTeam.ps1
@@ -1,0 +1,129 @@
+function Connect-VSTeam {
+   [cmdletbinding(DefaultParameterSetName='None')]
+   param(
+      [parameter(Position=0)]
+      $Path = (Join-path ([System.Environment]::GetFolderPath("UserProfile"))  "VsTeamCred.xml"),
+
+      [parameter(ParameterSetName = 'None' )]
+      [parameter(ParameterSetName = 'Insecure' )]
+      [parameter(ParameterSetName = 'Secure'   )]
+      [parameter(ParameterSetName = 'Clipboard')]
+      [string] $Account = ([vsteam_lib.Versions]::Account -replace '^.*/'),
+
+      [parameter(ParameterSetName = 'Insecure',Mandatory=$true)]
+      [Alias('Token')]
+      [string] $PersonalAccessToken,
+
+      [parameter(ParameterSetName = 'Secure',Mandatory=$true)]
+      [Alias('PAT')]
+      [securestring] $SecurePersonalAccessToken,
+
+      [parameter(ParameterSetName = 'Clipboard',Mandatory=$true)]
+      [Alias('Clipboard')]
+      [switch] $TokenFromClipboard,
+
+      [parameter(ParameterSetName = 'Cred')]
+      [pscredential]$Credential,
+
+      [parameter(ParameterSetName = 'None',      Mandatory=$false)]
+      [parameter(ParameterSetName = 'Insecure',  Mandatory=$false)]
+      [parameter(ParameterSetName = 'Secure',    Mandatory=$false)]
+      [parameter(ParameterSetName = 'Clipboard', Mandatory=$false)]
+      [ArgumentCompleter([vsteam_lib.ProjectCompleter])]
+      [string] $Project ,
+
+      [ValidateSet('TFS2017', 'TFS2018', 'AzD2019', 'VSTS', 'AzD', 'TFS2017U1', 'TFS2017U2', 'TFS2017U3', 'TFS2018U1', 'TFS2018U2', 'TFS2018U3', 'AzD2019U1')]
+      [string] $Version,
+
+      [switch] $Save,
+
+      [switch] $UseBearerToken
+   )
+
+   if (-not $Project -and $Account -eq ([vsteam_lib.Versions]::Account -replace '^.*/') -and $env:TEAM_PROJECT) {
+      Write-Verbose "Setting the default project to the current project, ' $env:TEAM_PROJECT'.'"
+      $Project = $env:TEAM_PROJECT
+   }
+   elseif ( $Project -and $Account -ne "" -and $Account -eq ([vsteam_lib.Versions]::Account -replace '^.*/') ) {
+      $validProjects = [vsteam_lib.ProjectCache]::GetCurrent($false)
+      if ($validProjects.count -ge 1 -and $validProjects -notcontains $Project) {
+         Write-Warning "'$Project' is not a valid project name" ; return
+      }
+   }
+   # If account wasn't specified, and we're not overwriting creds, get saved creds if they exist.
+   if ( (Test-path $path -PathType Leaf) -and -not $Save -and -not $PSBoundParameters.ContainsKey('Account')) {
+      $Credential = Import-Clixml $Path
+   }
+   #if we didn't read creds but have a plain text token from a parameter or the clipboard make it a secure string
+   elseif ($PersonalAccessToken) {
+      $SecurePersonalAccessToken = ConvertTo-SecureString $PersonalAccessToken -AsPlainText -Force
+   }
+   elseif ($TokenFromClipboard) {
+      Write-Verbose "Getting Personal Access token from the clipboard."
+      try {
+         $SecurePersonalAccessToken = ConvertTo-SecureString (Get-Clipboard) -AsPlainText -Force
+      }
+      catch {
+         Write-Warning "Clipboard contents were not valid." ; return
+      }
+   }
+
+   # if we don't have the access token or credential object, get the credential from the user
+   if (-not ($SecurePersonalAccessToken -or $Credential )) {
+      $GCParams = @{Message =  "Use org org/project as a user name, e.g. from  https://dev.azure.com/My_Org/project and accesstoken as password"}
+      if ($PSVersionTable.Platform -like 'win*' -and $PSVersionTable.PSEdition -eq 'core') {
+         $GCParams['Title'] = "Use [shift][insert] or mouse to paste access token as password."
+      }
+      if ($Account) {$GCParams['UserName']=("$account/$project" -replace '/$')}
+      $Credential = Get-Credential @GCParams
+   }
+
+   # if we got the credential by reading from a file or user input, use the password
+   # as the token and username for account/project; and if we're saving do that here.
+   if ($Credential) {
+      $Account = ($Credential.UserName -split  '/|\\')[0]
+      Write-verbose "Account is '$Account'."
+      if (-not $PSBoundParameters.ContainsKey('Project')) {
+         $Project = ($Credential.UserName -split  '/|\\')[1]
+         Write-verbose "Project is '$Project'."
+      }
+      else {Write-verbose "Using input parameter '$Project' for Project." }
+
+      $SecurePersonalAccessToken = $Credential.Password
+      if ($Save) {
+         Write-verbose "Saving credential for $($Credential.UserName) to $path"
+         $credential | Export-Clixml -Path $Path
+      }
+   }
+   # but we were told to save a token and account and, make a credential and save it.
+   elseif ($SecurePersonalAccessToken -and $Account -and $Save ) {
+      $userName = ("$Account/$Project" -replace '/$')
+      Write-Verbose "Saving credential for '$UserName' to $path."
+      [pscredential]::new($userName,$SecurePersonalAccessToken) | Export-Clixml -Path $Path
+   }
+
+   #We should have account & token from parameters file or user input.
+   if (-not $Account -or -not $SecurePersonalAccessToken) {
+      Write-Warning "Can't connect without an account and an access token"; return
+   }
+   else {
+      Write-verbose "Logging on..."
+      $SetVSTAParams = @{
+         Account = $Account
+         UseBearerToken = [boolean]$UseBearerToken
+         SecurePersonalAccessToken = $SecurePersonalAccessToken
+      }
+      if ($Version) {$SetVSTAParams['Version']=$Version}
+      Set-VSTeamAccount @SetVSTAParams
+      if ($Project) {
+         Set-VSTeamDefaultProject -Project $Project
+<#       #this is Set-VSTeamDefaultProject -  for now.
+         $env:TEAM_PROCESS = [vsteam_lib.Versions]::DefaultProcess = Get-VSTeamProcess  -ExpandProjects |
+               Where-Object Projects -Contains $Project | Select-Object -ExpandProperty Name
+#>
+         if ($env:TEAM_PROCESS) {
+            Write-Verbose "Set default process template to '$env:TEAM_PROCESS'."
+         }
+      }
+   }
+}

--- a/Source/Public/Get-VSTeamIteration.ps1
+++ b/Source/Public/Get-VSTeamIteration.ps1
@@ -13,9 +13,13 @@ function Get-VSTeamIteration {
       [Parameter(Mandatory = $true, ValueFromPipelineByPropertyName = $true)]
       [vsteam_lib.ProjectValidateAttribute($false)]
       [ArgumentCompleter([vsteam_lib.ProjectCompleter])]
-      [string] $ProjectName
-   )
+      [string] $ProjectName,
 
+      [switch] $Expand
+   )
+   begin {
+      function _expand {param($i) Write-Output $i ; foreach ($c in $i.children) {_expand $c}}
+   }
    process {
       if ($PSCmdlet.ParameterSetName -eq "ByPath") {
          $resp = Get-VSTeamClassificationNode -ProjectName $ProjectName `
@@ -28,6 +32,7 @@ function Get-VSTeamIteration {
             -Depth $Depth `
             -Id $Id
       }
-      Write-Output $resp
+      if ($Expand) {_expand      $resp}
+      else         {Write-Output $resp}
    }
 }

--- a/Source/Public/Get-VSTeamProcess.ps1
+++ b/Source/Public/Get-VSTeamProcess.ps1
@@ -74,7 +74,7 @@ function Get-VSTeamProcess {
             # We just fetched all the processes so let's update the cache.
             [vsteam_lib.ProcessTemplateCache]::Update([string[]]$($resp | Select-Object -ExpandProperty Name ))
 
-            foreach ($process in $resp.where({ $_.name -like $Name })) {
+            foreach ($process in $resp.where({foreach($n in $Name) {if($_.name -like $n){$true}}})) {
                if   ($process.psobject.Members.name -contains "projects") {
                      $process.projects = [string[]]($process.projects.name)
                }

--- a/Source/Public/Get-VSTeamProcessBehavior.ps1
+++ b/Source/Public/Get-VSTeamProcessBehavior.ps1
@@ -12,15 +12,15 @@ function Get-VSTeamProcessBehavior {
       if (-not $wit) {
          Write-Warning "Could not get WorkItem types for Process '$ProcessTemplate'." ; return
       }
-      # could use $url = _getProcessTemplateUrl $ProcessTemplate, but quicker to get use the URL on a workitem type
+      # could use $url = _getProcessTemplateUrl $ProcessTemplate, but quicker to use the URL from any WorkItem type object
       else { $url = $wit[0].url -replace '/workitemTypes/.*$', ''}
-      
+
       $url = $url +'/behaviors?$expand=combinedFields&api-version=' + (_getApiVersion Processes)
       $resp =$resp = _callApi -url $url
 
       $resp = $resp.value | Sort-Object -Property @{e="Rank"; Descending=$true},
                         @{e={$_.inherits.behaviorRefName};Descending=$true}
-      
+
       foreach ($r in $resp) {
             # Apply a Type Name so we can use custom format view and custom type extensions
             # and add the processTemplate name so it can become a parameter when the object is piped into other functions

--- a/Source/Public/Get-VSTeamProcessBehavior.ps1
+++ b/Source/Public/Get-VSTeamProcessBehavior.ps1
@@ -1,0 +1,35 @@
+
+function Get-VSTeamProcessBehavior {
+   [CmdletBinding()]
+   param (
+      [Parameter(ValueFromPipelineByPropertyName=$true,Position=1)]
+      [vsteam_lib.ProcessTemplateValidateAttribute()]
+      [ArgumentCompleter([vsteam_lib.ProcessTemplateCompleter])]
+      $ProcessTemplate = $env:TEAM_PROCESS
+   )
+   Process {
+      $wit = Get-VSTeamWorkItemType -ProcessTemplate $ProcessTemplate -Expand Behaviors
+      if (-not $wit) {
+         Write-Warning "Could not get WorkItem types for Process '$ProcessTemplate'." ; return
+      }
+      # could use $url = _getProcessTemplateUrl $ProcessTemplate, but quicker to get use the URL on a workitem type
+      else { $url = $wit[0].url -replace '/workitemTypes/.*$', ''}
+      
+      $url = $url +'/behaviors?$expand=combinedFields&api-version=' + (_getApiVersion Processes)
+      $resp =$resp = _callApi -url $url
+
+      $resp = $resp.value | Sort-Object -Property @{e="Rank"; Descending=$true},
+                        @{e={$_.inherits.behaviorRefName};Descending=$true}
+      
+      foreach ($r in $resp) {
+            # Apply a Type Name so we can use custom format view and custom type extensions
+            # and add the processTemplate name so it can become a parameter when the object is piped into other functions
+            $r.psobject.TypeNames.Insert(0,'vsteam_lib.Processbehavior')
+            $linkedWits = $wit.where({$_.behaviors.behavior.id -eq $r.referenceName}).name -Join ', '
+            Add-Member -InputObject $r -MemberType NoteProperty -Name LinkedWorkItemTypes -Value $linkedWits
+            Add-Member -InputObject $r -MemberType NoteProperty -Name ProcessTemplate     -Value $ProcessTemplate
+      }
+
+      return $resp
+   }
+}

--- a/Source/Public/Get-VSTeamProcessBehavior.ps1
+++ b/Source/Public/Get-VSTeamProcessBehavior.ps1
@@ -8,28 +8,26 @@ function Get-VSTeamProcessBehavior {
       $ProcessTemplate = $env:TEAM_PROCESS
    )
    Process {
-      $wit = Get-VSTeamWorkItemType -ProcessTemplate $ProcessTemplate -Expand Behaviors
-      if (-not $wit) {
-         Write-Warning "Could not get WorkItem types for Process '$ProcessTemplate'." ; return
+      foreach ($p in $ProcessTemplate){
+         $wit = Get-VSTeamWorkItemType -ProcessTemplate $P -Expand Behaviors
+         # could use $url = _getProcessTemplateUrl $ProcessTemplate, but quicker to use the URL from any WorkItem type object
+         $url  = $wit[0].url -replace '/workitemTypes/.*$', ''
+         $url  = $url +'/behaviors?$expand=combinedFields&api-version=' + (_getApiVersion Processes)
+
+         # Call the REST API
+         $resp = _callApi -url $url
+         $resp = $resp.value | Sort-Object -Property @{e="Rank"; Descending=$true},
+                           @{e={$_.inherits.behaviorRefName};Descending=$true}
+
+         foreach ($r in $resp) {
+               # Apply a Type Name so we can use custom format view and custom type extensions
+               # and add the processTemplate name so it can become a parameter when the object is piped into other functions
+               $r.psobject.TypeNames.Insert(0,'vsteam_lib.Processbehavior')
+               $linkedWits = $wit.where({$_.behaviors.behavior.id -eq $r.referenceName}).name -Join ', '
+               Add-Member -InputObject $r -MemberType NoteProperty -Name LinkedWorkItemTypes -Value $linkedWits
+               Add-Member -InputObject $r -MemberType NoteProperty -Name ProcessTemplate     -Value $wit[0].ProcessTemplate
+         }
+         Write-Output $resp
       }
-      # could use $url = _getProcessTemplateUrl $ProcessTemplate, but quicker to use the URL from any WorkItem type object
-      else { $url = $wit[0].url -replace '/workitemTypes/.*$', ''}
-
-      $url = $url +'/behaviors?$expand=combinedFields&api-version=' + (_getApiVersion Processes)
-      $resp =$resp = _callApi -url $url
-
-      $resp = $resp.value | Sort-Object -Property @{e="Rank"; Descending=$true},
-                        @{e={$_.inherits.behaviorRefName};Descending=$true}
-
-      foreach ($r in $resp) {
-            # Apply a Type Name so we can use custom format view and custom type extensions
-            # and add the processTemplate name so it can become a parameter when the object is piped into other functions
-            $r.psobject.TypeNames.Insert(0,'vsteam_lib.Processbehavior')
-            $linkedWits = $wit.where({$_.behaviors.behavior.id -eq $r.referenceName}).name -Join ', '
-            Add-Member -InputObject $r -MemberType NoteProperty -Name LinkedWorkItemTypes -Value $linkedWits
-            Add-Member -InputObject $r -MemberType NoteProperty -Name ProcessTemplate     -Value $ProcessTemplate
-      }
-
-      return $resp
    }
 }

--- a/Source/Public/Get-VSTeamSetting.ps1
+++ b/Source/Public/Get-VSTeamSetting.ps1
@@ -35,19 +35,27 @@ Function Get-VSTeamSetting {
 
       $settings = _callapi @params
       switch ($true) {
-         $BacklogIteration   {if ($settings.backlogIteration.psobject.properties.name -contains "url"){
-                                 $resp = _callAPI -url $settings.backlogIteration.url
-                                 return [vsteam_lib.ClassificationNode]::new($resp, $ProjectName)
-                           }}
-         $DefaultIteration   {if ($settings.defaultIteration.psobject.properties.name -contains "url"){
-                                 $resp = _callAPI -url $settings.defaultIteration.url
-                                 return [vsteam_lib.ClassificationNode]::new($resp, $ProjectName)
-                           }}
-         $BackLogVisibilites { $settings.backlogVisibilities.psobject.properties | Select-Object name, value   |
-                              Write-Output}
-         $BugsBehavior       { return $settings.bugsBehavior }
-         $WorkingDays        { return $settings.workingDays  }
-         Default             { return $settings }
+         $BacklogIteration   {
+                           if ($settings.backlogIteration.psobject.properties.name -contains "url"){
+                              $resp = _callAPI -url $settings.backlogIteration.url
+
+                              return [vsteam_lib.ClassificationNode]::new($resp, $ProjectName)
+                           }
+         }
+         $DefaultIteration   {
+                           if ($settings.defaultIteration.psobject.properties.name -contains "url"){
+                              $resp = _callAPI -url $settings.defaultIteration.url
+
+                              return [vsteam_lib.ClassificationNode]::new($resp, $ProjectName)
+                            }
+         }
+         $BackLogVisibilites {
+                              $settings.backlogVisibilities.psobject.properties | Select-Object name, value   |
+                              Write-Output
+         }
+         $BugsBehavior       {return $settings.bugsBehavior }
+         $WorkingDays        {return $settings.workingDays  }
+         default             {return $settings }
       }
    }
 }

--- a/Source/Public/Get-VSTeamSetting.ps1
+++ b/Source/Public/Get-VSTeamSetting.ps1
@@ -26,27 +26,28 @@ Function Get-VSTeamSetting {
       [Parameter(ParameterSetName="WorkingDays")]
       [switch]$WorkingDays
    )
+   process {
+      $params = @{Area            ='work'
+                  Resource        ='teamsettings'
+                  ProjectName     = $ProjectName
+      }
+      if ($Team) {$params["Team"] = $Team}
 
-   $params = @{Area            ='work'
-               Resource        ='teamsettings'
-               ProjectName     = $ProjectName
-   }
-   if ($Team) {$params["Team"] = $Team}
-
-   $settings = _callapi @params
-   switch ($true) {
-      $BacklogIteration   {if ($settings.backlogIteration.psobject.properties.name -contains "url"){
-                              $resp = _callAPI -url $settings.backlogIteration.url
-                              return [vsteam_lib.ClassificationNode]::new($resp, $ProjectName)
-                          }}
-      $DefaultIteration   {if ($settings.defaultIteration.psobject.properties.name -contains "url"){
-                              $resp = _callAPI -url $settings.defaultIteration.url
-                              return [vsteam_lib.ClassificationNode]::new($resp, $ProjectName)
-                          }}
-      $BackLogVisibilites { $settings.backlogVisibilities.psobject.properties | Select-Object name, value   |
-                           Write-Output}
-      $BugsBehavior       { return $settings.bugsBehavior }
-      $WorkingDays        { return $settings.workingDays  }
-      Default             { return $settings }
+      $settings = _callapi @params
+      switch ($true) {
+         $BacklogIteration   {if ($settings.backlogIteration.psobject.properties.name -contains "url"){
+                                 $resp = _callAPI -url $settings.backlogIteration.url
+                                 return [vsteam_lib.ClassificationNode]::new($resp, $ProjectName)
+                           }}
+         $DefaultIteration   {if ($settings.defaultIteration.psobject.properties.name -contains "url"){
+                                 $resp = _callAPI -url $settings.defaultIteration.url
+                                 return [vsteam_lib.ClassificationNode]::new($resp, $ProjectName)
+                           }}
+         $BackLogVisibilites { $settings.backlogVisibilities.psobject.properties | Select-Object name, value   |
+                              Write-Output}
+         $BugsBehavior       { return $settings.bugsBehavior }
+         $WorkingDays        { return $settings.workingDays  }
+         Default             { return $settings }
+      }
    }
 }

--- a/Source/Public/Get-VSTeamSetting.ps1
+++ b/Source/Public/Get-VSTeamSetting.ps1
@@ -1,0 +1,52 @@
+Function Get-VSTeamSetting {
+   [CmdletBinding(DefaultParameterSetName="Default")]
+   Param (
+
+      [Parameter(Mandatory = $True, Position = 1)]
+      [vsteam_lib.ProjectValidateAttribute($false)]
+      [ArgumentCompleter([vsteam_lib.ProjectCompleter])]
+      $ProjectName,
+
+      [Parameter(Mandatory = $false, Position = 0, ValueFromPipelineByPropertyName=$true)]
+      [Alias('Name')]
+      [string]$Team,
+
+      [Parameter(ParameterSetName="DefaultIteration")]
+      [switch]$DefaultIteration,
+
+      [Parameter(ParameterSetName="BackLogIteration")]
+      [switch]$BackLogIteration,
+
+      [Parameter(ParameterSetName="BackLogVisibilites")]
+      [switch]$BackLogVisibilites,
+
+      [Parameter(ParameterSetName="BugsBehavior")]
+      [switch]$BugsBehavior,
+
+      [Parameter(ParameterSetName="WorkingDays")]
+      [switch]$WorkingDays
+   )
+
+   $params = @{Area            ='work'
+               Resource        ='teamsettings'
+               ProjectName     = $ProjectName
+   }
+   if ($Team) {$params["Team"] = $Team}
+
+   $settings = _callapi @params
+   switch ($true) {
+      $BacklogIteration   {if ($settings.backlogIteration.psobject.properties.name -contains "url"){
+                              $resp = _callAPI -url $settings.backlogIteration.url
+                              return [vsteam_lib.ClassificationNode]::new($resp, $ProjectName)
+                          }}
+      $DefaultIteration   {if ($settings.defaultIteration.psobject.properties.name -contains "url"){
+                              $resp = _callAPI -url $settings.defaultIteration.url
+                              return [vsteam_lib.ClassificationNode]::new($resp, $ProjectName)
+                          }}
+      $BackLogVisibilites { $settings.backlogVisibilities.psobject.properties | Select-Object name, value   |
+                           Write-Output}
+      $BugsBehavior       { return $settings.bugsBehavior }
+      $WorkingDays        { return $settings.workingDays  }
+      Default             { return $settings }
+   }
+}

--- a/Source/Public/Get-VSTeamWorkItemBehavior.ps1
+++ b/Source/Public/Get-VSTeamWorkItemBehavior.ps1
@@ -1,0 +1,31 @@
+
+function Get-VSTeamWorkItemBehavior {
+   [CmdletBinding()]
+   param (
+      [Parameter( ValueFromPipelineByPropertyName=$true)]
+      [vsteam_lib.ProcessTemplateValidateAttribute()]
+      [ArgumentCompleter([vsteam_lib.ProcessTemplateCompleter])]
+      $ProcessTemplate = $env:TEAM_PROCESS,
+
+      [parameter(Mandatory = $true,ValueFromPipelineByPropertyName=$true, Position=1 )]
+      [ArgumentCompleter([vsteam_lib.WorkItemTypeCompleter])]
+      [string]$WorkItemType
+   )
+   process {
+      $expandedItemTypes = Get-VSTeamWorkItemType -ProcessTemplate $ProcessTemplate -WorkItemType $WorkItemType -Expand Behaviors
+      foreach ($wit in $expandedItemTypes) {
+         $behaviors = $wit.behaviors
+         if (-not $behaviors) {Write-Warning "$($wit.name) has no behaviors." }
+         else { 
+            foreach ($b in $behaviors) {
+               $b.psobject.TypeNames.Insert(0,'vsteam_lib.WorkItembehavior')
+               Add-Member -InputObject $b -MemberType ScriptProperty -Name BehaviorID      -Value {$this.behavior.id}
+               Add-Member -InputObject $b -MemberType NoteProperty   -Name WorkItemType    -Value $wit.name
+               Add-Member -InputObject $b -MemberType NoteProperty   -Name ProcessTemplate -Value $ProcessTemplate 
+            }
+
+            Write-Output $behaviors
+        }
+      }
+   }
+}

--- a/Source/Public/Get-VSTeamWorkItemIconList.ps1
+++ b/Source/Public/Get-VSTeamWorkItemIconList.ps1
@@ -1,0 +1,18 @@
+function Get-VSTeamWorkItemIconList {
+   [CmdletBinding()]
+   param()
+
+   process {
+
+      $commonArgs = @{
+         Area                 = 'wit' 
+         Resource             = 'workitemicons'
+         IgnoreDefaultProject = $true
+         Version              = $(_getApiVersion Processes)
+      }
+      # Call the REST API
+      $resp = _callAPI @commonArgs 
+
+      Write-Output $resp.value
+   }
+}

--- a/Source/Public/Get-VSTeamWorkItemType.ps1
+++ b/Source/Public/Get-VSTeamWorkItemType.ps1
@@ -58,35 +58,39 @@ function Get-VSTeamWorkItemType {
             Add-Member -InputObject $item  -MemberType NoteProperty -Name "Hidden" -Value ($item.name -in $hidden)
          }
          if ($NotHidden.IsPresent) {
-            $resp = $resp | Where-Object -not Hidden
+            $result = $resp | Where-Object -not Hidden
+         }
+         else {
+            $result = $resp
          }
          if ($ProjectName -eq $env:TEAM_PROJECT -and $env:TEAM_PROCESS) {$ProcessTemplate = $env:TEAM_PROCESS}
+         if ($ProcessTemplate) {
+            $result | Add-Member -MemberType NoteProperty  -Name "ProcessTemplate" -Value $ProcessTemplate
+         }
       }
       else {
-         $url = _getProcessTemplateUrl $ProcessTemplate
-         if (-not $url) {Write-Warning "Could not find the Process for '$ProcessTemplate" ; return}
-         else           { $url += "/workitemtypes?api-version=" + (_getApiVersion Processes)}
-
-         if ($Expand) { $resp = _callAPI -Url $url -QueryString @{'$expand' = ($Expand -Join ',').ToLower() }    }
-         else         { $resp = _callapi -Url $url }
-
-         $resp = $resp.value
+         $result = @()
+         foreach ($pt in $ProcessTemplate) {
+            $url = _getProcessTemplateUrl $pt
+            if (-not $url) {Write-Warning "Could not find the Process for '$pt" ; continuye}
+            else           { $url += "/workitemtypes?api-version=" + (_getApiVersion Processes)}
+            if ($Expand) { $resp = _callAPI -Url $url -QueryString @{'$expand' = ($Expand -Join ',').ToLower() }    }
+            else         { $resp = _callapi -Url $url }
+            $resp.value | Add-Member -MemberType NoteProperty  -Name "ProcessTemplate" -Value $pt
+            $result += $resp.value
+         }
       }
-
       <# Apply a Type Name so we can use custom format view and custom type extensions
          add an alias so that workitemType can become a parameter when the object is piped into other functions
          and the processTemplate name (if there is one) for the same reason.
          And finally return the items, filtered to any name we given
       #>
-      foreach ($item in $resp) {
+      foreach ($item in $result) {
          _applyTypesWorkItemType -item $item
          Add-Member    -InputObject $item -MemberType AliasProperty -Name "WorkItemType"    -Value "name"
-         if ($ProcessTemplate) {
-            Add-Member -InputObject $item -MemberType NoteProperty  -Name "ProcessTemplate" -Value $ProcessTemplate
-         }
       }
-      #Allow the $WorkItemType to contain wild cards and multiple items, by converting to regex
+      #Allow the $WorkItemType to contain wild cards AND multiple items, by converting to regex
       $regex = "^" + ($WorkItemType -replace '\*','.*' -replace '\?','.' -join '$|^') + '$'
-      return ($resp | Where-Object -Property Name -match $regex)
+      return ($result | Where-Object -Property Name -match $regex)
    }
 }

--- a/Source/Public/Get-VSTeamWorkItemType.ps1
+++ b/Source/Public/Get-VSTeamWorkItemType.ps1
@@ -2,50 +2,83 @@ function Get-VSTeamWorkItemType {
    [CmdletBinding(DefaultParameterSetName = 'List',
     HelpUri='https://methodsandpractices.github.io/vsteam-docs/docs/modules/vsteam/commands/Get-VSTeamWorkItemType')]
    param(
-      [Parameter(Mandatory = $true, ValueFromPipelineByPropertyName = $true)]
+      [Parameter(ParameterSetName = 'List',  Mandatory = $true, ValueFromPipelineByPropertyName = $true)]
+      [parameter(ParameterSetName='Process', Mandatory = $false)]
       [vsteam_lib.ProjectValidateAttribute($false)]
       [ArgumentCompleter([vsteam_lib.ProjectCompleter])]
       [string] $ProjectName,
 
+      [parameter(ParameterSetName='Process', Mandatory = $true , ValueFromPipelineByPropertyName = $true)]
+      [vsteam_lib.ProcessTemplateValidateAttribute()]
+      [ArgumentCompleter([vsteam_lib.ProcessTemplateCompleter])]
+      $ProcessTemplate,
+
       [Parameter()]
-      [vsteam_lib.WorkItemTypeValidateAttribute()]
       [ArgumentCompleter([vsteam_lib.WorkItemTypeCompleter])]
-      [string] $WorkItemType
+      [string] $WorkItemType = '*',
+
+      [parameter(ParameterSetName='Process',ValueFromPipelineByPropertyName=$true)]
+      [ValidateSet('behaviors','layout','states')]
+      [string[]]$Expand
    )
 
-   Process {
-      # Call the REST API
+   process {
+      <# Call the REST API in one of 2 ways; 
+        if process template is given, then call as work/processes/workitemtypes (this API doesn't take a workitem ID, and so always returns multiple values)
+        otherwise call as wit/workitemtypes  (JSON needs special conversion and contains mutliple  values)
+        DON'T validate $workitem type and call with wit/workitemtypes/name - instead allow wildcards and filter down  the workitem(s) will be in $resp after the IF / ELSE 
+      #>
       $commonArgs = @{
          ProjectName = $ProjectName
          Area        = 'wit'
          Resource    = 'workitemtypes'
          Version     = $(_getApiVersion Core)
       }
-
-      if ($WorkItemType) {
-         $resp = _callAPI @commonArgs -id $WorkItemType
-
-         # This call returns JSON with "": which causes the ConvertFrom-Json to fail.
-         # To replace all the "": with "_end":
-         $resp = $resp.Replace('"":', '"_end":') | ConvertFrom-Json
-
-         _applyTypesWorkItemType -item $resp
-
-         return $resp
-      }
-      else {
+      if (-not $ProcessTemplate) {
          $resp = _callAPI @commonArgs
 
          # This call returns JSON with "": which causes the ConvertFrom-Json to fail.
          # To replace all the "": with "_end":
-         $resp = $resp.Replace('"":', '"_end":') | ConvertFrom-Json
+         $resp = $resp.Replace('"":', '"_end":') | ConvertFrom-Json | Select-Object -ExpandProperty Value
 
-         # Apply a Type Name so we can use custom format view and custom type extensions
-         foreach ($item in $resp.value) {
-            _applyTypesWorkItemType -item $item
+         #Find Workitem-Types that are hidden in this project 
+         #(they may be visible in others using the same process template)
+         $commonArgs.Resource = 'workitemtypecategories'
+         $resp2  = _callAPI @commonArgs
+         if (-not $resp2) {$hidden = @() }
+         else             {$hidden = $resp2.value.where({$_.referencename -eq "Microsoft.HiddenCategory"}).workitemtypes.name}
+
+         #Add a property named "hidden" to workitem types, so we can filter pick-lists to visible itmes only later.
+         foreach ($item in $resp) {
+            Add-Member -InputObject $item  -MemberType NoteProperty -Name "Hidden" -Value ($item.name -in $hidden)
          }
 
-         return $resp.value
+         if ($ProjectName -eq $env:TEAM_PROJECT -and $env:TEAM_PROCESS) {$ProcessTemplate = $env:TEAM_PROCESS}
       }
+      else {  
+         $url = _getProcessTemplateUrl $ProcessTemplate
+         if (-not $url) {Write-Warning "Could not find the Process for '$ProcessTemplate" ; return}
+         else           { $url += "/workitemtypes?api-version=" + (_getApiVersion Processes)}
+         
+         if ($Expand) { $resp = _callAPI -Url $url -QueryString @{'$expand' = ($Expand -Join ',').ToLower() }    }
+         else         { $resp = _callapi -Url $url }
+
+         $resp = $resp.value 
+      }
+
+      <# Apply a Type Name so we can use custom format view and custom type extensions
+         add an alias so that workitemType can become a parameter when the object is piped into other functions
+         and the processTemplate name (if there is one) for the same reason. 
+         And finally return the items, filtered to any name we given
+      #>
+      foreach ($item in $resp) {
+         _applyTypesWorkItemType -item $item
+         Add-Member    -InputObject $item -MemberType AliasProperty -Name "WorkItemType"    -Value "name"
+         if ($ProcessTemplate) {
+            Add-Member -InputObject $item -MemberType NoteProperty  -Name "ProcessTemplate" -Value $ProcessTemplate
+         }
+      }
+
+      return ($resp | Where-Object -Property Name -like $WorkItemType)
    }
 }

--- a/Source/Public/Get-VSTeamWorkItemType.ps1
+++ b/Source/Public/Get-VSTeamWorkItemType.ps1
@@ -15,7 +15,7 @@ function Get-VSTeamWorkItemType {
 
       [Parameter(Position=0)]
       [ArgumentCompleter([vsteam_lib.WorkItemTypeCompleter])]
-      [string] $WorkItemType = '*',
+      [string[]] $WorkItemType = '*',
 
       [parameter(ParameterSetName='Process',ValueFromPipelineByPropertyName=$true)]
       [ValidateSet('behaviors','layout','states')]
@@ -85,7 +85,8 @@ function Get-VSTeamWorkItemType {
             Add-Member -InputObject $item -MemberType NoteProperty  -Name "ProcessTemplate" -Value $ProcessTemplate
          }
       }
-
-      return ($resp | Where-Object -Property Name -like $WorkItemType)
+      #Allow the $WorkItemType to contain wild cards and multiple items, by converting to regex
+      $regex = "^" + ($WorkItemType -replace '\*','.*' -replace '\?','.' -join '$|^') + '$'
+      return ($resp | Where-Object -Property Name -match $regex)
    }
 }

--- a/Source/Public/Remove-VSTeamProcess.ps1
+++ b/Source/Public/Remove-VSTeamProcess.ps1
@@ -1,0 +1,26 @@
+function Remove-VSTeamProcess {
+   [CmdletBinding(DefaultParameterSetName='LeaveAlone',SupportsShouldProcess=$true,ConfirmImpact='High')]
+   param (
+      [parameter(Mandatory = $true,ValueFromPipelineByPropertyName=$true,Position=1)]
+      [vsteam_lib.ProcessTemplateValidateAttribute()]
+      [ArgumentCompleter([vsteam_lib.ProcessTemplateCompleter])]
+      [Alias('Name','ProcessName')]
+      $ProcessTemplate,
+
+      [switch]$Force
+   )
+   process {
+      forEach ($p in $ProcessTemplate){
+         $url =  (_getProcessTemplateUrl $p.toString()) + "?api-version=" + (_getApiVersion Processes)
+         if ($Force -or $PSCmdlet.ShouldProcess($P,'DELETE Process template')) {
+            try {
+               # Call the REST API
+               $null = _callAPI -method Delete -url $url
+            }
+            Catch {
+               Write-Error -Category InvalidResult -Activity "Remove-VSWorkItemProcess"  -Message "An error occured trying to remove $p"
+            }
+         }
+      }
+   }
+}

--- a/Source/Public/Remove-VSTeamProcessBehavior.ps1
+++ b/Source/Public/Remove-VSTeamProcessBehavior.ps1
@@ -1,0 +1,31 @@
+function Remove-VSTeamProcessBehavior {
+   [CmdletBinding(SupportsShouldProcess=$true,ConfirmImpact='High')]
+   param (
+      [Parameter(ValueFromPipelineByPropertyName=$true,Position=1)]
+      [vsteam_lib.ProcessTemplateValidateAttribute()]
+      [ArgumentCompleter([vsteam_lib.ProcessTemplateCompleter])]
+      $ProcessTemplate = $env:TEAM_PROCESS,
+
+      [Parameter(Mandatory=$true,Position=1)]
+      [string]
+      $Name,
+
+      [switch]
+      $Force
+   )
+   Process {
+      
+      $behavior = Get-VSTeamProcessBehavior -ProcessTemplate $ProcessTemplate | 
+                     Where-Object -Property name -eq $Name
+
+      if (-not $behavior) {Write-Warning "'$Name' is not a process behavior in $ProcessTemplate" ; return}
+      $Params= @{
+         url         = $behavior.url + "?api-version=" + (_getApiVersion Processes) 
+         method      = 'Delete'
+      }
+      if ($Force -or $PSCmdlet.ShouldProcess($ProcessTemplate,"Remove behavior named '$Name' from process")) {
+         #Call the Rest API
+         $null = _callAPI @params 
+      }
+   }
+}

--- a/Source/Public/Remove-VSTeamProcessBehavior.ps1
+++ b/Source/Public/Remove-VSTeamProcessBehavior.ps1
@@ -14,18 +14,18 @@ function Remove-VSTeamProcessBehavior {
       $Force
    )
    Process {
-      
-      $behavior = Get-VSTeamProcessBehavior -ProcessTemplate $ProcessTemplate | 
+
+      $behavior = Get-VSTeamProcessBehavior -ProcessTemplate $ProcessTemplate |
                      Where-Object -Property name -eq $Name
 
       if (-not $behavior) {Write-Warning "'$Name' is not a process behavior in $ProcessTemplate" ; return}
       $Params= @{
-         url         = $behavior.url + "?api-version=" + (_getApiVersion Processes) 
+         url         = $behavior.url + "?api-version=" + (_getApiVersion Processes)
          method      = 'Delete'
       }
       if ($Force -or $PSCmdlet.ShouldProcess($ProcessTemplate,"Remove behavior named '$Name' from process")) {
          #Call the Rest API
-         $null = _callAPI @params 
+         $null = _callAPI @params
       }
    }
 }

--- a/Source/Public/Remove-VSTeamProcessBehavior.ps1
+++ b/Source/Public/Remove-VSTeamProcessBehavior.ps1
@@ -14,18 +14,19 @@ function Remove-VSTeamProcessBehavior {
       $Force
    )
    Process {
+      foreach ($p in $ProcessTemplate) {
+         $behavior = Get-VSTeamProcessBehavior -ProcessTemplate $p |
+                        Where-Object -Property name -eq $Name
 
-      $behavior = Get-VSTeamProcessBehavior -ProcessTemplate $ProcessTemplate |
-                     Where-Object -Property name -eq $Name
-
-      if (-not $behavior) {Write-Warning "'$Name' is not a process behavior in $ProcessTemplate" ; return}
-      $Params= @{
-         url         = $behavior.url + "?api-version=" + (_getApiVersion Processes)
-         method      = 'Delete'
-      }
-      if ($Force -or $PSCmdlet.ShouldProcess($ProcessTemplate,"Remove behavior named '$Name' from process")) {
-         #Call the Rest API
-         $null = _callAPI @params
+         if (-not $behavior) {Write-Warning "'$Name' is not a process behavior in $p" ; return}
+         $Params= @{
+            url         = $behavior.url + "?api-version=" + (_getApiVersion Processes)
+            method      = 'Delete'
+         }
+         if ($Force -or $PSCmdlet.ShouldProcess($p,"Remove behavior named '$Name' from process")) {
+            #Call the Rest API
+            $null = _callAPI @params
+         }
       }
    }
 }

--- a/Source/Public/Remove-VSTeamWorkItemType.ps1
+++ b/Source/Public/Remove-VSTeamWorkItemType.ps1
@@ -1,0 +1,32 @@
+function Remove-VSTeamWorkItemType {
+   [CmdletBinding(DefaultParameterSetName='LeaveAlone',SupportsShouldProcess=$true,ConfirmImpact='High')]
+   param(
+      [parameter(Mandatory = $true,ValueFromPipelineByPropertyName=$true)]
+      [vsteam_lib.ProcessTemplateValidateAttribute()]
+      [ArgumentCompleter([vsteam_lib.ProcessTemplateCompleter])]
+      $ProcessTemplate,
+
+      [parameter(Mandatory = $true,ValueFromPipelineByPropertyName=$true)]
+      [ArgumentCompleter([vsteam_lib.WorkItemTypeCompleter])]
+      [Alias('Name')]
+      $WorkItemType,
+
+      [switch]$Force
+   )
+   process {
+      #Get the existing workitem-type definition. Drop out if can't be found or if it is a system type 
+      $wit  = Get-VSTeamWorkItemType -ProcessTemplate $ProcessTemplate -WorkItemType $WorkItemType
+      if (-not $wit) {Write-Warning "'$workitemType' does not appear to be a valid Workitem type." ; return}
+      elseif  ($wit.customization -eq 'System') {
+          throw "'$workitemType' is a system WorkItem type and cannot be deleted (but can be disabled)." ; return
+      }
+      else {$url  = "$($wit.url)?api-version=" + (_getApiVersion Processes)  }
+      
+      if ($Force -or $PSCmdlet.ShouldProcess($WorkItemType,"Modify $ProcessTemplate to delete definition of Workitem type") ) {
+         # Call the rest API - nothing to return, if this is the current process invalidate the cache of WorkItemTypeNames.
+         $null =  _callapi -Url $url -method  Delete
+
+         if ($env:TEAM_PROCESS -eq $ProcessTemplate) {[vsteam_lib.WorkItemTypeCache]::Invalidate()}
+      }
+   }
+}

--- a/Source/Public/Remove-VSTeamWorkItemType.ps1
+++ b/Source/Public/Remove-VSTeamWorkItemType.ps1
@@ -14,19 +14,19 @@ function Remove-VSTeamWorkItemType {
       [switch]$Force
    )
    process {
-      #Get the existing workitem-type definition. Drop out if can't be found or if it is a system type 
-      $wit  = Get-VSTeamWorkItemType -ProcessTemplate $ProcessTemplate -WorkItemType $WorkItemType
-      if (-not $wit) {Write-Warning "'$workitemType' does not appear to be a valid Workitem type." ; return}
-      elseif  ($wit.customization -eq 'System') {
-          throw "'$workitemType' is a system WorkItem type and cannot be deleted (but can be disabled)." ; return
-      }
-      else {$url  = "$($wit.url)?api-version=" + (_getApiVersion Processes)  }
-      
-      if ($Force -or $PSCmdlet.ShouldProcess($WorkItemType,"Modify $ProcessTemplate to delete definition of Workitem type") ) {
-         # Call the rest API - nothing to return, if this is the current process invalidate the cache of WorkItemTypeNames.
-         $null =  _callapi -Url $url -method  Delete
+      #Get the existing workitem-type definition. Drop out if can't be found or if it is a system type
+      $wit  = Get-VSTeamWorkItemType -ProcessTemplate $ProcessTemplate -WorkItemType $WorkItemType |
+               Where-Object -Property customization -NE 'System'
+      if (-not $wit) {Write-Warning "'$workitemType' does not match a user defined Workitem type." ; return}
 
-         if ($env:TEAM_PROCESS -eq $ProcessTemplate) {[vsteam_lib.WorkItemTypeCache]::Invalidate()}
+      foreach ($w in $wit) {
+         $url  = "$($w.url)?api-version=" + (_getApiVersion Processes)
+         if ($Force -or $PSCmdlet.ShouldProcess($w.name,"Modify $ProcessTemplate : delete definition of Workitem type.") ) {
+            # Call the rest API - nothing to return, if this is the current process invalidate the cache of WorkItemTypeNames.
+            $null =  _callapi -Url $url -method  Delete
+
+            if ($env:TEAM_PROCESS -eq $ProcessTemplate) {[vsteam_lib.WorkItemTypeCache]::Invalidate()}
+         }
       }
    }
 }

--- a/Source/Public/Remove-VSTeamWorkItemType.ps1
+++ b/Source/Public/Remove-VSTeamWorkItemType.ps1
@@ -6,7 +6,7 @@ function Remove-VSTeamWorkItemType {
       [ArgumentCompleter([vsteam_lib.ProcessTemplateCompleter])]
       $ProcessTemplate,
 
-      [parameter(Mandatory = $true,ValueFromPipelineByPropertyName=$true)]
+      [parameter(Mandatory = $true,ValueFromPipelineByPropertyName=$true,Position=0)]
       [ArgumentCompleter([vsteam_lib.WorkItemTypeCompleter])]
       [Alias('Name')]
       $WorkItemType,

--- a/Source/Public/Set-VSTeamAccount.ps1
+++ b/Source/Public/Set-VSTeamAccount.ps1
@@ -68,6 +68,10 @@ function Set-VSTeamAccount {
       # invalidate cache when changing account/collection
       # otherwise dynamic parameters being picked for a wrong collection
       [vsteam_lib.ProjectCache]::Invalidate()
+      [vsteam_lib.ProcessTemplateCache]::Invalidate()
+      [vsteam_lib.IconCache]::Invalidate()
+      [vsteam_lib.QueryCache]::Invalidate()
+      [vsteam_lib.WorkItemTypeCache]::Invalidate()
 
       # Bind the parameter to a friendly variable
       $vsteamProfile = $PSBoundParameters['Profile']

--- a/Source/Public/Set-VSTeamDefaultProject.ps1
+++ b/Source/Public/Set-VSTeamDefaultProject.ps1
@@ -49,19 +49,22 @@ function Set-VSTeamDefaultProject {
 
    process {
       if ($Force -or $pscmdlet.ShouldProcess($Project, "Set-VSTeamDefaultProject")) {
-         if (_isOnWindows) {
-            if (-not $Level) {
-               $Level = "Process"
-            }
+         #Set at the process level, for any OS
+         $env:TEAM_PROJECT = $Project
+         [vsteam_lib.Versions]::DefaultProject = $Project
 
-            # You always have to set at the process level or they will Not
-            # be seen in your current session.
-            $env:TEAM_PROJECT = $Project
-            [vsteam_lib.Versions]::DefaultProject = $Project
+         $env:TEAM_PROCESS = [vsteam_lib.Versions]::DefaultProcess =
+                _callapi -NoProject -area 'work' -resource 'processes' -QueryString @{'$expand'='projects'}  -version (_getAPIVersion Processes) |
+                   Select-Object -ExpandProperty Value  | 
+                     Where-Object {$_.psobject.properties['projects'] -and $_.projects.name -eq $ProjectName} |
+                        Select-Object -ExpandProperty Name 
 
-            [System.Environment]::SetEnvironmentVariable("TEAM_PROJECT", $Project, $Level)
+         if  ((_isOnWindows) -and $Level -and $level -ne "Process") {
+            [System.Environment]::SetEnvironmentVariable("TEAM_PROJECT", $Project,           $Level)
+            [System.Environment]::SetEnvironmentVariable("TEAM_PROCESS", $env:TEAM_PROCESS , $Level)
          }
-
+         
+         # Note: ProjectName Parameters should be given a default value of [vsteam_lib.Versions]::DefaultProject instead of globally forcing it this way.
          $Global:PSDefaultParameterValues["*-vsteam*:projectName"] = $Project
       }
    }

--- a/Source/Public/Set-VSTeamDefaultProject.ps1
+++ b/Source/Public/Set-VSTeamDefaultProject.ps1
@@ -57,8 +57,7 @@ function Set-VSTeamDefaultProject {
                Where-Object Projects -Contains $Project | Select-Object -ExpandProperty Name
 
          if  ((_isOnWindows) -and $Level -and $level -ne "Process") {
-            [System.Environment]::SetEnvironmentVariable("TEAM_PROJECT", $Project,           $Level)
-            [System.Environment]::SetEnvironmentVariable("TEAM_PROCESS", $env:TEAM_PROCESS , $Level)
+            [System.Environment]::SetEnvironmentVariable("TEAM_PROJECT", $Project, $Level)
          }
 
          # Note: ProjectName Parameters should be given a default value of [vsteam_lib.Versions]::DefaultProject instead of globally forcing it this way.

--- a/Source/Public/Set-VSTeamDefaultProject.ps1
+++ b/Source/Public/Set-VSTeamDefaultProject.ps1
@@ -53,17 +53,14 @@ function Set-VSTeamDefaultProject {
          $env:TEAM_PROJECT = $Project
          [vsteam_lib.Versions]::DefaultProject = $Project
 
-         $env:TEAM_PROCESS = [vsteam_lib.Versions]::DefaultProcess =
-                _callapi -NoProject -area 'work' -resource 'processes' -QueryString @{'$expand'='projects'}  -version (_getAPIVersion Processes) |
-                   Select-Object -ExpandProperty Value  | 
-                     Where-Object {$_.psobject.properties['projects'] -and $_.projects.name -eq $ProjectName} |
-                        Select-Object -ExpandProperty Name 
+         $env:TEAM_PROCESS = [vsteam_lib.Versions]::DefaultProcess = Get-VSTeamProcess  -ExpandProjects |
+               Where-Object Projects -Contains $Project | Select-Object -ExpandProperty Name
 
          if  ((_isOnWindows) -and $Level -and $level -ne "Process") {
             [System.Environment]::SetEnvironmentVariable("TEAM_PROJECT", $Project,           $Level)
             [System.Environment]::SetEnvironmentVariable("TEAM_PROCESS", $env:TEAM_PROCESS , $Level)
          }
-         
+
          # Note: ProjectName Parameters should be given a default value of [vsteam_lib.Versions]::DefaultProject instead of globally forcing it this way.
          $Global:PSDefaultParameterValues["*-vsteam*:projectName"] = $Project
       }

--- a/Source/Public/Set-VSTeamProcess.ps1
+++ b/Source/Public/Set-VSTeamProcess.ps1
@@ -1,0 +1,60 @@
+function Set-VSTeamProcess {
+   [CmdletBinding(DefaultParameterSetName='LeaveAlone',SupportsShouldProcess=$true,ConfirmImpact='High')]
+   param (
+      [parameter(Mandatory = $true,ValueFromPipelineByPropertyName=$true,Position=1)]
+      [vsteam_lib.ProcessTemplateValidateAttribute()]
+      [ArgumentCompleter([vsteam_lib.ProcessTemplateCompleter])]
+      [Alias('Name')]
+      $ProcessTemplate,
+
+      [String]$Description,
+
+      [String]$NewName,
+
+      [parameter(ParameterSetName='Hide', Mandatory = $true)]
+      [switch]$Disabled,
+
+      [parameter(ParameterSetName='Show', Mandatory = $true)]
+      [switch]$Enabled,
+
+      [parameter(ParameterSetName='LeaveAlone')]
+      [parameter(ParameterSetName='Show')]
+      [switch]$AsDefault,
+
+      [switch]$Force
+   )
+   process {
+      if ($PSBoundParameters.Keys.count -lt 2 -or ($Force -and $PSBoundParameters.Keys.count -lt 2)) {
+         Write-Warning "Nothing to do!" ; return
+      }
+      $url =  _getProcessTemplateUrl $ProcessTemplate
+      if (-not $url) {Write-Warning "Could not find the Process for '$ProcessTemplate" ; return}
+      
+      $body = @{}
+      if ($Description) {$body['description'] = $Description}
+      if ($NewName    ) {$body['name']        = $NewName}
+      if ($Disabled   ) {$body['IsEnabled']   = $false}
+      if ($Enabled    ) {$body['IsEnabled']   = $true}
+      if ($AsDefault  ) {$body['IsDefault']   = $true}
+
+      $commonArgs = @{
+         Method      = "Patch"
+         URL         =  $url + "?api-version=" + (_getApiVersion Processes)
+         ContentType = "application/json" 
+         Body        = ConvertTo-Json  $body
+      }
+
+      if ($Force -or $PSCmdlet.ShouldProcess($ProcessTemplate,'Update Devops Process template')) {
+         # Call the REST API
+         $resp = _callAPI @commonArgs
+         if ($resp.psobject.Properties.name -Notcontains 'typeid') { 
+            Write-Warning 'The server did not return an ID for a modified process. '
+         }
+         else {
+
+            return [vsteam_lib.Process]::new($resp)
+
+         }
+      }
+   }
+}

--- a/Source/Public/Set-VSTeamProcess.ps1
+++ b/Source/Public/Set-VSTeamProcess.ps1
@@ -1,5 +1,6 @@
 function Set-VSTeamProcess {
    [CmdletBinding(DefaultParameterSetName='LeaveAlone',SupportsShouldProcess=$true,ConfirmImpact='High')]
+   [OutputType([vsteam_lib.Process])]
    param (
       [parameter(Mandatory = $true,ValueFromPipelineByPropertyName=$true,Position=1)]
       [vsteam_lib.ProcessTemplateValidateAttribute()]
@@ -43,7 +44,7 @@ function Set-VSTeamProcess {
          Body        = ConvertTo-Json  $body
       }
 
-      if ($Force -or $PSCmdlet.ShouldProcess($ProcessTemplate,'Update Devops Process template')) {
+      if ($Force -or $PSCmdlet.ShouldProcess($ProcessTemplate,'Update Process template')) {
          # Call the REST API
          $resp = _callAPI @commonArgs
          if ($resp.psobject.Properties.name -Notcontains 'typeid') {

--- a/Source/Public/Set-VSTeamProcess.ps1
+++ b/Source/Public/Set-VSTeamProcess.ps1
@@ -29,7 +29,7 @@ function Set-VSTeamProcess {
       }
       $url =  _getProcessTemplateUrl $ProcessTemplate
       if (-not $url) {Write-Warning "Could not find the Process for '$ProcessTemplate" ; return}
-      
+
       $body = @{}
       if ($Description) {$body['description'] = $Description}
       if ($NewName    ) {$body['name']        = $NewName}
@@ -40,14 +40,13 @@ function Set-VSTeamProcess {
       $commonArgs = @{
          Method      = "Patch"
          URL         =  $url + "?api-version=" + (_getApiVersion Processes)
-         ContentType = "application/json" 
          Body        = ConvertTo-Json  $body
       }
 
       if ($Force -or $PSCmdlet.ShouldProcess($ProcessTemplate,'Update Devops Process template')) {
          # Call the REST API
          $resp = _callAPI @commonArgs
-         if ($resp.psobject.Properties.name -Notcontains 'typeid') { 
+         if ($resp.psobject.Properties.name -Notcontains 'typeid') {
             Write-Warning 'The server did not return an ID for a modified process. '
          }
          else {

--- a/Source/Public/Set-VSTeamProcessBehavior.ps1
+++ b/Source/Public/Set-VSTeamProcessBehavior.ps1
@@ -31,25 +31,27 @@ function Set-VSTeamProcessBehavior {
          if ($NewName) {$body['name'] = $NewName}
          else          {$body['name'] = $Name}
       }
-      $behavior = Get-VSTeamProcessBehavior -ProcessTemplate $ProcessTemplate |
-                     Where-Object -Property name -eq $Name
+      foreach($p in $ProcessTemplate) {
+         $behavior = Get-VSTeamProcessBehavior -ProcessTemplate $p |
+                        Where-Object -Property name -eq $Name
 
-      if (-not $behavior) {Write-Warning "'$Name' is not a process behavior in $ProcessTemplate" ; return}
-      $Params= @{
-         url         = $behavior.url + "?api-version=" + (_getApiVersion Processes)
-         method      = 'Put'
-         body        = ConvertTo-Json $body
-      }
-      if ($Force -or $PSCmdlet.ShouldProcess($ProcessTemplate,"Modify behavior named '$Name' to process")) {
-         #Call the Rest API
-         $resp = _callAPI @params
+         if (-not $behavior) {Write-Warning "'$Name' is not a process behavior in $p" ; continue}
+         $Params= @{
+            url         = $behavior.url + "?api-version=" + (_getApiVersion Processes)
+            method      = 'Put'
+            body        = ConvertTo-Json $body
+         }
+         if ($Force -or $PSCmdlet.ShouldProcess($p,"Modify behavior named '$Name' to process")) {
+            #Call the Rest API
+            $resp = _callAPI @params
 
-         # Apply a Type Name so we can use custom format view and custom type extensions
-         # and add the processTemplate name so it can become a parameter when the object is piped into other functions
-         $resp.psobject.TypeNames.Insert(0,'vsteam_lib.Processbehavior')
-         Add-Member -InputObject $resp -MemberType NoteProperty -Name ProcessTemplate -Value $ProcessTemplate
+            # Apply a Type Name so we can use custom format view and custom type extensions
+            # and add the processTemplate name so it can become a parameter when the object is piped into other functions
+            $resp.psobject.TypeNames.Insert(0,'vsteam_lib.Processbehavior')
+            Add-Member -InputObject $resp -MemberType NoteProperty -Name ProcessTemplate -Value $p
 
-         return $resp
+            return $resp
+         }
       }
    }
 }

--- a/Source/Public/Set-VSTeamProcessBehavior.ps1
+++ b/Source/Public/Set-VSTeamProcessBehavior.ps1
@@ -23,7 +23,7 @@ function Set-VSTeamProcessBehavior {
 
    )
    Process {
-      
+
       if (-not $color -and -not $NewName) {Write-Warning "Nothing to do!"; return}
       else {
          $body = @{}
@@ -31,26 +31,25 @@ function Set-VSTeamProcessBehavior {
          if ($NewName) {$body['name'] = $NewName}
          else          {$body['name'] = $Name}
       }
-      $behavior = Get-VSTeamProcessBehavior -ProcessTemplate $ProcessTemplate | 
+      $behavior = Get-VSTeamProcessBehavior -ProcessTemplate $ProcessTemplate |
                      Where-Object -Property name -eq $Name
 
       if (-not $behavior) {Write-Warning "'$Name' is not a process behavior in $ProcessTemplate" ; return}
       $Params= @{
-         url         = $behavior.url + "?api-version=" + (_getApiVersion Processes) 
+         url         = $behavior.url + "?api-version=" + (_getApiVersion Processes)
          method      = 'Put'
          body        = ConvertTo-Json $body
-         ContentType = 'application/json'
       }
       if ($Force -or $PSCmdlet.ShouldProcess($ProcessTemplate,"Modify behavior named '$Name' to process")) {
          #Call the Rest API
-         $resp = _callAPI @params 
-         
+         $resp = _callAPI @params
+
          # Apply a Type Name so we can use custom format view and custom type extensions
          # and add the processTemplate name so it can become a parameter when the object is piped into other functions
          $resp.psobject.TypeNames.Insert(0,'vsteam_lib.Processbehavior')
          Add-Member -InputObject $resp -MemberType NoteProperty -Name ProcessTemplate -Value $ProcessTemplate
 
-         return $resp 
+         return $resp
       }
    }
 }

--- a/Source/Public/Set-VSTeamProcessBehavior.ps1
+++ b/Source/Public/Set-VSTeamProcessBehavior.ps1
@@ -1,0 +1,56 @@
+function Set-VSTeamProcessBehavior {
+   [CmdletBinding(SupportsShouldProcess=$true,ConfirmImpact='High')]
+   param (
+      [Parameter(ValueFromPipelineByPropertyName=$true,Position=1)]
+      [vsteam_lib.ProcessTemplateValidateAttribute()]
+      [ArgumentCompleter([vsteam_lib.ProcessTemplateCompleter])]
+      $ProcessTemplate = $env:TEAM_PROCESS,
+
+      [Parameter(ValueFromPipelineByPropertyName=$true, Mandatory=$true,Position=0)]
+      [string]
+      $Name,
+
+      [ArgumentCompleter([vsteam_lib.ColorCompleter])]
+      [vsteam_lib.ColorTransformToHexAttribute()]
+      [String]
+      $Color,
+
+      [string]
+      $NewName,
+
+      [switch]
+      $Force
+
+   )
+   Process {
+      
+      if (-not $color -and -not $NewName) {Write-Warning "Nothing to do!"; return}
+      else {
+         $body = @{}
+         if ($Color)   {$body['color']= $Color}
+         if ($NewName) {$body['name'] = $NewName}
+         else          {$body['name'] = $Name}
+      }
+      $behavior = Get-VSTeamProcessBehavior -ProcessTemplate $ProcessTemplate | 
+                     Where-Object -Property name -eq $Name
+
+      if (-not $behavior) {Write-Warning "'$Name' is not a process behavior in $ProcessTemplate" ; return}
+      $Params= @{
+         url         = $behavior.url + "?api-version=" + (_getApiVersion Processes) 
+         method      = 'Put'
+         body        = ConvertTo-Json $body
+         ContentType = 'application/json'
+      }
+      if ($Force -or $PSCmdlet.ShouldProcess($ProcessTemplate,"Modify behavior named '$Name' to process")) {
+         #Call the Rest API
+         $resp = _callAPI @params 
+         
+         # Apply a Type Name so we can use custom format view and custom type extensions
+         # and add the processTemplate name so it can become a parameter when the object is piped into other functions
+         $resp.psobject.TypeNames.Insert(0,'vsteam_lib.Processbehavior')
+         Add-Member -InputObject $resp -MemberType NoteProperty -Name ProcessTemplate -Value $ProcessTemplate
+
+         return $resp 
+      }
+   }
+}

--- a/Source/Public/Set-VSTeamSetting.ps1
+++ b/Source/Public/Set-VSTeamSetting.ps1
@@ -1,5 +1,5 @@
 Function Set-VSTeamSetting {
-   [CmdletBinding()]
+   [CmdletBinding(SupportsShouldProcess=$True)]
    param(
       [Parameter(Mandatory = $True, Position = 1)]
       [vsteam_lib.ProjectValidateAttribute($false)]
@@ -31,107 +31,114 @@ Function Set-VSTeamSetting {
       $Description,
 
       [switch]
+      $Force,
+
+      [switch]
       $RawOutput
    )
+   process {
+      #We can't use valueFromPipelineByPropertyName because $PSDefaultParameterValues forces the current project into
+      #$projectname. So instead Pipe the whole object into team and then get the projectname and team name from it.
+      if ($Team.psobject.properties.name -contains 'ProjectName') {$ProjectName = $Team.ProjectName}
+      if ($Team.psobject.properties.name -contains 'Name')        {$Team        = $Team.Name}
 
-   #We can't use valueFromPipelineByPropertyName because $PSDefaultParameterValues forces the current project into
-   #$projectname. So instead Pipe the whole object into team and then get the projectname and team name from it.
-   if ($Team.psobject.properties.name -contains 'ProjectName') {$ProjectName = $Team.ProjectName}
-   if ($Team.psobject.properties.name -contains 'Name')        {$Team        = $Team.Name}
-
-   $params = @{contentType = 'application/json'
-               method      = 'Patch'
-               version     = _getApiVersion Processes
-   }
-
-   if ($NewName -or $Description) {
-      $body = @{}
-      if ($NewName) {$body['name'] = $NewName}
-      if ($Description) {$body['description'] = $Description}
-      $params +=  @{
-         Area     = 'projects'
-         Resource = "$ProjectName/teams"
-         id       = $Team
-         body     = ConvertTo-Json $body
+      $params = @{contentType = 'application/json'
+                  method      = 'Patch'
+                  version     = _getApiVersion Processes
       }
-      $resp = _callapi @params
 
-      Write-Output [vsteam_lib.Team]::new($resp, $ProjectName)
-   }
+      if ($NewName -or $Description) {
+         $body = @{}
+         if ($NewName) {$body['name'] = $NewName}
+         if ($Description) {$body['description'] = $Description}
+         $params +=  @{
+            Area     = 'projects'
+            Resource = "$ProjectName/teams"
+            id       = $Team
+            body     = ConvertTo-Json $body
+         }
 
-   #see https://docs.microsoft.com/en-us/rest/api/azure/devops/core/projects/update?view=azure-devops-rest-6.1
-   # for making a team the default project team.
-   #can't see where to set team area.
-
-   $body = @{}
-   #Resolve default and backlog interations. If they are digits look up that ID
-   #If they were or just came back as an obkect with an identifier GUID, use it.
-   #if we haven't got a GUID yet treat what we have as a path and try to get that
-   if ($DefaultIteration -match "^\d+$" ) {
-      $DefaultIteration = Get-VSTeamIteration -projectname $ProjectName -id $DefaultIteration
-   }
-   if ($DefaultIteration -and 'identifier' -in $DefaultIteration.psobject.Properties.name) {
-      $DefaultIteration = $DefaultIteration.Identifier.Guid
-   }
-   if ($DefaultIteration -and $DefaultIteration -notmatch "[0-9A-F]{8}-([0-9A-F]{4}-){3}[0-9A-F]{12}") {
-         $i = Get-VSTeamIteration -Path $DefaultIteration -ProjectName $ProjectName
-         if (-not $i) {Write-Warning "$DefaultIteration not found" ; return }
-         else {$DefaultIteration = $i.Identifier.Guid}
-   }
-   if ($BacklogIteration -match "^\d+$" ) {
-      $BacklogIteration = Get-VSTeamIteration -projectname $ProjectName -id $BacklogIteration
-   }
-   if ($BacklogIteration -and 'identifier' -in $BacklogIteration.psobject.Properties.name) {
-      $BacklogIteration = $BacklogIteration.Identifier.Guid
-   }
-   if ($BacklogIteration -and $BacklogIteration -notmatch "[0-9A-F]{8}-([0-9A-F]{4}-){3}[0-9A-F]{12}") {
-         $i = Get-VSTeamIteration -Path $BacklogIteration -ProjectName $ProjectName
-         if (-not $i) {Write-Warning "$BacklogIteration not found" ; return }
-         else {$BacklogIteration = $i.Identifier.Guid}
-   }
-   if ($BackLogVisibilites) {
-      $visibilites  = @{}
-      # Validate Names & translate from "Backlog items" 'Microsoft.RequirementCategory' etc. Ensure values are boolean.
-      $bhash = @{}
-      $backlogConfig =  _callapi -ProjectName $ProjectName -area work -resource 'backlogconfiguration'
-      @($backlogConfig.portfolioBacklogs) + $backlogConfig.requirementBacklog |
-          ForEach-Object {$bhash[$_.name] = $_.id}
-
-      foreach ($k in $BackLogVisibilites.Keys) {
-         if     ($bhash.ContainsValue($k)) {$Visibilites[$k]         = $BackLogVisibilites[$k] -notmatch "false|No" }
-         elseif ($bhash.ContainsKey($k))   {$Visibilites[$bhash[$k]] = $BackLogVisibilites[$k] -notmatch "false|No" }
-         else  {
-            Write-Warning ("$K is not a valid backlog for the project '$ProjectName'. Valid backlogs are" + ($bhash.Values -join ', ') + '.')
-            return
+         if ($force -or $PSCmdlet.ShouldContinue($Team,'Change name and/or description of team.')){
+            $resp = _callapi @params
+            Write-Output [vsteam_lib.Team]::new($resp, $ProjectName)
          }
       }
-      $body['backlogVisibilities'] = $visibilites
+
+      #see https://docs.microsoft.com/en-us/rest/api/azure/devops/core/projects/update?view=azure-devops-rest-6.1
+      # for making a team the default project team.
+      #can't see where to set team area.
+
+      $body = @{}
+      #Resolve default and backlog interations. If they are digits look up that ID
+      #If they were or just came back as an obkect with an identifier GUID, use it.
+      #if we haven't got a GUID yet treat what we have as a path and try to get that
+      if ($DefaultIteration -match "^\d+$" ) {
+         $DefaultIteration = Get-VSTeamIteration -projectname $ProjectName -id $DefaultIteration
+      }
+      if ($DefaultIteration -and 'identifier' -in $DefaultIteration.psobject.Properties.name) {
+         $DefaultIteration = $DefaultIteration.Identifier.Guid
+      }
+      if ($DefaultIteration -and $DefaultIteration -notmatch "[0-9A-F]{8}-([0-9A-F]{4}-){3}[0-9A-F]{12}") {
+            $i = Get-VSTeamIteration -Path $DefaultIteration -ProjectName $ProjectName
+            if (-not $i) {Write-Warning "$DefaultIteration not found" ; return }
+            else {$DefaultIteration = $i.Identifier.Guid}
+      }
+      if ($BacklogIteration -match "^\d+$" ) {
+         $BacklogIteration = Get-VSTeamIteration -projectname $ProjectName -id $BacklogIteration
+      }
+      if ($BacklogIteration -and 'identifier' -in $BacklogIteration.psobject.Properties.name) {
+         $BacklogIteration = $BacklogIteration.Identifier.Guid
+      }
+      if ($BacklogIteration -and $BacklogIteration -notmatch "[0-9A-F]{8}-([0-9A-F]{4}-){3}[0-9A-F]{12}") {
+            $i = Get-VSTeamIteration -Path $BacklogIteration -ProjectName $ProjectName
+            if (-not $i) {Write-Warning "$BacklogIteration not found" ; return }
+            else {$BacklogIteration = $i.Identifier.Guid}
+      }
+      if ($BackLogVisibilites) {
+         $visibilites  = @{}
+         # Validate Names & translate from "Backlog items" 'Microsoft.RequirementCategory' etc. Ensure values are boolean.
+         $bhash = @{}
+         $backlogConfig =  _callapi -ProjectName $ProjectName -area work -resource 'backlogconfiguration'
+         @($backlogConfig.portfolioBacklogs) + $backlogConfig.requirementBacklog |
+            ForEach-Object {$bhash[$_.name] = $_.id}
+
+         foreach ($k in $BackLogVisibilites.Keys) {
+            if     ($bhash.ContainsValue($k)) {$Visibilites[$k]         = $BackLogVisibilites[$k] -notmatch "false|No" }
+            elseif ($bhash.ContainsKey($k))   {$Visibilites[$bhash[$k]] = $BackLogVisibilites[$k] -notmatch "false|No" }
+            else  {
+               Write-Warning ("$K is not a valid backlog for the project '$ProjectName'. Valid backlogs are" + ($bhash.Values -join ', ') + '.')
+               return
+            }
+         }
+         $body['backlogVisibilities'] = $visibilites
+      }
+      if ($BacklogIteration) {$body['backlogIteration']  = $BacklogIteration}
+      if ($DefaultIteration) {$body['defaultIteration']  = $DefaultIteration}
+      if ($BugsBehavior)     {$body['bugsBehavior']      = $BugsBehavior}
+      if ($WorkingDays)      {$body['workingDays']       = $WorkingDays }
+
+      if ($body.Count -eq 0 ) {return }
+
+      if ($Team) {
+         $params["Team"]     = $Team
+      }
+      $params['area']        ='work'
+      $params['resource']    ='teamsettings'
+      $params['projectName'] = $ProjectName
+      $params['body']        = ConvertTo-Json $body
+
+      if ($force -or $PSCmdlet.ShouldProcess($Team,'Change settings for team.')){
+         $resp = _callAPI @params
+
+         if ($RawOutput) {return $resp}
+         else {
+            $resp.backlogVisibilities.psobject.properties | Select-Object Name, @{n='Value';e={if($_.value) {'Visible'} else{'Hidden'}} }  |
+               Write-Output
+            [PSCustomObject]@{Name = 'Bug display mode';  Value =  $resp.bugsBehavior}
+            [PSCustomObject]@{Name = 'Working Days';   ;  Value =  ($resp.workingDays -join ', ')}
+            [PSCustomObject]@{Name = 'Default Iteration'; Value =  $resp.defaultIteration.name}
+            [PSCustomObject]@{Name = 'Backlog Iteration'; Value =  $resp.BacklogIteration.name}
+         }
+      }
    }
-   if ($BacklogIteration) {$body['backlogIteration']  = $BacklogIteration}
-   if ($DefaultIteration) {$body['defaultIteration']  = $DefaultIteration}
-   if ($BugsBehavior)     {$body['bugsBehavior']      = $BugsBehavior}
-   if ($WorkingDays)      {$body['workingDays']       = $WorkingDays }
-
-   if ($body.Count -eq 0 ) {return }
-
-   if ($Team) {
-      $params["Team"]     = $Team
-   }
-   $params['area']        ='work'
-   $params['resource']    ='teamsettings'
-   $params['projectName'] = $ProjectName
-   $params['body']        = ConvertTo-Json $body
-
-   $resp = _callAPI @params
-
-   if ($RawOutput) {return $resp}
-   else {
-      $resp.backlogVisibilities.psobject.properties | Select-Object Name, @{n='Value';e={if($_.value) {'Visible'} else{'Hidden'}} }  |
-          Write-Output
-      [PSCustomObject]@{Name = 'Bug display mode';  Value =  $resp.bugsBehavior}
-      [PSCustomObject]@{Name = 'Working Days';   ;  Value =  ($resp.workingDays -join ', ')}
-      [PSCustomObject]@{Name = 'Default Iteration'; Value =  $resp.defaultIteration.name}
-      [PSCustomObject]@{Name = 'Backlog Iteration'; Value =  $resp.BacklogIteration.name}
-  }
-
 }

--- a/Source/Public/Set-VSTeamSetting.ps1
+++ b/Source/Public/Set-VSTeamSetting.ps1
@@ -1,0 +1,137 @@
+Function Set-VSTeamSetting {
+   [CmdletBinding()]
+   param(
+      [Parameter(Mandatory = $True, Position = 1)]
+      [vsteam_lib.ProjectValidateAttribute($false)]
+      [ArgumentCompleter([vsteam_lib.ProjectCompleter])]
+      $ProjectName,
+
+      [Parameter(Mandatory = $false, Position = 0, ValueFromPipeline=$true)]
+      $Team,
+
+      [ValidateSet('asRequirements' , 'asTasks', 'off')]
+      [string]
+      $BugsBehavior,
+
+      [hashtable]
+      $BackLogVisibilites,
+
+      $BacklogIteration,
+
+      $DefaultIteration,
+
+      [ValidateSet('monday', 'tuesday', 'wednesday', 'thursday', 'friday', 'saturday', 'sunday')]
+      [string[]]
+      $WorkingDays,
+
+      [string]
+      $NewName,
+
+      [string]
+      $Description,
+
+      [switch]
+      $RawOutput
+   )
+
+   #We can't use valueFromPipelineByPropertyName because $PSDefaultParameterValues forces the current project into
+   #$projectname. So instead Pipe the whole object into team and then get the projectname and team name from it.
+   if ($Team.psobject.properties.name -contains 'ProjectName') {$ProjectName = $Team.ProjectName}
+   if ($Team.psobject.properties.name -contains 'Name')        {$Team        = $Team.Name}
+
+   $params = @{contentType = 'application/json'
+               method      = 'Patch'
+               version     = _getApiVersion Processes
+   }
+
+   if ($NewName -or $Description) {
+      $body = @{}
+      if ($NewName) {$body['name'] = $NewName}
+      if ($Description) {$body['description'] = $Description}
+      $params +=  @{
+         Area     = 'projects'
+         Resource = "$ProjectName/teams"
+         id       = $Team
+         body     = ConvertTo-Json $body
+      }
+      $resp = _callapi @params
+
+      Write-Output [vsteam_lib.Team]::new($resp, $ProjectName)
+   }
+
+   #see https://docs.microsoft.com/en-us/rest/api/azure/devops/core/projects/update?view=azure-devops-rest-6.1
+   # for making a team the default project team.
+   #can't see where to set team area.
+
+   $body = @{}
+   #Resolve default and backlog interations. If they are digits look up that ID
+   #If they were or just came back as an obkect with an identifier GUID, use it.
+   #if we haven't got a GUID yet treat what we have as a path and try to get that
+   if ($DefaultIteration -match "^\d+$" ) {
+      $DefaultIteration = Get-VSTeamIteration -projectname $ProjectName -id $DefaultIteration
+   }
+   if ($DefaultIteration -and 'identifier' -in $DefaultIteration.psobject.Properties.name) {
+      $DefaultIteration = $DefaultIteration.Identifier.Guid
+   }
+   if ($DefaultIteration -and $DefaultIteration -notmatch "[0-9A-F]{8}-([0-9A-F]{4}-){3}[0-9A-F]{12}") {
+         $i = Get-VSTeamIteration -Path $DefaultIteration -ProjectName $ProjectName
+         if (-not $i) {Write-Warning "$DefaultIteration not found" ; return }
+         else {$DefaultIteration = $i.Identifier.Guid}
+   }
+   if ($BacklogIteration -match "^\d+$" ) {
+      $BacklogIteration = Get-VSTeamIteration -projectname $ProjectName -id $BacklogIteration
+   }
+   if ($BacklogIteration -and 'identifier' -in $BacklogIteration.psobject.Properties.name) {
+      $BacklogIteration = $BacklogIteration.Identifier.Guid
+   }
+   if ($BacklogIteration -and $BacklogIteration -notmatch "[0-9A-F]{8}-([0-9A-F]{4}-){3}[0-9A-F]{12}") {
+         $i = Get-VSTeamIteration -Path $BacklogIteration -ProjectName $ProjectName
+         if (-not $i) {Write-Warning "$BacklogIteration not found" ; return }
+         else {$BacklogIteration = $i.Identifier.Guid}
+   }
+   if ($BackLogVisibilites) {
+      $visibilites  = @{}
+      # Validate Names & translate from "Backlog items" 'Microsoft.RequirementCategory' etc. Ensure values are boolean.
+      $bhash = @{}
+      $backlogConfig =  _callapi -ProjectName $ProjectName -area work -resource 'backlogconfiguration'
+      @($backlogConfig.portfolioBacklogs) + $backlogConfig.requirementBacklog |
+          ForEach-Object {$bhash[$_.name] = $_.id}
+
+      foreach ($k in $BackLogVisibilites.Keys) {
+         if     ($bhash.ContainsValue($k)) {$Visibilites[$k]         = $BackLogVisibilites[$k] -notmatch "false|No" }
+         elseif ($bhash.ContainsKey($k))   {$Visibilites[$bhash[$k]] = $BackLogVisibilites[$k] -notmatch "false|No" }
+         else  {
+            Write-Warning ("$K is not a valid backlog for the project '$ProjectName'. Valid backlogs are" + ($bhash.Values -join ', ') + '.')
+            return
+         }
+      }
+      $body['backlogVisibilities'] = $visibilites
+   }
+   if ($BacklogIteration) {$body['backlogIteration']  = $BacklogIteration}
+   if ($DefaultIteration) {$body['defaultIteration']  = $DefaultIteration}
+   if ($BugsBehavior)     {$body['bugsBehavior']      = $BugsBehavior}
+   if ($WorkingDays)      {$body['workingDays']       = $WorkingDays }
+
+   if ($body.Count -eq 0 ) {return }
+
+   if ($Team) {
+      $params["Team"]     = $Team
+   }
+   $params['area']        ='work'
+   $params['resource']    ='teamsettings'
+   $params['projectName'] = $ProjectName
+   $params['body']        = ConvertTo-Json $body
+
+   $resp = _callAPI @params
+
+   if ($RawOutput) {return $resp}
+   else {
+      $resp.backlogVisibilities.psobject.properties | Select-Object Name, @{n='Value';e={if($_.value) {'Visible'} else{'Hidden'}} }  |
+          Write-Output
+      [PSCustomObject]@{Name = 'Bug display mode';  Value =  $resp.bugsBehavior}
+      [PSCustomObject]@{Name = 'Working Days';   ;  Value =  ($resp.workingDays -join ', ')}
+      [PSCustomObject]@{Name = 'Default Iteration'; Value =  $resp.defaultIteration.name}
+      [PSCustomObject]@{Name = 'Backlog Iteration'; Value =  $resp.BacklogIteration.name}
+  }
+
+}

--- a/Source/Public/Set-VSTeamSetting.ps1
+++ b/Source/Public/Set-VSTeamSetting.ps1
@@ -42,8 +42,7 @@ Function Set-VSTeamSetting {
       if ($Team.psobject.properties.name -contains 'ProjectName') {$ProjectName = $Team.ProjectName}
       if ($Team.psobject.properties.name -contains 'Name')        {$Team        = $Team.Name}
 
-      $params = @{contentType = 'application/json'
-                  method      = 'Patch'
+      $params = @{method      = 'Patch'
                   version     = _getApiVersion Processes
       }
 
@@ -73,30 +72,30 @@ Function Set-VSTeamSetting {
       #If they were or just came back as an obkect with an identifier GUID, use it.
       #if we haven't got a GUID yet treat what we have as a path and try to get that
       if ($DefaultIteration -match "^\d+$" ) {
-         $DefaultIteration = Get-VSTeamIteration -projectname $ProjectName -id $DefaultIteration
+          $DefaultIteration = Get-VSTeamIteration -projectname $ProjectName -id $DefaultIteration
       }
       if ($DefaultIteration -and 'identifier' -in $DefaultIteration.psobject.Properties.name) {
-         $DefaultIteration = $DefaultIteration.Identifier.Guid
+          $DefaultIteration = $DefaultIteration.Identifier.Guid
       }
       if ($DefaultIteration -and $DefaultIteration -notmatch "[0-9A-F]{8}-([0-9A-F]{4}-){3}[0-9A-F]{12}") {
-            $i = Get-VSTeamIteration -Path $DefaultIteration -ProjectName $ProjectName
-            if (-not $i) {Write-Warning "$DefaultIteration not found" ; return }
-            else {$DefaultIteration = $i.Identifier.Guid}
+         $i = Get-VSTeamIteration -Path $DefaultIteration -ProjectName $ProjectName
+         if (-not $i) {Write-Warning "$DefaultIteration not found" ; return }
+         else {$DefaultIteration = $i.Identifier.Guid}
       }
       if ($BacklogIteration -match "^\d+$" ) {
-         $BacklogIteration = Get-VSTeamIteration -projectname $ProjectName -id $BacklogIteration
+          $BacklogIteration = Get-VSTeamIteration -projectname $ProjectName -id $BacklogIteration
       }
       if ($BacklogIteration -and 'identifier' -in $BacklogIteration.psobject.Properties.name) {
-         $BacklogIteration = $BacklogIteration.Identifier.Guid
+          $BacklogIteration = $BacklogIteration.Identifier.Guid
       }
       if ($BacklogIteration -and $BacklogIteration -notmatch "[0-9A-F]{8}-([0-9A-F]{4}-){3}[0-9A-F]{12}") {
-            $i = Get-VSTeamIteration -Path $BacklogIteration -ProjectName $ProjectName
-            if (-not $i) {Write-Warning "$BacklogIteration not found" ; return }
-            else {$BacklogIteration = $i.Identifier.Guid}
+         $i = Get-VSTeamIteration -Path $BacklogIteration -ProjectName $ProjectName
+         if (-not $i) {Write-Warning "$BacklogIteration not found" ; return }
+         else {$BacklogIteration = $i.Identifier.Guid}
       }
       if ($BackLogVisibilites) {
          $visibilites  = @{}
-         # Validate Names & translate from "Backlog items" 'Microsoft.RequirementCategory' etc. Ensure values are boolean.
+         # Validate Names & translate from "Backlog items" to 'Microsoft.RequirementCategory' etc. Ensure values are boolean.
          $bhash = @{}
          $backlogConfig =  _callapi -ProjectName $ProjectName -area work -resource 'backlogconfiguration'
          @($backlogConfig.portfolioBacklogs) + $backlogConfig.requirementBacklog |
@@ -135,7 +134,7 @@ Function Set-VSTeamSetting {
             $resp.backlogVisibilities.psobject.properties | Select-Object Name, @{n='Value';e={if($_.value) {'Visible'} else{'Hidden'}} }  |
                Write-Output
             [PSCustomObject]@{Name = 'Bug display mode';  Value =  $resp.bugsBehavior}
-            [PSCustomObject]@{Name = 'Working Days';   ;  Value =  ($resp.workingDays -join ', ')}
+            [PSCustomObject]@{Name = 'Working Days';   ;  Value = ($resp.workingDays -join ', ')}
             [PSCustomObject]@{Name = 'Default Iteration'; Value =  $resp.defaultIteration.name}
             [PSCustomObject]@{Name = 'Backlog Iteration'; Value =  $resp.BacklogIteration.name}
          }

--- a/Source/Public/Set-VSTeamWorkItemBehavior.ps1
+++ b/Source/Public/Set-VSTeamWorkItemBehavior.ps1
@@ -1,0 +1,83 @@
+function Set-VSTeamWorkItemBehavior {
+   [CmdletBinding(DefaultParameterSetName='AddOrSet',SupportsShouldProcess=$true,ConfirmImpact='High')]
+   param(
+      [parameter(ValueFromPipelineByPropertyName=$true)]
+      [vsteam_lib.ProcessTemplateValidateAttribute()]
+      [ArgumentCompleter([vsteam_lib.ProcessTemplateCompleter])]
+      $ProcessTemplate = $env:TEAM_PROCESS,
+
+      [parameter(Mandatory = $true,ValueFromPipelineByPropertyName=$true, Position=0)]
+      [ArgumentCompleter([vsteam_lib.WorkItemTypeCompleter])]
+      [string]$WorkItemType,
+
+      [parameter(Mandatory =$true, ParameterSetName='AddOrSet')]
+      [string]$Behavior,
+
+      [parameter(ParameterSetName='AddOrSet')]
+      [switch]$IsDefault,
+
+      [parameter(Mandatory =$true, ParameterSetName='Delete')]
+      [switch]$Remove,
+
+      [switch]$Force
+   )
+   process {
+      #Get real backlog behaviors - skip those with a rank of 0 
+      if (-not $remove) {
+         $processbehaviors = Get-VSTeamProcessBehavior -ProcessTemplate $ProcessTemplate | Where-Object Rank -gt 0 
+         #Allow either the name or feature name
+         if ($Behavior -in $processbehaviors.name) {
+             $Behavior = $processbehaviors.Where({$_.name -eq $Behavior}).referencename 
+         }
+         if ($Behavior -notin $processbehaviors.referencename) {
+            Write-Warning ("$Behavior is not a valid behavior name. Possible names are '" + ($processbehaviors.name -join "', '") + "'") ; return
+         }
+      }
+      $wit = Get-VSTeamWorkitemType -ProcessTemplate $ProcessTemplate -WorkItemType $WorkItemType -Expand behaviors
+
+      $url = ($wit.url -replace '/workItemTypes/' , '/workitemtypesbehaviors/')
+      if     ($Remove -and $wit.behaviors.Count -eq 0  ) {Write-Warning  "Nothing to do!" ;return}
+      elseif ($Remove) {
+            foreach ($b in $wit.behaviors) {
+               if ($force -or $PSCmdlet.ShouldProcess($wit.name,'Remove behavior from WorkItem Type')) {
+                  $params = @{
+                     url = "$url/behaviors/{0}?api-version={1}" -f $b.behavior.id, (_getApiVersion Processes)
+                     method = 'Delete' 
+                   }
+                _callAPI @params
+               }
+            }
+            return
+      }
+      if ($wit.behaviors.count -gt 0 -and  $wit.behaviors.behavior.id -contains $Behavior) {
+         Write-Warning "'$workitemType' is already assigned to $Behavior!. To change the default, remove and re-add it." ;return
+      }
+      if ($wit.behaviors.count -gt 0 -and  $wit.behaviors.behavior.id -notcontains $Behavior) {
+         Write-Warning ("'$workitemType' is already assigned to $($wit.behaviors.behavior.id) remove it before assigning to another type") ; return
+      }
+      
+      $params = @{
+         method      = "Post"
+         url         = "$url/behaviors?api-version=" + (_getApiVersion Processes)  
+         ContentType = "application/json" 
+         body        = ConvertTo-JSON @{
+            behavior  = @{id= $Behavior} 
+            isDefault = $IsDefault -as [bool]
+            id        = $wit.referenceName
+         }
+      }
+      if ($Force -or $PSCmdlet.ShouldProcess($WorkItemType,"Modify $ProcessTemplate to update definition of workitem type") ) {
+         try   { 
+            $resp = _callapi @params -ErrorAction stop  
+            $r = [PSCustomObject][ordered]@{ ProcessTemplate = $ProcessTemplate; 
+                                             WorkItemType    = $WorkItemType 
+                                             Behavior        = $resp.behavior.id
+                                             IsDefault       = $resp.isdefault  }
+            $r.PSObject.TypeNames.Insert(0, 'vsteam_lib.WorkItembehavior')
+            
+            return $r
+         }
+         catch { Write-Warning "$workitemType exists, but failed to update. It may not be possible to change this type."}
+      }
+   }
+}

--- a/Source/Public/Set-VSTeamWorkItemBehavior.ps1
+++ b/Source/Public/Set-VSTeamWorkItemBehavior.ps1
@@ -22,62 +22,58 @@ function Set-VSTeamWorkItemBehavior {
       [switch]$Force
    )
    process {
-      #Get real backlog behaviors - skip those with a rank of 0 
+      #Get real backlog behaviors - skip those with a rank of 0
       if (-not $remove) {
-         $processbehaviors = Get-VSTeamProcessBehavior -ProcessTemplate $ProcessTemplate | Where-Object Rank -gt 0 
+         $processbehaviors = Get-VSTeamProcessBehavior -ProcessTemplate $ProcessTemplate | Where-Object Rank -gt 0
          #Allow either the name or feature name
          if ($Behavior -in $processbehaviors.name) {
-             $Behavior = $processbehaviors.Where({$_.name -eq $Behavior}).referencename 
+             $Behavior = $processbehaviors.Where({$_.name -eq $Behavior}).referencename
          }
          if ($Behavior -notin $processbehaviors.referencename) {
             Write-Warning ("$Behavior is not a valid behavior name. Possible names are '" + ($processbehaviors.name -join "', '") + "'") ; return
          }
       }
       $wit = Get-VSTeamWorkitemType -ProcessTemplate $ProcessTemplate -WorkItemType $WorkItemType -Expand behaviors
-
-      $url = ($wit.url -replace '/workItemTypes/' , '/workitemtypesbehaviors/')
-      if     ($Remove -and $wit.behaviors.Count -eq 0  ) {Write-Warning  "Nothing to do!" ;return}
-      elseif ($Remove) {
-            foreach ($b in $wit.behaviors) {
-               if ($force -or $PSCmdlet.ShouldProcess($wit.name,'Remove behavior from WorkItem Type')) {
-                  $params = @{
-                     url = "$url/behaviors/{0}?api-version={1}" -f $b.behavior.id, (_getApiVersion Processes)
-                     method = 'Delete' 
-                   }
-                _callAPI @params
+      foreach ($w in $wit) {
+         $url = ($w.url -replace '/workItemTypes/' , '/workitemtypesbehaviors/')
+         if     ($Remove -and $w.behaviors.Count -eq 0  ) {Write-Warning  "Nothing to do for $($w.name)!" ; continue}
+         elseif ($Remove) {
+            foreach ($b in $w.behaviors) {
+               if ($force -or $PSCmdlet.ShouldProcess($w.name,'Remove behavior from WorkItem Type')) {
+                  _callAPI -method Delete -Url ("$url/behaviors/{0}?api-version={1}" -f $b.behavior.id, (_getApiVersion Processes))
                }
             }
-            return
-      }
-      if ($wit.behaviors.count -gt 0 -and  $wit.behaviors.behavior.id -contains $Behavior) {
-         Write-Warning "'$workitemType' is already assigned to $Behavior!. To change the default, remove and re-add it." ;return
-      }
-      if ($wit.behaviors.count -gt 0 -and  $wit.behaviors.behavior.id -notcontains $Behavior) {
-         Write-Warning ("'$workitemType' is already assigned to $($wit.behaviors.behavior.id) remove it before assigning to another type") ; return
-      }
-      
-      $params = @{
-         method      = "Post"
-         url         = "$url/behaviors?api-version=" + (_getApiVersion Processes)  
-         ContentType = "application/json" 
-         body        = ConvertTo-JSON @{
-            behavior  = @{id= $Behavior} 
-            isDefault = $IsDefault -as [bool]
-            id        = $wit.referenceName
+            continue
          }
-      }
-      if ($Force -or $PSCmdlet.ShouldProcess($WorkItemType,"Modify $ProcessTemplate to update definition of workitem type") ) {
-         try   { 
-            $resp = _callapi @params -ErrorAction stop  
-            $r = [PSCustomObject][ordered]@{ ProcessTemplate = $ProcessTemplate; 
-                                             WorkItemType    = $WorkItemType 
-                                             Behavior        = $resp.behavior.id
-                                             IsDefault       = $resp.isdefault  }
-            $r.PSObject.TypeNames.Insert(0, 'vsteam_lib.WorkItembehavior')
-            
-            return $r
+         if     ($w.behaviors.count -gt 0 -and  $w.behaviors.behavior.id -contains $Behavior) {
+            Write-Warning "'$($w.name)' is already assigned to $Behavior!. To change the default, remove and re-add it." ; continue
          }
-         catch { Write-Warning "$workitemType exists, but failed to update. It may not be possible to change this type."}
+         elseif ($w.behaviors.count -gt 0 ) {
+            Write-Warning ("'$($w.name)' is already assigned to $($w.behaviors.behavior.id) remove it before assigning to another type") ; continue
+         }
+
+         $params = @{
+            method      = "Post"
+            url         = "$url/behaviors?api-version=" + (_getApiVersion Processes)
+            body        = ConvertTo-JSON @{
+               behavior  = @{id= $Behavior}
+               isDefault = $IsDefault -as [bool]
+               id        = $w.referenceName
+            }
+         }
+         if ($Force -or $PSCmdlet.ShouldProcess($w.name,"Modify $ProcessTemplate to update behavior of workitem type") ) {
+            try   {
+               $resp = _callapi @params -ErrorAction stop
+               $r = [PSCustomObject][ordered]@{ ProcessTemplate = $ProcessTemplate;
+                                                WorkItemType    = $w.name
+                                                Behavior        = $resp.behavior.id
+                                                IsDefault       = $resp.isdefault  }
+               $r.PSObject.TypeNames.Insert(0, 'vsteam_lib.WorkItembehavior')
+
+               Write-Output $r
+            }
+            catch { Write-Warning "$($w.name) exists, but failed to update. It may not be possible to change this type."}
+         }
       }
    }
 }

--- a/Source/Public/Set-VSTeamWorkItemBehavior.ps1
+++ b/Source/Public/Set-VSTeamWorkItemBehavior.ps1
@@ -22,57 +22,59 @@ function Set-VSTeamWorkItemBehavior {
       [switch]$Force
    )
    process {
-      #Get real backlog behaviors - skip those with a rank of 0
-      if (-not $remove) {
-         $processbehaviors = Get-VSTeamProcessBehavior -ProcessTemplate $ProcessTemplate | Where-Object Rank -gt 0
-         #Allow either the name or feature name
-         if ($Behavior -in $processbehaviors.name) {
-             $Behavior = $processbehaviors.Where({$_.name -eq $Behavior}).referencename
+      foreach ($p in $ProcessTemplate) {
+         #Get real backlog behaviors - skip those with a rank of 0
+         if (-not $remove) {
+            $processbehaviors = Get-VSTeamProcessBehavior -ProcessTemplate $p | Where-Object Rank -gt 0
+            #Allow either the name or feature name
+            if ($Behavior -in $processbehaviors.name) {
+               $Behavior = $processbehaviors.Where({$_.name -eq $Behavior}).referencename
+            }
+            if ($Behavior -notin $processbehaviors.referencename) {
+               Write-Warning ("$Behavior is not a valid behavior name. Possible names are '" + ($processbehaviors.name -join "', '") + "'") ; return
+            }
          }
-         if ($Behavior -notin $processbehaviors.referencename) {
-            Write-Warning ("$Behavior is not a valid behavior name. Possible names are '" + ($processbehaviors.name -join "', '") + "'") ; return
-         }
-      }
-      $wit = Get-VSTeamWorkitemType -ProcessTemplate $ProcessTemplate -WorkItemType $WorkItemType -Expand behaviors
-      foreach ($w in $wit) {
-         $url = ($w.url -replace '/workItemTypes/' , '/workitemtypesbehaviors/')
-         if     ($Remove -and $w.behaviors.Count -eq 0  ) {Write-Warning  "Nothing to do for $($w.name)!" ; continue}
-         elseif ($Remove) {
-            foreach ($b in $w.behaviors) {
-               if ($force -or $PSCmdlet.ShouldProcess($w.name,'Remove behavior from WorkItem Type')) {
-                  _callAPI -method Delete -Url ("$url/behaviors/{0}?api-version={1}" -f $b.behavior.id, (_getApiVersion Processes))
+         $wit = Get-VSTeamWorkitemType -ProcessTemplate $p -WorkItemType $WorkItemType -Expand behaviors
+         foreach ($w in $wit) {
+            $url = ($w.url -replace '/workItemTypes/' , '/workitemtypesbehaviors/')
+            if     ($Remove -and $w.behaviors.Count -eq 0  ) {Write-Warning  "Nothing to do for $($w.name)!" ; continue}
+            elseif ($Remove) {
+               foreach ($b in $w.behaviors) {
+                  if ($force -or $PSCmdlet.ShouldProcess($w.name,'Remove behavior from WorkItem Type')) {
+                     _callAPI -method Delete -Url ("$url/behaviors/{0}?api-version={1}" -f $b.behavior.id, (_getApiVersion Processes))
+                  }
+               }
+               continue
+            }
+            if     ($w.behaviors.count -gt 0 -and  $w.behaviors.behavior.id -contains $Behavior) {
+               Write-Warning "'$($w.name)' is already assigned to $Behavior!. To change the default, remove and re-add it." ; continue
+            }
+            elseif ($w.behaviors.count -gt 0 ) {
+               Write-Warning ("'$($w.name)' is already assigned to $($w.behaviors.behavior.id) remove it before assigning to another type") ; continue
+            }
+
+            $params = @{
+               method      = "Post"
+               url         = "$url/behaviors?api-version=" + (_getApiVersion Processes)
+               body        = ConvertTo-JSON @{
+                  behavior  = @{id= $Behavior}
+                  isDefault = $IsDefault -as [bool]
+                  id        = $w.referenceName
                }
             }
-            continue
-         }
-         if     ($w.behaviors.count -gt 0 -and  $w.behaviors.behavior.id -contains $Behavior) {
-            Write-Warning "'$($w.name)' is already assigned to $Behavior!. To change the default, remove and re-add it." ; continue
-         }
-         elseif ($w.behaviors.count -gt 0 ) {
-            Write-Warning ("'$($w.name)' is already assigned to $($w.behaviors.behavior.id) remove it before assigning to another type") ; continue
-         }
+            if ($Force -or $PSCmdlet.ShouldProcess($w.name,"Modify $p to update behavior of workitem type") ) {
+               try   {
+                  $resp = _callapi @params -ErrorAction stop
+                  $r = [PSCustomObject][ordered]@{ ProcessTemplate = $p;
+                                                   WorkItemType    = $w.name
+                                                   Behavior        = $resp.behavior.id
+                                                   IsDefault       = $resp.isdefault  }
+                  $r.PSObject.TypeNames.Insert(0, 'vsteam_lib.WorkItembehavior')
 
-         $params = @{
-            method      = "Post"
-            url         = "$url/behaviors?api-version=" + (_getApiVersion Processes)
-            body        = ConvertTo-JSON @{
-               behavior  = @{id= $Behavior}
-               isDefault = $IsDefault -as [bool]
-               id        = $w.referenceName
+                  Write-Output $r
+               }
+               catch { Write-Warning "$($w.name) exists, but failed to update. It may not be possible to change this type."}
             }
-         }
-         if ($Force -or $PSCmdlet.ShouldProcess($w.name,"Modify $ProcessTemplate to update behavior of workitem type") ) {
-            try   {
-               $resp = _callapi @params -ErrorAction stop
-               $r = [PSCustomObject][ordered]@{ ProcessTemplate = $ProcessTemplate;
-                                                WorkItemType    = $w.name
-                                                Behavior        = $resp.behavior.id
-                                                IsDefault       = $resp.isdefault  }
-               $r.PSObject.TypeNames.Insert(0, 'vsteam_lib.WorkItembehavior')
-
-               Write-Output $r
-            }
-            catch { Write-Warning "$($w.name) exists, but failed to update. It may not be possible to change this type."}
          }
       }
    }

--- a/Source/Public/Set-VSTeamWorkItemType.ps1
+++ b/Source/Public/Set-VSTeamWorkItemType.ps1
@@ -1,0 +1,90 @@
+function Set-VSTeamWorkItemType {
+   [CmdletBinding(DefaultParameterSetName='LeaveAlone',SupportsShouldProcess=$true,ConfirmImpact='High')]
+   param(
+      [parameter(ValueFromPipelineByPropertyName=$true)]
+      [vsteam_lib.ProcessTemplateValidateAttribute()]
+      [ArgumentCompleter([vsteam_lib.ProcessTemplateCompleter])]
+      $ProcessTemplate = $env:TEAM_PROCESS,
+
+      [parameter(Mandatory = $true,ValueFromPipelineByPropertyName=$true, Position=0)]
+      [ArgumentCompleter([vsteam_lib.WorkItemTypeCompleter])]
+      [Alias('Name')]
+      $WorkItemType,
+
+      [string] $Description,
+
+      [ArgumentCompleter([vsteam_lib.ColorCompleter])]
+      [vsteam_lib.ColorTransformToHexAttribute()]
+      $Color,
+
+      [vsteam_lib.IconTransformAttribute()]
+      [ArgumentCompleter([vsteam_lib.IconCompleter])]
+      [string]$Icon ,
+
+      [parameter(ParameterSetName='Hide', Mandatory = $true)]
+      [switch]$Disabled,
+
+      [parameter(ParameterSetName='Show', Mandatory = $true)]
+      [switch]$Enabled,
+
+      [switch]$Force
+   )
+   process {
+      #Get the existing workitem-type definition. Drop out if can't be found 
+      $wit  = Get-VSTeamWorkItemType -ProcessTemplate $ProcessTemplate -WorkItemType $WorkItemType
+      if (-not $wit) {Write-Warning "'$workitemType' does not appear to be a valid Workitem type." ; return}
+      else           {$url  = $wit.url + "?api-version=" + (_getApiVersion Processes)  }
+
+#region set up the contents to go in the JSON body
+      $body = @{} #note. "Changing" some options to their current value has caused errors but those below seem OK...
+      if ($Icon -and $Icon -ne $wit.icon) {
+               $body['icon']        = $Icon
+      }
+      else {   $body['icon']        = $wit.icon}
+
+      if ($Color -match '^[\da-f]{6}$' -and $color -ne $wit.color) {
+               $body['color']       = $Color
+      }
+      else {   $body['color']       = $wit.color}
+
+      if ($Description -and $Description -ne $wit.description) {
+               $body['description'] = $Description 
+      } 
+      else {   $body['description'] = $wit.description }
+      
+      if ($Disabled -and -not $wit.isDisabled) {
+               $body['isDisabled']  = $true 
+      }        
+      elseif($Enabled    -and $wit.isDisabled) {
+               $body['isDisabled']  = $false 
+      }
+      else  {  $body['isDisabled']  = $wit.isDisabled }
+#endregion      
+     if ($Force -or $PSCmdlet.ShouldProcess($WorkItemType,"Modify $ProcessTemplate, to update definition of workitem type") ) {
+         <# Call the REST API - 
+            if this system definition POST a new definition inheriting from the existing one
+            if it is a custom or inherited defintion use PATCH to make chanages. 
+         #>
+         try   { 
+               if ($wit.customization -ne 'system') { 
+                   $resp = _callapi -Url $url -method  Patch  -ContentType "application/json" -body (ConvertTo-Json $body) -ErrorAction stop 
+               }
+               else { #for system items we have to POST to the creation URL
+                  $body['inheritsFrom'] = $wit.referenceName
+                  $url    = ($url -replace 'workItemTypes/.*$' , 'workItemTypes?api-version=')  + (_getApiVersion Processes) 
+                  $resp = _callapi -Url $url -method  POST  -ContentType "application/json" -body (ConvertTo-Json $body) -ErrorAction stop 
+               }
+
+          }
+         catch { Write-Warning "$workitemType exists, but failed to update. It may not be possible to change this type."}
+
+         # Apply a Type Name so we can use custom format view and custom type extensions and add workitemType
+         # and processTemplate properties to become a parameters when the object is piped into other functions
+         _applyTypesWorkItemType -item $resp
+         Add-Member -InputObject $resp -MemberType AliasProperty -Name WorkItemType    -Value "name"
+         Add-Member -InputObject $resp -MemberType NoteProperty  -Name ProcessTemplate -Value $ProcessTemplate
+
+         return $resp 
+      }
+   }
+}

--- a/Source/Public/Set-VSTeamWorkItemType.ps1
+++ b/Source/Public/Set-VSTeamWorkItemType.ps1
@@ -30,61 +30,63 @@ function Set-VSTeamWorkItemType {
       [switch]$Force
    )
    process {
-      #Get the existing workitem-type definition. Drop out if can't be found 
+      #Get the existing workitem-type definition. Drop out if can't be found
       $wit  = Get-VSTeamWorkItemType -ProcessTemplate $ProcessTemplate -WorkItemType $WorkItemType
-      if (-not $wit) {Write-Warning "'$workitemType' does not appear to be a valid Workitem type." ; return}
-      else           {$url  = $wit.url + "?api-version=" + (_getApiVersion Processes)  }
+      if (-not $wit) {Write-Warning "'$workitemType' does not match a Workitem type." ; return}
 
-#region set up the contents to go in the JSON body
-      $body = @{} #note. "Changing" some options to their current value has caused errors but those below seem OK...
-      if ($Icon -and $Icon -ne $wit.icon) {
-               $body['icon']        = $Icon
-      }
-      else {   $body['icon']        = $wit.icon}
+      foreach ($w in $wit)   {
+         $url  = $w.url + "?api-version=" + (_getApiVersion Processes)
 
-      if ($Color -match '^[\da-f]{6}$' -and $color -ne $wit.color) {
-               $body['color']       = $Color
-      }
-      else {   $body['color']       = $wit.color}
+         #region set up the contents to go in the JSON body
+         $body = @{} #note. "Changing" some options to their current value has caused errors but those below seem OK...
+         if ($Icon -and $Icon -ne $w.icon) {
+                  $body['icon']        = $Icon
+         }
+         else {   $body['icon']        = $w.icon}
 
-      if ($Description -and $Description -ne $wit.description) {
-               $body['description'] = $Description 
-      } 
-      else {   $body['description'] = $wit.description }
-      
-      if ($Disabled -and -not $wit.isDisabled) {
-               $body['isDisabled']  = $true 
-      }        
-      elseif($Enabled    -and $wit.isDisabled) {
-               $body['isDisabled']  = $false 
-      }
-      else  {  $body['isDisabled']  = $wit.isDisabled }
-#endregion      
-     if ($Force -or $PSCmdlet.ShouldProcess($WorkItemType,"Modify $ProcessTemplate, to update definition of workitem type") ) {
-         <# Call the REST API - 
-            if this system definition POST a new definition inheriting from the existing one
-            if it is a custom or inherited defintion use PATCH to make chanages. 
-         #>
-         try   { 
-               if ($wit.customization -ne 'system') { 
-                   $resp = _callapi -Url $url -method  Patch  -ContentType "application/json" -body (ConvertTo-Json $body) -ErrorAction stop 
-               }
-               else { #for system items we have to POST to the creation URL
-                  $body['inheritsFrom'] = $wit.referenceName
-                  $url    = ($url -replace 'workItemTypes/.*$' , 'workItemTypes?api-version=')  + (_getApiVersion Processes) 
-                  $resp = _callapi -Url $url -method  POST  -ContentType "application/json" -body (ConvertTo-Json $body) -ErrorAction stop 
-               }
+         if ($Color -match '^[\da-f]{6}$' -and $color -ne $w.color) {
+                  $body['color']       = $Color
+         }
+         else {   $body['color']       = $w.color}
 
-          }
-         catch { Write-Warning "$workitemType exists, but failed to update. It may not be possible to change this type."}
+         if ($Description -and $Description -ne $w.description) {
+                  $body['description'] = $Description
+         }
+         else {   $body['description'] = $w.description }
 
-         # Apply a Type Name so we can use custom format view and custom type extensions and add workitemType
-         # and processTemplate properties to become a parameters when the object is piped into other functions
-         _applyTypesWorkItemType -item $resp
-         Add-Member -InputObject $resp -MemberType AliasProperty -Name WorkItemType    -Value "name"
-         Add-Member -InputObject $resp -MemberType NoteProperty  -Name ProcessTemplate -Value $ProcessTemplate
+         if ($Disabled -and -not $w.isDisabled) {
+                  $body['isDisabled']  = $true
+         }
+         elseif($Enabled    -and $w.isDisabled) {
+                  $body['isDisabled']  = $false }
+         else {   $body['isDisabled']  = $w.isDisabled }
+         #endregion
 
-         return $resp 
+         if ($Force -or $PSCmdlet.ShouldProcess($w.Name,"Modify $ProcessTemplate, to update definition of workitem type") ) {
+            <# Call the REST API -
+               if this is a *system* definition then POST a new definition inheriting from the existing one
+               if it is a custom or inherited defintion then use PATCH to make chanages.
+            #>
+            try   {
+                  if ($w.customization -ne 'system') {
+                     $resp = _callapi -Url $url -method  Patch  -ContentType "application/json" -body (ConvertTo-Json $body) -ErrorAction stop
+                  }
+                  else {
+                     $body['inheritsFrom'] = $w.referenceName
+                     $url    = ($url -replace 'workItemTypes/.*$' , 'workItemTypes?api-version=')  + (_getApiVersion Processes)
+                     $resp = _callapi -Url $url -method  POST  -ContentType "application/json" -body (ConvertTo-Json $body) -ErrorAction stop
+                  }
+            }
+            catch { Write-Warning "$workitemType exists, but failed to update. It may not be possible to change this type." ; continue}
+
+            # Apply a Type Name so we can use custom format view and custom type extensions and add workitemType
+            # and processTemplate properties to become a parameters when the object is piped into other functions
+            _applyTypesWorkItemType -item $resp
+            Add-Member -InputObject $resp -MemberType AliasProperty -Name WorkItemType    -Value "name"
+            Add-Member -InputObject $resp -MemberType NoteProperty  -Name ProcessTemplate -Value $ProcessTemplate
+
+            Write-Output $resp
+         }
       }
    }
 }

--- a/Source/Public/Unlock-VSTeamWorkItemType.ps1
+++ b/Source/Public/Unlock-VSTeamWorkItemType.ps1
@@ -1,0 +1,44 @@
+function Unlock-VSTeamWorkItemType {
+   [CmdletBinding(SupportsShouldProcess=$true,ConfirmImpact='High')]
+   param(
+      [Parameter(Position=0,ValueFromPipeline=$true,Mandatory=$true)]
+      $WorkItemType,
+
+      [AllowNull()]
+      [ValidateSet('behaviors','layout','states')]
+      [string[]]$Expand,
+
+      [switch]$Force
+   )
+   process {
+      if (-not ($WorkItemType.psobject.properties["customization"] -and $WorkItemType.customization -eq 'system')) {
+         return $WorkItemType
+      }
+      else {
+         $url  = ($WorkItemType.url -replace '/workItemTypes/.*$', '/workItemTypes?api-version=') +  (_getApiVersion Processes)
+         $body = @{
+            color        = $WorkItemType.color
+            description  = $WorkItemType.description
+            icon         = $WorkItemType.icon
+            inheritsFrom = $WorkItemType.referenceName
+            isDisabled   = $WorkItemType.isDisabled
+            name         = $WorkItemType.name
+         }
+         if ($force -or $PSCmdlet.ShouldProcess($WorkItemType.name,"Update WorkItemType")) {
+            $resp = _callAPI -Url $url -method Post -body (ConvertTo-Json $body)
+            if ($expand) {Get-VSTeamWorkItemType -ProcessTemplate $WorkItemType.ProcessTemplate -WorkItemType $WorkItemType.name -Expand $Expand}
+            else         {
+               # Apply a Type Name so we can use custom format view and/or custom type extensions
+               #  add members to help piping into other functions
+               _applyTypesWorkItemType -item $resp
+               Add-Member -InputObject $resp -MemberType AliasProperty -Name "WorkItemType"    -Value "name"
+               if ($WorkItemType.psobject.properties["ProcessTemplate"]) {
+                  Add-Member -InputObject $resp -MemberType NoteProperty  -Name "ProcessTemplate" -Value $WorkItemType.ProcessTemplate
+               }
+               return $resp
+            }
+         }
+      }
+   }
+}
+

--- a/Source/Public/Unlock-VSTeamWorkItemType.ps1
+++ b/Source/Public/Unlock-VSTeamWorkItemType.ps1
@@ -1,6 +1,10 @@
 function Unlock-VSTeamWorkItemType {
    [CmdletBinding(SupportsShouldProcess=$true,ConfirmImpact='High')]
    param(
+      [vsteam_lib.ProcessTemplateValidateAttribute()]
+      [ArgumentCompleter([vsteam_lib.ProcessTemplateCompleter])]
+      $ProcessTemplate = $env:TEAM_PROCESS,
+
       [Parameter(Position=0,ValueFromPipeline=$true,Mandatory=$true)]
       $WorkItemType,
 
@@ -11,7 +15,18 @@ function Unlock-VSTeamWorkItemType {
       [switch]$Force
    )
    process {
-      if (-not ($WorkItemType.psobject.properties["customization"] -and $WorkItemType.customization -eq 'system')) {
+      if ($WorkItemType -is [string]) {
+         if ($expand) {
+            Get-VSTeamWorkItemType -ProcessTemplate $ProcessTemplate -WorkItemType $WorkItemType |
+               Unlock-VSTeamWorkItemType -Expand $Expand -Force:Force
+         }
+         else {
+            Get-VSTeamWorkItemType -ProcessTemplate $ProcessTemplate -WorkItemType $WorkItemType |
+               Unlock-VSTeamWorkItemType -Force:Force
+         }
+         return
+      }
+      elseif (-not ($WorkItemType.psobject.properties["customization"] -and $WorkItemType.customization -eq 'system')) {
          return $WorkItemType
       }
       else {
@@ -52,4 +67,3 @@ function Unlock-VSTeamWorkItemType {
       }
    }
 }
-

--- a/Source/Public/Unlock-VSTeamWorkItemType.ps1
+++ b/Source/Public/Unlock-VSTeamWorkItemType.ps1
@@ -25,11 +25,22 @@ function Unlock-VSTeamWorkItemType {
             name         = $WorkItemType.name
          }
          if ($force -or $PSCmdlet.ShouldProcess($WorkItemType.name,"Update WorkItemType")) {
-            $resp = _callAPI -Url $url -method Post -body (ConvertTo-Json $body)
+            # Call the Rest API. _callAPi displays errors for the user and throws,
+            # if this happens half way through processing to mulitple work item types
+            # don't stop with some done and some not.
+            try   {$resp = _callAPI -Url $url -method Post -body (ConvertTo-Json $body) }
+            catch {
+               $msg = "An Error occured trying to create the inherited version of " + $WorkItemType.name + "."
+               if ($WorkItemType.psobject.Properties["ProcessTemplate"]) {
+                  $msg = $msg -replace "\.$",  " in Process Template $($WorkItemType.ProcessTemplate)."
+               }
+               Write-Warning $msg
+               return
+            }
             if ($expand) {Get-VSTeamWorkItemType -ProcessTemplate $WorkItemType.ProcessTemplate -WorkItemType $WorkItemType.name -Expand $Expand}
             else         {
                # Apply a Type Name so we can use custom format view and/or custom type extensions
-               #  add members to help piping into other functions
+               # and add members to help piping into other functions
                _applyTypesWorkItemType -item $resp
                Add-Member -InputObject $resp -MemberType AliasProperty -Name "WorkItemType"    -Value "name"
                if ($WorkItemType.psobject.properties["ProcessTemplate"]) {

--- a/Source/formats/_formats.json
+++ b/Source/formats/_formats.json
@@ -81,6 +81,7 @@
       "vsteam_lib.Project.ListView.ps1xml",
       "vsteam_lib.Process.TableView.ps1xml",
       "vsteam_lib.Process.ListView.ps1xml",
+      "vsteam_lib.ProcessBehavior.TableView.ps1xml",
       "vsteam_lib.AgentPool.TableView.ps1xml",
       "vsteam_lib.Provider.AgentPool.TableView.ps1xml",
       "vsteam_lib.Extension.TableView.ps1xml",

--- a/Source/formats/_formats.json
+++ b/Source/formats/_formats.json
@@ -94,6 +94,7 @@
       "vsteam_lib.PSDrive.Default.ListView.ps1xml",
       "vsteam_lib.WorkItemType.TableView.ps1xml",
       "vsteam_lib.WorkItemType.ListView.ps1xml",
+      "vsteam_lib.WorkItemBehavior.TableView.ps1xml",
       "vsteam_lib.Wiql.TableView.ps1xml",
       "vsteam_lib.Wiql.ListView.ps1xml",
       "vsteam_lib.WorkItem.TableView.ps1xml",

--- a/Source/formats/vsteam_lib.ProcessBehavior.TableView.ps1xml
+++ b/Source/formats/vsteam_lib.ProcessBehavior.TableView.ps1xml
@@ -1,0 +1,60 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<Configuration>
+	<ViewDefinitions>
+		<View>
+			<Name>vsteam_lib.ProcessBehavior.TableView</Name>
+			<ViewSelectedBy>
+				<TypeName>vsteam_lib.ProcessBehavior</TypeName>
+			</ViewSelectedBy>
+			<TableControl>
+				<AutoSize />
+				<TableHeaders>
+					<TableColumnHeader>
+						<Label>Rank</Label>
+					</TableColumnHeader>
+					<TableColumnHeader>
+						<Label>Name</Label>
+					</TableColumnHeader>
+					<TableColumnHeader>
+						<Label>Workitem types</Label>
+					</TableColumnHeader>
+					<TableColumnHeader>
+						<Label>Inherits</Label>
+					</TableColumnHeader>
+					<TableColumnHeader>
+						<Label>color</Label>
+					</TableColumnHeader>
+					<TableColumnHeader>
+						<Label>Description</Label>
+					</TableColumnHeader>
+
+				</TableHeaders>
+				<TableRowEntries>
+					<TableRowEntry>
+						<Wrap />
+						<TableColumnItems>
+							<TableColumnItem>
+								<PropertyName>Rank</PropertyName>
+							</TableColumnItem>
+							<TableColumnItem>
+								<PropertyName>Name</PropertyName>
+							</TableColumnItem>
+							<TableColumnItem>
+								<PropertyName>LinkedWorkItemTypes</PropertyName>
+							</TableColumnItem>
+							<TableColumnItem>
+								<ScriptBlock>$_.inherits.behaviorRefName</ScriptBlock>
+							</TableColumnItem>
+							<TableColumnItem>
+								<PropertyName>color</PropertyName>
+							</TableColumnItem>
+							<TableColumnItem>
+								<PropertyName>description</PropertyName>
+							</TableColumnItem>
+						</TableColumnItems>
+					</TableRowEntry>
+				</TableRowEntries>
+			</TableControl>
+		</View>
+	</ViewDefinitions>
+</Configuration>

--- a/Source/formats/vsteam_lib.WorkItemBehavior.TableView.ps1xml
+++ b/Source/formats/vsteam_lib.WorkItemBehavior.TableView.ps1xml
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<Configuration>
+	<ViewDefinitions>
+		<View>
+			<Name>vsteam_lib.WorkItemBehavior.TableView</Name>
+			<ViewSelectedBy>
+				<TypeName>vsteam_lib.WorkItemBehavior</TypeName>
+			</ViewSelectedBy>
+			<TableControl>
+				<AutoSize />
+				<TableHeaders>
+					<TableColumnHeader>
+						<Label>WorkItem Type</Label>
+					</TableColumnHeader>
+					<TableColumnHeader>
+						<Label>Behavior ID</Label>
+					</TableColumnHeader>
+					<TableColumnHeader>
+						<Label>Is Default</Label>
+					</TableColumnHeader>
+				</TableHeaders>
+				<TableRowEntries>
+					<TableRowEntry>
+						<Wrap />
+						<TableColumnItems>
+							<TableColumnItem>
+								<PropertyName>WorkItemType</PropertyName>
+							</TableColumnItem>
+							<TableColumnItem>
+								<PropertyName>BehaviorID</PropertyName>
+							</TableColumnItem>
+							<TableColumnItem>
+								<PropertyName>isDefault</PropertyName>
+							</TableColumnItem>
+						</TableColumnItems>
+					</TableRowEntry>
+				</TableRowEntries>
+			</TableControl>
+		</View>
+	</ViewDefinitions>
+</Configuration>

--- a/Tests/SampleFiles/Get-VSTeamProcess.json
+++ b/Tests/SampleFiles/Get-VSTeamProcess.json
@@ -4,7 +4,7 @@
     {
       "typeId": "6b724908-ef14-45cf-84f8-768b5384da45",
       "name": "Scrum",
-      "referenceName": null,
+      "referenceName": "test",
       "description": "This template is for teams who follow the Scrum framework.",
       "parentProcessTypeId": "00000000-0000-0000-0000-000000000000",
       "isEnabled": true,
@@ -16,6 +16,20 @@
       "name": "Agile",
       "referenceName": null,
       "description": "This template is flexible and will work great for most teams using Agile planning methods, including those practicing Scrum.",
+      "projects": [
+        {
+          "id": "f5563894-c8da-49cf-bf5c-7caeaeed1af7",
+          "name": "Voting-App",
+          "description": "Vote App",
+          "url": "vstfs:///Classification/TeamProject/f5563894-c8da-49cf-bf5c-7caeaeed1af7"
+        },
+        {
+          "id": "15af52f7-47f1-40a7-817a-7661062cea76",
+          "name": "PeopleTracker",
+          "description": null,
+          "url": "vstfs:///Classification/TeamProject/15af52f7-47f1-40a7-817a-7661062cea76"
+        }
+      ],
       "parentProcessTypeId": "00000000-0000-0000-0000-000000000000",
       "isEnabled": true,
       "isDefault": true,

--- a/Tests/SampleFiles/processesBehaviors.json
+++ b/Tests/SampleFiles/processesBehaviors.json
@@ -1,0 +1,71 @@
+{
+  "count": 6,
+  "value": [
+    {
+      "name": "Ordered",
+      "referenceName": "System.OrderedBehavior",
+      "color": null,
+      "rank": 0,
+      "description": "Enables work items to be ordered relative to other work items",
+      "customization": "inherited",
+      "fields": "",
+      "inherits": null,
+      "url": "https://dev.azure.com/aticpac/_apis/work/processes/6b724908-ef14-45cf-84f8-768b5384da45/behaviors/System.OrderedBehavior"
+    },
+    {
+      "name": "Backlog items",
+      "referenceName": "System.RequirementBacklogBehavior",
+      "color": "009CCC",
+      "rank": 20,
+      "description": "Requirement level backlog and board",
+      "customization": "inherited",
+      "fields": " ",
+      "inherits": "@{behaviorRefName=System.OrderedBehavior; url=https://dev.azure.com/aticpac/_apis/work/processes/6b724908-ef14-45cf-84f8-768b5384da45/behaviors/System.OrderedBehavior}",
+      "url": "https://dev.azure.com/aticpac/_apis/work/processes/6b724908-ef14-45cf-84f8-768b5384da45/behaviors/System.RequirementBacklogBehavior"
+    },
+    {
+      "name": "Epics",
+      "referenceName": "Microsoft.VSTS.Scrum.EpicBacklogBehavior",
+      "color": "FF7B00",
+      "rank": 40,
+      "description": "Epic level backlog and board",
+      "customization": "system",
+      "fields": "",
+      "inherits": "@{behaviorRefName=System.PortfolioBacklogBehavior; url=https://dev.azure.com/aticpac/_apis/work/processes/6b724908-ef14-45cf-84f8-768b5384da45/behaviors/System.PortfolioBacklogBehavior}",
+      "url": "https://dev.azure.com/aticpac/_apis/work/processes/6b724908-ef14-45cf-84f8-768b5384da45/behaviors/Microsoft.VSTS.Scrum.EpicBacklogBehavior"
+    },
+    {
+      "name": "Features",
+      "referenceName": "Microsoft.VSTS.Scrum.FeatureBacklogBehavior",
+      "color": "773B93",
+      "rank": 30,
+      "description": "Feature level backlog and board",
+      "customization": "system",
+      "fields": "",
+      "inherits": "@{behaviorRefName=System.PortfolioBacklogBehavior; url=https://dev.azure.com/aticpac/_apis/work/processes/6b724908-ef14-45cf-84f8-768b5384da45/behaviors/System.PortfolioBacklogBehavior}",
+      "url": "https://dev.azure.com/aticpac/_apis/work/processes/6b724908-ef14-45cf-84f8-768b5384da45/behaviors/Microsoft.VSTS.Scrum.FeatureBacklogBehavior"
+    },
+    {
+      "name": "Tasks",
+      "referenceName": "System.TaskBacklogBehavior",
+      "color": "F2CB1D",
+      "rank": 10,
+      "description": "Task level backlog and board",
+      "customization": "system",
+      "fields": "  ",
+      "inherits": "@{behaviorRefName=System.OrderedBehavior; url=https://dev.azure.com/aticpac/_apis/work/processes/6b724908-ef14-45cf-84f8-768b5384da45/behaviors/System.OrderedBehavior}",
+      "url": "https://dev.azure.com/aticpac/_apis/work/processes/6b724908-ef14-45cf-84f8-768b5384da45/behaviors/System.TaskBacklogBehavior"
+    },
+    {
+      "name": "Portfolio",
+      "referenceName": "System.PortfolioBacklogBehavior",
+      "color": null,
+      "rank": 0,
+      "description": "Portfolio level backlog and board",
+      "customization": "system",
+      "fields": "",
+      "inherits": "@{behaviorRefName=System.OrderedBehavior; url=https://dev.azure.com/aticpac/_apis/work/processes/6b724908-ef14-45cf-84f8-768b5384da45/behaviors/System.OrderedBehavior}",
+      "url": "https://dev.azure.com/aticpac/_apis/work/processes/6b724908-ef14-45cf-84f8-768b5384da45/behaviors/System.PortfolioBacklogBehavior"
+    }
+  ]
+}

--- a/Tests/SampleFiles/workitemsWithBehaviors.json
+++ b/Tests/SampleFiles/workitemsWithBehaviors.json
@@ -1,0 +1,136 @@
+[
+  {
+    "referenceName": "Microsoft.VSTS.WorkItemTypes.Task",
+    "name": "Task",
+    "description": "Tracks work that needs to be done.",
+    "url": "https://dev.azure.com/aticpac/_apis/work/processes/6b724908-ef14-45cf-84f8-768b5384da45/workItemTypes/Microsoft.VSTS.WorkItemTypes.Task",
+    "customization": "system",
+    "color": "F2CB1D",
+    "icon": "icon_clipboard",
+    "isDisabled": false,
+    "inherits": null,
+    "behaviors": [
+      "@{behavior=; isDefault=True; isLegacyDefault=True; url=https://dev.azure.com/aticpac/_apis/work/processes/6b724908-ef14-45cf-84f8-768b5384da45/behaviors/System.TaskBacklogBehavior}"
+    ],
+    "WorkItemType": "Task",
+    "ProcessTemplate": "Scrum"
+  },
+  {
+    "referenceName": "Microsoft.VSTS.WorkItemTypes.Bug",
+    "name": "Bug",
+    "description": "Describes a divergence between required and actual behavior, and tracks the work done to correct the defect and verify the correction.",
+    "url": "https://dev.azure.com/aticpac/_apis/work/processes/6b724908-ef14-45cf-84f8-768b5384da45/workItemTypes/Microsoft.VSTS.WorkItemTypes.Bug",
+    "customization": "system",
+    "color": "CC293D",
+    "icon": "icon_insect",
+    "isDisabled": false,
+    "inherits": null,
+    "behaviors": [],
+    "WorkItemType": "Bug",
+    "ProcessTemplate": "Scrum"
+  },
+  {
+    "referenceName": "Microsoft.VSTS.WorkItemTypes.Epic",
+    "name": "Epic",
+    "description": "Epics help teams effectively manage and groom their product backlog",
+    "url": "https://dev.azure.com/aticpac/_apis/work/processes/6b724908-ef14-45cf-84f8-768b5384da45/workItemTypes/Microsoft.VSTS.WorkItemTypes.Epic",
+    "customization": "system",
+    "color": "FF7B00",
+    "icon": "icon_crown",
+    "isDisabled": false,
+    "inherits": null,
+    "behaviors": [
+      "@{behavior=; isDefault=True; isLegacyDefault=True; url=https://dev.azure.com/aticpac/_apis/work/processes/6b724908-ef14-45cf-84f8-768b5384da45/behaviors/Microsoft.VSTS.Scrum.EpicBacklogBehavior}"
+    ],
+    "WorkItemType": "Epic",
+    "ProcessTemplate": "Scrum"
+  },
+  {
+    "referenceName": "Microsoft.VSTS.WorkItemTypes.Feature",
+    "name": "Feature",
+    "description": "Tracks a feature that will be released with the product",
+    "url": "https://dev.azure.com/aticpac/_apis/work/processes/6b724908-ef14-45cf-84f8-768b5384da45/workItemTypes/Microsoft.VSTS.WorkItemTypes.Feature",
+    "customization": "system",
+    "color": "773B93",
+    "icon": "icon_trophy",
+    "isDisabled": false,
+    "inherits": null,
+    "behaviors": [
+      "@{behavior=; isDefault=True; isLegacyDefault=True; url=https://dev.azure.com/aticpac/_apis/work/processes/6b724908-ef14-45cf-84f8-768b5384da45/behaviors/Microsoft.VSTS.Scrum.FeatureBacklogBehavior}"
+    ],
+    "WorkItemType": "Feature",
+    "ProcessTemplate": "Scrum"
+  },
+  {
+    "referenceName": "Microsoft.VSTS.WorkItemTypes.Impediment",
+    "name": "Impediment",
+    "description": "Tracks an obstacle to progress.",
+    "url": "https://dev.azure.com/aticpac/_apis/work/processes/6b724908-ef14-45cf-84f8-768b5384da45/workItemTypes/Microsoft.VSTS.WorkItemTypes.Impediment",
+    "customization": "system",
+    "color": "B4009E",
+    "icon": "icon_traffic_cone",
+    "isDisabled": false,
+    "inherits": null,
+    "behaviors": [],
+    "WorkItemType": "Impediment",
+    "ProcessTemplate": "Scrum"
+  },
+  {
+    "referenceName": "Microsoft.VSTS.WorkItemTypes.ProductBacklogItem",
+    "name": "Product Backlog Item",
+    "description": "Tracks an activity the user will be able to perform with the product.",
+    "url": "https://dev.azure.com/aticpac/_apis/work/processes/6b724908-ef14-45cf-84f8-768b5384da45/workItemTypes/Microsoft.VSTS.WorkItemTypes.ProductBacklogItem",
+    "customization": "system",
+    "color": "009CCC",
+    "icon": "icon_list",
+    "isDisabled": false,
+    "inherits": null,
+    "behaviors": [
+      "@{behavior=; isDefault=True; isLegacyDefault=True; url=https://dev.azure.com/aticpac/_apis/work/processes/6b724908-ef14-45cf-84f8-768b5384da45/behaviors/System.RequirementBacklogBehavior}"
+    ],
+    "WorkItemType": "Product Backlog Item",
+    "ProcessTemplate": "Scrum"
+  },
+  {
+    "referenceName": "Microsoft.VSTS.WorkItemTypes.TestCase",
+    "name": "Test Case",
+    "description": "Server-side data for a set of steps to be tested.",
+    "url": "https://dev.azure.com/aticpac/_apis/work/processes/6b724908-ef14-45cf-84f8-768b5384da45/workItemTypes/Microsoft.VSTS.WorkItemTypes.TestCase",
+    "customization": "system",
+    "color": "004B50",
+    "icon": "icon_test_case",
+    "isDisabled": false,
+    "inherits": null,
+    "behaviors": [],
+    "WorkItemType": "Test Case",
+    "ProcessTemplate": "Scrum"
+  },
+  {
+    "referenceName": "Microsoft.VSTS.WorkItemTypes.TestPlan",
+    "name": "Test Plan",
+    "description": "Tracks test activities for a specific milestone or release.",
+    "url": "https://dev.azure.com/aticpac/_apis/work/processes/6b724908-ef14-45cf-84f8-768b5384da45/workItemTypes/Microsoft.VSTS.WorkItemTypes.TestPlan",
+    "customization": "system",
+    "color": "004B50",
+    "icon": "icon_test_plan",
+    "isDisabled": false,
+    "inherits": null,
+    "behaviors": [],
+    "WorkItemType": "Test Plan",
+    "ProcessTemplate": "Scrum"
+  },
+  {
+    "referenceName": "Microsoft.VSTS.WorkItemTypes.TestSuite",
+    "name": "Test Suite",
+    "description": "Tracks test activites for a specific feature, requirement, or user story.",
+    "url": "https://dev.azure.com/aticpac/_apis/work/processes/6b724908-ef14-45cf-84f8-768b5384da45/workItemTypes/Microsoft.VSTS.WorkItemTypes.TestSuite",
+    "customization": "system",
+    "color": "004B50",
+    "icon": "icon_test_suite",
+    "isDisabled": false,
+    "inherits": null,
+    "behaviors": [],
+    "WorkItemType": "Test Suite",
+    "ProcessTemplate": "Scrum"
+  }
+]

--- a/Tests/function/tests/Add-VSTeamProcess.Tests.ps1
+++ b/Tests/function/tests/Add-VSTeamProcess.Tests.ps1
@@ -1,10 +1,10 @@
 Set-StrictMode -Version Latest
 
-Describe 'Add-VSTeamProcess' {
+Describe 'VSTeamProcess' {
    BeforeAll {
       . "$PSScriptRoot\_testInitialize.ps1" $PSCommandPath
       . "$PSScriptRoot\..\..\..\Source\Public\Get-VSTeamProcess.ps1"
-    
+
 
       ## Arrange
       # Set the account to use for testing. A normal user would do this
@@ -13,14 +13,14 @@ Describe 'Add-VSTeamProcess' {
       Mock _getApiVersion    { return '1.0-unitTests' }
 
       Mock _callApi          {
-            #Return a single process object. Any process will do. 
+            #Return a single process object. Any process will do.
             return ([psCustomObject]@{
                typeId              = '6b724908-ef14-45cf-84f8-768b5384da45'
-               name                = 'Scrum' 
+               name                = 'Scrum'
                referenceName       = ''
                description         = 'This template is for teams who follow the Scrum framework.'
-               parentProcessTypeId = '00000000-0000-0000-0000-000000000000' 
-               isEnabled           = $True 
+               parentProcessTypeId = '00000000-0000-0000-0000-000000000000'
+               isEnabled           = $True
                isDefault           = $True
                customizationType   = 'system'
                })
@@ -34,34 +34,44 @@ Describe 'Add-VSTeamProcess' {
             [PSCustomObject]@{Name = "Scrum With Space"; ID = "12345678-0000-0000-0000-000000000000"}
          )
          if ($name) {return $processes.where({$_.name -like $name})}
-         else       {return $processes}  
+         else       {return $processes}
       }
       [vsteam_lib.ProcessTemplateCache]::Invalidate()
    }
 
-   Context 'Create a new process template' {
+   Context 'Add-VSTeamProcess' {
 
-      It 'Posts with basic parameters.' {
-         Add-VsteamProcess -Parent "Scrum" -processName "Scrum2"
+      It 'Posts with basic parameters when creating new process templates' {
+         Add-VsteamProcess -Parent "Scrum" -processName "Scrum2","Scrum3" -Force
          Should -Invoke _callApi -Exactly -Times 1 -Scope It -ParameterFilter {
-            $NoProject -eq       $true
-            $area      -eq       'Work'
-            $resource  -eq       'processes'
-            $Body      -match    '"parentProcessTypeId":\s+"6b724908-ef14-45cf-84f8-768b5384da45"' -and  
+            $Method    -eq       'Post'                      -and
+            $NoProject -eq       $true                       -and
+            $area      -eq       'Work'                      -and
+            $resource  -eq       'processes'                 -and
             $Body      -match    '"name":\s+"Scrum2"'        -and
             $Body      -notmatch 'ReferenceName|Description' -and
-            $Method    -eq       'Post'
+
+            $Body      -match    '"parentProcessTypeId":\s+"6b724908-ef14-45cf-84f8-768b5384da45"'
+         }
+         Should -Invoke _callApi -Exactly -Times 1 -Scope It -ParameterFilter {
+            $Method    -eq       'Post'                      -and
+            $NoProject -eq       $true                       -and
+            $area      -eq       'Work'                      -and
+            $resource  -eq       'processes'                 -and
+            $Body      -match    '"name":\s+"Scrum3"'        -and
+            $Body      -notmatch 'ReferenceName|Description' -and
+            $Body      -match    '"parentProcessTypeId":\s+"6b724908-ef14-45cf-84f8-768b5384da45"'
          }
       }
-      It 'Uses more than one template and Posts with ref name and description.' {
-         Add-VsteamProcess -Parent "Agile" -processName "Agile2" -referenceName "Custom.agile2" -Desc "Custom agile process"
+      It 'Uses more than one template and Posts with ref name and description when creating a new process template.' {
+         Add-VsteamProcess -Parent "Agile" -processName "Agile2" -referenceName "Custom.agile2" -Desc "Custom agile process" -Force
          Should -Invoke _callApi -Exactly -Times 1 -Scope It -ParameterFilter {
             $NoProject -eq       $true
             $area      -eq       'Work'
             $resource  -eq       'processes'
-            $Body   -match '"parentProcessTypeId":\s+"adcc42ab-9882-485e-a3ed-7678f01f66bc"' -and  
+            $Body   -match '"parentProcessTypeId":\s+"adcc42ab-9882-485e-a3ed-7678f01f66bc"' -and
             $Body   -match '"name":\s+"Agile2"'                       -and
-            $Body   -match '"ReferenceName":\s+"Custom\.agile2"'      -and 
+            $Body   -match '"ReferenceName":\s+"Custom\.agile2"'      -and
             $Body   -match '"Description":\s+"Custom agile process"'  -and
             $Method -eq       'Post'
          }

--- a/Tests/function/tests/Add-VSTeamProcess.Tests.ps1
+++ b/Tests/function/tests/Add-VSTeamProcess.Tests.ps1
@@ -1,0 +1,70 @@
+Set-StrictMode -Version Latest
+
+Describe 'Add-VSTeamProcess' {
+   BeforeAll {
+      . "$PSScriptRoot\_testInitialize.ps1" $PSCommandPath
+      . "$PSScriptRoot\..\..\..\Source\Public\Get-VSTeamProcess.ps1"
+    
+
+      ## Arrange
+      # Set the account to use for testing. A normal user would do this
+      # using the Set-VSTeamAccount function.
+      Mock _getInstance      { return 'https://dev.azure.com/test' }
+      Mock _getApiVersion    { return '1.0-unitTests' }
+
+      Mock _callApi          {
+            #Return a single process object. Any process will do. 
+            return ([psCustomObject]@{
+               typeId              = '6b724908-ef14-45cf-84f8-768b5384da45'
+               name                = 'Scrum' 
+               referenceName       = ''
+               description         = 'This template is for teams who follow the Scrum framework.'
+               parentProcessTypeId = '00000000-0000-0000-0000-000000000000' 
+               isEnabled           = $True 
+               isDefault           = $True
+               customizationType   = 'system'
+               })
+      }
+      Mock Get-VSTeamProcess {
+         $processes =  @(
+            [PSCustomObject]@{Name = "Scrum";            ID = "6b724908-ef14-45cf-84f8-768b5384da45"},
+            [PSCustomObject]@{Name = "Basic";            ID = "b8a3a935-7e91-48b8-a94c-606d37c3e9f2"},
+            [PSCustomObject]@{Name = "CMMI";             ID = "27450541-8e31-4150-9947-dc59f998fc01"},
+            [PSCustomObject]@{Name = "Agile";            ID = "adcc42ab-9882-485e-a3ed-7678f01f66bc"},
+            [PSCustomObject]@{Name = "Scrum With Space"; ID = "12345678-0000-0000-0000-000000000000"}
+         )
+         if ($name) {return $processes.where({$_.name -like $name})}
+         else       {return $processes}  
+      }
+      [vsteam_lib.ProcessTemplateCache]::Invalidate()
+   }
+
+   Context 'Create a new process template' {
+
+      It 'Posts with basic parameters.' {
+         Add-VsteamProcess -Parent "Scrum" -processName "Scrum2"
+         Should -Invoke _callApi -Exactly -Times 1 -Scope It -ParameterFilter {
+            $NoProject -eq       $true
+            $area      -eq       'Work'
+            $resource  -eq       'processes'
+            $Body      -match    '"parentProcessTypeId":\s+"6b724908-ef14-45cf-84f8-768b5384da45"' -and  
+            $Body      -match    '"name":\s+"Scrum2"'        -and
+            $Body      -notmatch 'ReferenceName|Description' -and
+            $Method    -eq       'Post'
+         }
+      }
+      It 'Uses more than one template and Posts with ref name and description.' {
+         Add-VsteamProcess -Parent "Agile" -processName "Agile2" -referenceName "Custom.agile2" -Desc "Custom agile process"
+         Should -Invoke _callApi -Exactly -Times 1 -Scope It -ParameterFilter {
+            $NoProject -eq       $true
+            $area      -eq       'Work'
+            $resource  -eq       'processes'
+            $Body   -match '"parentProcessTypeId":\s+"adcc42ab-9882-485e-a3ed-7678f01f66bc"' -and  
+            $Body   -match '"name":\s+"Agile2"'                       -and
+            $Body   -match '"ReferenceName":\s+"Custom\.agile2"'      -and 
+            $Body   -match '"Description":\s+"Custom agile process"'  -and
+            $Method -eq       'Post'
+         }
+      }
+   }
+}

--- a/Tests/function/tests/Add-VSTeamProcessBehavior.Tests.ps1
+++ b/Tests/function/tests/Add-VSTeamProcessBehavior.Tests.ps1
@@ -8,7 +8,7 @@ Describe 'VSTeamProcessBehavior' {
       # Set the account to use for testing. A normal user would do this
       # using the Set-VSTeamAccount function.
       Mock _getInstance       { return 'https://dev.azure.com/test' }
-      Mock _getApiVersion     { return '1.0-unitTests' } 
+      Mock _getApiVersion     { return '1.0-unitTests' }
       Mock _getDefaultProject { return "MockProject"}
    }
 
@@ -16,7 +16,7 @@ Describe 'VSTeamProcessBehavior' {
       BeforeAll {
          ## Arrange
          Mock _callAPi {return [pscustomobject]@{name="Dummy"}} -ParameterFilter {$method -eq "post"}
-         Mock _callAPi {return @{value=@{name="Dummy"}}} 
+         Mock _callAPi {return @{value=@{name="Dummy"}}}
          Mock Get-VSTeamProcess { return @(
               [PSCustomObject]@{
                   Name = "Scrum"
@@ -30,12 +30,12 @@ Describe 'VSTeamProcessBehavior' {
 
       It 'Calls the right API to add a process behavior' {
          ## Act
-         $behavior = Add-VSTeamProcessBehavior -ProcessTemplate Scrum -Name "Test" -Color Green 
+         $behavior = Add-VSTeamProcessBehavior -ProcessTemplate Scrum -Name "Test" -Color Green
 
          ## Assert
          Should -Invoke _callapi -Scope It -ParameterFilter {
                 $method -eq 'Post' -and
-                $url     -match "https://dummy.none/_apis/work/processes/6b724908-ef14-45cf-84f8-768b5384da45/behaviors" -and 
+                $url     -match "https://dummy.none/_apis/work/processes/6b724908-ef14-45cf-84f8-768b5384da45/behaviors" -and
                 $body   -match '"inherits":\s*"System.PortfolioBacklogBehavior"' -and
                 $body   -match '"name":\s*"Test"' -and
                 $body   -match '"color":\s*"008000"' #Green translated

--- a/Tests/function/tests/Add-VSTeamProcessBehavior.Tests.ps1
+++ b/Tests/function/tests/Add-VSTeamProcessBehavior.Tests.ps1
@@ -1,0 +1,48 @@
+Set-StrictMode -Version Latest
+
+Describe 'VSTeamProcessBehavior' {
+   BeforeAll {
+      . "$PSScriptRoot\_testInitialize.ps1" $PSCommandPath
+      . "$PSScriptRoot\..\..\..\Source\Public\Get-VSTeamProcess.ps1"
+      ## Arrange
+      # Set the account to use for testing. A normal user would do this
+      # using the Set-VSTeamAccount function.
+      Mock _getInstance       { return 'https://dev.azure.com/test' }
+      Mock _getApiVersion     { return '1.0-unitTests' } 
+      Mock _getDefaultProject { return "MockProject"}
+   }
+
+   Context 'Add-VSTeamProcessBehavior' {
+      BeforeAll {
+         ## Arrange
+         Mock _callAPi {return [pscustomobject]@{name="Dummy"}} -ParameterFilter {$method -eq "post"}
+         Mock _callAPi {return @{value=@{name="Dummy"}}} 
+         Mock Get-VSTeamProcess { return @(
+              [PSCustomObject]@{
+                  Name = "Scrum"
+                  URL  = "https://dummy.none/_apis/work/processes/6b724908-ef14-45cf-84f8-768b5384da45"
+               }
+            )
+         }
+         Mock _getProcessTemplateUrl { return "https://dummy.none/_apis/work/processes/6b724908-ef14-45cf-84f8-768b5384da45" }
+         [vsteam_lib.ProcessTemplateCache]::Invalidate()
+      }
+
+      It 'Calls the right API to add a process behavior' {
+         ## Act
+         $behavior = Add-VSTeamProcessBehavior -ProcessTemplate Scrum -Name "Test" -Color Green 
+
+         ## Assert
+         Should -Invoke _callapi -Scope It -ParameterFilter {
+                $method -eq 'Post' -and
+                $url     -match "https://dummy.none/_apis/work/processes/6b724908-ef14-45cf-84f8-768b5384da45/behaviors" -and 
+                $body   -match '"inherits":\s*"System.PortfolioBacklogBehavior"' -and
+                $body   -match '"name":\s*"Test"' -and
+                $body   -match '"color":\s*"008000"' #Green translated
+         } -Times 1 -Exactly
+         Should -Invoke _callapi -Scope It -ParameterFilter {$method -ne 'Post' -and $body -eq $null} -Times 1 -Exactly
+         $behavior.psobject.Typenames   | Should -Contain 'vsteam_lib.Processbehavior'
+         $behavior.ProcessTemplate      | Should -Be      'Scrum'
+      }
+   }
+}

--- a/Tests/function/tests/Add-VSTeamProcessBehavior.Tests.ps1
+++ b/Tests/function/tests/Add-VSTeamProcessBehavior.Tests.ps1
@@ -45,4 +45,9 @@ Describe 'VSTeamProcessBehavior' {
          $behavior.ProcessTemplate      | Should -Be      'Scrum'
       }
    }
+
+   AfterAll {
+      [vsteam_lib.Versions]::Account = 'https://dev.azure.com/test'
+   }
+
 }

--- a/Tests/function/tests/Add-VSTeamProcessBehavior.Tests.ps1
+++ b/Tests/function/tests/Add-VSTeamProcessBehavior.Tests.ps1
@@ -7,7 +7,7 @@ Describe 'VSTeamProcessBehavior' {
       ## Arrange
       # Set the account to use for testing. A normal user would do this
       # using the Set-VSTeamAccount function.
-      Mock _getInstance       { return 'https://dev.azure.com/test' }
+      [vsteam_lib.Versions]::Account = 'https://dev.azure.com/test'
       Mock _getApiVersion     { return '1.0-unitTests' }
       Mock _getDefaultProject { return "MockProject"}
    }

--- a/Tests/function/tests/Add-VSTeamProject.Tests.ps1
+++ b/Tests/function/tests/Add-VSTeamProject.Tests.ps1
@@ -16,9 +16,8 @@ Describe 'VSTeamProject' {
       Mock _getApiVersion { return '1.0-unitTests' }
       Mock _callApi { Open-SampleFile 'Get-VSTeamProcess.json' } -ParameterFilter { $area -eq 'work' -and $resource -eq 'processes' }
 
-      # Get-VSTeamProject for cache 
-      Mock Invoke-RestMethod { return @() } -ParameterFilter {
-         $Uri -like "*`$top=100*" -and
+      # Get-VSTeamProject for cache
+      Mock Invoke-RestMethod { return [pscustomobject]@{value=@()} } -ParameterFilter {
          $Uri -like "*stateFilter=WellFormed*"
       }
    }
@@ -34,7 +33,7 @@ Describe 'VSTeamProject' {
          }
 
          # Track Progress
-         Mock Invoke-RestMethod {            
+         Mock Invoke-RestMethod {
             # This $i is in the module. Because we use InModuleScope
             # we can see it
             if ($i -gt 9) {

--- a/Tests/function/tests/Add-VSTeamProject.Tests.ps1
+++ b/Tests/function/tests/Add-VSTeamProject.Tests.ps1
@@ -12,7 +12,7 @@ Describe 'VSTeamProject' {
       }
 
       Mock Start-Sleep
-      Mock _getInstance { return 'https://dev.azure.com/test' }
+      [vsteam_lib.Versions]::Account = 'https://dev.azure.com/test'
       Mock _getApiVersion { return '1.0-unitTests' }
       Mock _callApi { Open-SampleFile 'Get-VSTeamProcess.json' } -ParameterFilter { $area -eq 'work' -and $resource -eq 'processes' }
 

--- a/Tests/function/tests/Add-VSTeamProject.Tests.ps1
+++ b/Tests/function/tests/Add-VSTeamProject.Tests.ps1
@@ -111,4 +111,9 @@ Describe 'VSTeamProject' {
          { Add-VSTeamProject -projectName Test -processTemplate CMMI } | Should -Throw
       }
    }
+
+   AfterAll {
+      [vsteam_lib.Versions]::Account = 'https://dev.azure.com/test'
+   }
+
 }

--- a/Tests/function/tests/Add-VSTeamProject.Tests.ps1
+++ b/Tests/function/tests/Add-VSTeamProject.Tests.ps1
@@ -16,7 +16,7 @@ Describe 'VSTeamProject' {
       Mock _getApiVersion { return '1.0-unitTests' }
       Mock _callApi { Open-SampleFile 'Get-VSTeamProcess.json' } -ParameterFilter { $area -eq 'work' -and $resource -eq 'processes' }
 
-      # Get-VSTeamProject for cache 
+      # Get-VSTeamProject for cache
       Mock Invoke-RestMethod { return @() } -ParameterFilter {
          $Uri -like "*`$top=100*" -and
          $Uri -like "*stateFilter=WellFormed*"
@@ -34,7 +34,7 @@ Describe 'VSTeamProject' {
          }
 
          # Track Progress
-         Mock Invoke-RestMethod {            
+         Mock Invoke-RestMethod {
             # This $i is in the module. Because we use InModuleScope
             # we can see it
             if ($i -gt 9) {
@@ -68,6 +68,8 @@ Describe 'VSTeamProject' {
       BeforeAll {
          Mock Invoke-RestMethod { return @{status = 'inProgress'; id = 1; url = 'https://someplace.com' } } -ParameterFilter { $Method -eq 'Post' -and $Uri -eq "https://dev.azure.com/test/_apis/projects?api-version=$(_getApiVersion Core)" }
          Mock _trackProjectProgress
+
+         [vsteam_lib.ProcessTemplateCache]::Invalidate()
       }
 
       It 'Should create project with Agile' {

--- a/Tests/function/tests/Add-VSTeamProject.Tests.ps1
+++ b/Tests/function/tests/Add-VSTeamProject.Tests.ps1
@@ -88,6 +88,7 @@ Describe 'VSTeamProject' {
                Typeid = '00000000-0000-0000-0000-000000000002'
             }
          }
+         [vsteam_lib.ProcessTemplateCache]::Invalidate()
       }
 
       It 'Should create project with CMMI' {

--- a/Tests/function/tests/Add-VSTeamWorkItem.Tests.ps1
+++ b/Tests/function/tests/Add-VSTeamWorkItem.Tests.ps1
@@ -3,6 +3,7 @@ Set-StrictMode -Version Latest
 Describe 'VSTeamWorkItem' {
    BeforeAll {
       . "$PSScriptRoot\_testInitialize.ps1" $PSCommandPath
+      . "$PSScriptRoot\..\..\..\Source\Public\Get-VSTeamWorkItemType.ps1"
 
       Mock _getInstance { return 'https://dev.azure.com/test' }
       Mock Invoke-RestMethod { Open-SampleFile 'Get-VSTeamWorkItem-Id16.json' }

--- a/Tests/function/tests/Add-VSTeamWorkItemType.Tests.ps1
+++ b/Tests/function/tests/Add-VSTeamWorkItemType.Tests.ps1
@@ -1,10 +1,10 @@
 Set-StrictMode -Version Latest
 
-Describe 'VSTeamWorkItemType' {
+Describe 'AddVSTeamWorkItemType' {
    BeforeAll {
       . "$PSScriptRoot\_testInitialize.ps1" $PSCommandPath
-      . "$PSScriptRoot\..\..\..\Source\Public\Get-VSteamProcess.ps1"
-      . "$PSScriptRoot\..\..\..\Source\Public\Get-VSTeamWorkItemIconList"
+      . "$PSScriptRoot\..\..\..\Source\Public\Get-VSTeamProcess.ps1"
+      . "$PSScriptRoot\..\..\..\Source\Public\Get-VSTeamWorkItemIconList.ps1"
 
       $Global:PSDefaultParameterValues.Remove("*-vsteam*:projectName")
 

--- a/Tests/function/tests/Add-VSTeamWorkItemType.Tests.ps1
+++ b/Tests/function/tests/Add-VSTeamWorkItemType.Tests.ps1
@@ -1,0 +1,57 @@
+Set-StrictMode -Version Latest
+
+Describe 'VSTeamWorkItemType' {
+   BeforeAll {
+      . "$PSScriptRoot\_testInitialize.ps1" $PSCommandPath
+      . "$PSScriptRoot\..\..\..\Source\Public\Get-VSteamProcess.ps1"
+      . "$PSScriptRoot\..\..\..\Source\Public\Get-VSTeamWorkItemIconList"
+
+      $Global:PSDefaultParameterValues.Remove("*-vsteam*:projectName")
+
+      ## Arrange
+      # Set the account to use for testing. A normal user would do this
+      # using the Set-VSTeamAccount function.
+      Mock _getInstance { return 'https://dev.azure.com/test' }
+      Mock _getApiVersion { return '1.0-unitTests' } -ParameterFilter { $Service -eq 'Processes' }
+
+      Mock Get-VSTeamProcess {
+         $processes = @(
+            [PSCustomObject]@{Name = "Scrum"; url = 'http://bogus.none/1'; ID = "6b724908-ef14-45cf-84f8-768b5384da45" },
+            [PSCustomObject]@{Name = "Basic"; url = 'http://bogus.none/2'; ID = "b8a3a935-7e91-48b8-a94c-606d37c3e9f2" },
+            [PSCustomObject]@{Name = "CMMI"; url = 'http://bogus.none/3'; ID = "27450541-8e31-4150-9947-dc59f998fc01" },
+            [PSCustomObject]@{Name = "Agile"; url = 'http://bogus.none/4'; ID = "adcc42ab-9882-485e-a3ed-7678f01f66bc" },
+            [PSCustomObject]@{Name = "Scrum With Space"; url = 'http://bogus.none/5'; ID = "12345678-0000-0000-0000-000000000000" }
+         )
+         if ($name) { return $processes.where( { $_.name -like $name }) }
+         else { return $processes }  
+      }
+      Mock _callApi -ParameterFilter { $resource -eq 'workitemicons' }  -MockWith {
+         return [pscustomobject]@{'Value' = @(
+               [pscustomobject]@{'ID' = 'icon_airplane' }
+               [pscustomobject]@{'ID' = 'icon_asterisk' }
+               [pscustomobject]@{'ID' = 'icon_Book' }
+            ) 
+         }
+      }
+      Mock _callApi -ParameterFilter { $Method -eq 'Post' } -MockWith {
+         return ([psCustomObject]@{name = 'Dummy' })
+      }
+   }
+
+   Context 'Add-VSTeamWorkItemType' {
+      BeforeAll {
+            [vsteam_lib.ProcessTemplateCache]::Invalidate()
+      }
+      It 'Calls the API with the expected body. ' {
+         Add-VSTeamWorkItemType -ProcessTemplate Scrum -WorkItemType NewWit -Description "New Work item Type" -Color Red  -Icon asterisk 
+         Should -Invoke _callApi -Exactly -Times 1 -Scope It -ParameterFilter {
+            $Url -like 'https://dev.azure.com/test/_apis/work/processes/6b724908-ef14-45cf-84f8-768b5384da45/workitemtypes?api-version=*' -and
+            $Body -match '"name":\s+"NewWit"' -and  
+            $Body -match '"color":\s+"ff0000"' -and
+            $Body -match '"icon":\s+"icon_asterisk"' -and  
+            $Body -match '"description":\s+"New Work item Type"' -and  
+            $Method -eq 'Post'
+         }
+      }
+   }
+}

--- a/Tests/function/tests/Add-VSTeamWorkItemType.Tests.ps1
+++ b/Tests/function/tests/Add-VSTeamWorkItemType.Tests.ps1
@@ -36,6 +36,7 @@ Describe 'AddVSTeamWorkItemType' {
       Mock _callApi -ParameterFilter { $Method -eq 'Post' } -MockWith {
          return ([psCustomObject]@{name = 'Dummy' })
       }
+      [vsteam_lib.ProcessTemplateCache]::Invalidate()
    }
 
    Context 'Add-VSTeamWorkItemType' {

--- a/Tests/function/tests/Get-VSTeamAccessControlList.Tests.ps1
+++ b/Tests/function/tests/Get-VSTeamAccessControlList.Tests.ps1
@@ -4,6 +4,7 @@ Describe 'VSTeamAccessControlList' {
    BeforeAll {
       . "$PSScriptRoot\_testInitialize.ps1" $PSCommandPath
       . "$baseFolder/Source/Public/Set-VSTeamDefaultProject.ps1"
+      . "$baseFolder/Source/Public/Get-VSTeamProcess.ps1"
 
       ## Arrange
       # You have to set the version or the api-version will not be added when versions = ''
@@ -14,6 +15,13 @@ Describe 'VSTeamAccessControlList' {
       # Set the account to use for testing. A normal user would do this
       # using the Set-VSTeamAccount function.
       Mock _getInstance { return 'https://dev.azure.com/test' }
+      Mock Get-VSTeamProcess { return [PSCustomObject]@{
+            name   = 'CMMI'
+            id     = 1
+            Typeid = '00000000-0000-0000-0000-000000000002'
+         }
+      }
+
    }
 
    Context 'Get-VSTeamAccessControlList' {

--- a/Tests/function/tests/Get-VSTeamAgent.Tests.ps1
+++ b/Tests/function/tests/Get-VSTeamAgent.Tests.ps1
@@ -7,7 +7,7 @@ Describe 'VSTeamAgent' {
       
       ## Arrange
       Mock _getApiVersion { return '1.0-unitTests' } -ParameterFilter { $Service -eq 'DistributedTaskReleased' }
-
+      Mock Invoke-RestMethod { return @() } -ParameterFilter {$Uri -like "*_apis/work/processes*" }
       Mock _getInstance { return 'https://dev.azure.com/test' }
 
       # Even with a default set this URI should not have the project added.

--- a/Tests/function/tests/Get-VSTeamAgent.Tests.ps1
+++ b/Tests/function/tests/Get-VSTeamAgent.Tests.ps1
@@ -2,13 +2,22 @@ Set-StrictMode -Version Latest
 
 Describe 'VSTeamAgent' {
    BeforeAll {
-      . "$PSScriptRoot\_testInitialize.ps1" $PSCommandPath      
+      . "$PSScriptRoot\_testInitialize.ps1" $PSCommandPath
       . "$baseFolder/Source/Public/Set-VSTeamDefaultProject.ps1"
-      
+      . "$baseFolder/Source/Public/Get-VSTeamProcess.ps1"
+
+
       ## Arrange
       Mock _getApiVersion { return '1.0-unitTests' } -ParameterFilter { $Service -eq 'DistributedTaskReleased' }
       Mock Invoke-RestMethod { return @() } -ParameterFilter {$Uri -like "*_apis/work/processes*" }
       Mock _getInstance { return 'https://dev.azure.com/test' }
+      Mock Get-VSTeamProcess { return [PSCustomObject]@{
+            name   = 'CMMI'
+            id     = 1
+            Typeid = '00000000-0000-0000-0000-000000000002'
+         }
+      }
+      [vsteam_lib.ProcessTemplateCache]::Invalidate()
 
       # Even with a default set this URI should not have the project added.
       Set-VSTeamDefaultProject -Project Testing

--- a/Tests/function/tests/Get-VSTeamInfo.Tests.ps1
+++ b/Tests/function/tests/Get-VSTeamInfo.Tests.ps1
@@ -8,6 +8,7 @@ Describe 'VSTeamInfo' {
    Context 'Get-VSTeamInfo' {
       AfterAll {
          $Global:PSDefaultParameterValues.Remove("*-vsteam*:projectName")
+         [vsteam_lib.Versions]::Account = ''
       }
 
       It 'should return account and default project' {

--- a/Tests/function/tests/Get-VSTeamProcessBehavior.Tests.ps1
+++ b/Tests/function/tests/Get-VSTeamProcessBehavior.Tests.ps1
@@ -8,7 +8,7 @@ Describe 'VSTeamProcessBehavior' {
       ## Arrange
       # Set the account to use for testing. A normal user would do this
       # using the Set-VSTeamAccount function.
-      Mock _getInstance       { return 'https://dev.azure.com/test' }
+      [vsteam_lib.Versions]::Account = 'https://dev.azure.com/test'
       Mock _getApiVersion     { return '1.0-unitTests' } -ParameterFilter { $Service -eq 'Processes' }
       Mock _getDefaultProject { return "MockProject"}
    }
@@ -17,7 +17,7 @@ Describe 'VSTeamProcessBehavior' {
       BeforeAll {
          ## Arrange
          Mock Get-VSTeamWorkItemType { Open-SampleFile 'workitemsWithBehaviors.json'   }
-         Mock _callAPi {Open-SampleFile 'processesBehaviors.json'  } 
+         Mock _callAPi {Open-SampleFile 'processesBehaviors.json'  }
          Mock Get-VSTeamProcess { return @(
               [PSCustomObject]@{
                   Name = "Scrum"
@@ -30,7 +30,7 @@ Describe 'VSTeamProcessBehavior' {
 
       It 'should get behaviors and set their type correctly' {
          ## Act
-         $behaviors = Get-VSTeamProcessBehavior -ProcessTemplate Scrum  
+         $behaviors = Get-VSTeamProcessBehavior -ProcessTemplate Scrum
 
          ## Assert
          Should -Invoke Get-VSTeamWorkItemType -Scope It -ParameterFilter {$Expand -eq 'Behaviors'} -Times 1 -Exactly

--- a/Tests/function/tests/Get-VSTeamProcessBehavior.Tests.ps1
+++ b/Tests/function/tests/Get-VSTeamProcessBehavior.Tests.ps1
@@ -41,4 +41,9 @@ Describe 'VSTeamProcessBehavior' {
 
       }
    }
+
+   AfterAll {
+      [vsteam_lib.Versions]::Account = 'https://dev.azure.com/test'
+   }
+
 }

--- a/Tests/function/tests/Get-VSTeamProcessBehavior.Tests.ps1
+++ b/Tests/function/tests/Get-VSTeamProcessBehavior.Tests.ps1
@@ -1,0 +1,44 @@
+Set-StrictMode -Version Latest
+
+Describe 'VSTeamProcessBehavior' {
+   BeforeAll {
+      . "$PSScriptRoot\_testInitialize.ps1" $PSCommandPath
+      . "$PSScriptRoot\..\..\..\Source\Public\Get-VSTeamProcess.ps1"
+      . "$PSScriptRoot\..\..\..\Source\Public\Get-VSTeamWorkItemType.ps1"
+      ## Arrange
+      # Set the account to use for testing. A normal user would do this
+      # using the Set-VSTeamAccount function.
+      Mock _getInstance       { return 'https://dev.azure.com/test' }
+      Mock _getApiVersion     { return '1.0-unitTests' } -ParameterFilter { $Service -eq 'Processes' }
+      Mock _getDefaultProject { return "MockProject"}
+   }
+
+   Context 'Get-VSTeamProcessBehavior' {
+      BeforeAll {
+         ## Arrange
+         Mock Get-VSTeamWorkItemType { Open-SampleFile 'workitemsWithBehaviors.json'   }
+         Mock _callAPi {Open-SampleFile 'processesBehaviors.json'  } 
+         Mock Get-VSTeamProcess { return @(
+              [PSCustomObject]@{
+                  Name = "Scrum"
+                  URL  = "https://dummy.none/_apis/work/processes/6b724908-ef14-45cf-84f8-768b5384da45"
+               }
+            )
+         }
+         [vsteam_lib.ProcessTemplateCache]::Invalidate()
+      }
+
+      It 'should get behaviors and set their type correctly' {
+         ## Act
+         $behaviors = Get-VSTeamProcessBehavior -ProcessTemplate Scrum  
+
+         ## Assert
+         Should -Invoke Get-VSTeamWorkItemType -Scope It -ParameterFilter {$Expand -eq 'Behaviors'} -Times 1 -Exactly
+         Should -Invoke _callapi -Scope It -ParameterFilter {$url -like '*/behaviors?$expand=combinedFields*'} -Times 1 -Exactly
+         $behaviors.count                   | Should -Be 6
+         $behaviors[0].psobject.Typenames   | Should -Contain 'vsteam_lib.Processbehavior'
+         $behaviors[0].ProcessTemplate      | Should -Be      'Scrum'
+
+      }
+   }
+}

--- a/Tests/function/tests/Get-VSTeamSetting.Tests.ps1
+++ b/Tests/function/tests/Get-VSTeamSetting.Tests.ps1
@@ -6,7 +6,7 @@ Describe 'VSTeamSetting' {
       ## Arrange
       # Set the account to use for testing. A normal user would do this
       # using the Set-VSTeamAccount function.
-      Mock _getInstance       { return 'https://dev.azure.com/test' }
+      [vsteam_lib.Versions]::Account = 'https://dev.azure.com/test'
       Mock _getApiVersion     { return '1.0-unitTests' } -ParameterFilter { $Service -eq 'Processes' }
       Mock _getDefaultProject { return "MockProject"}
    }

--- a/Tests/function/tests/Get-VSTeamSetting.Tests.ps1
+++ b/Tests/function/tests/Get-VSTeamSetting.Tests.ps1
@@ -1,0 +1,30 @@
+Set-StrictMode -Version Latest
+
+Describe 'VSTeamSetting' {
+   BeforeAll {
+      . "$PSScriptRoot\_testInitialize.ps1" $PSCommandPath
+      ## Arrange
+      # Set the account to use for testing. A normal user would do this
+      # using the Set-VSTeamAccount function.
+      Mock _getInstance       { return 'https://dev.azure.com/test' }
+      Mock _getApiVersion     { return '1.0-unitTests' } -ParameterFilter { $Service -eq 'Processes' }
+      Mock _getDefaultProject { return "MockProject"}
+   }
+
+   Context 'Get-VSTeamSetting' {
+      BeforeAll {
+         ## Arrange
+         Mock _callAPi {}
+      }
+
+      It 'should get make the correct api call to get settings' {
+         ## Act
+         $settings = Get-VSTeamSetting -project "MockProject"
+
+         ## Assert
+         Should -Invoke _callapi -Scope It -ParameterFilter {
+            $resource -eq "teamsettings" -and  $area -eq "work"} -Times 1 -Exactly
+
+      }
+   }
+}

--- a/Tests/function/tests/Get-VSTeamSetting.Tests.ps1
+++ b/Tests/function/tests/Get-VSTeamSetting.Tests.ps1
@@ -27,4 +27,9 @@ Describe 'VSTeamSetting' {
 
       }
    }
+
+   AfterAll {
+      [vsteam_lib.Versions]::Account = 'https://dev.azure.com/test'
+   }
+
 }

--- a/Tests/function/tests/Get-VSTeamWorkItemBehavior.Tests.ps1
+++ b/Tests/function/tests/Get-VSTeamWorkItemBehavior.Tests.ps1
@@ -8,7 +8,7 @@ Describe 'VSTeamWorkItemBehavior' {
       ## Arrange
       # Set the account to use for testing. A normal user would do this
       # using the Set-VSTeamAccount function.
-      Mock _getInstance       { return 'https://dev.azure.com/test' }
+      [vsteam_lib.Versions]::Account = 'https://dev.azure.com/test'
       Mock _getApiVersion     { return '1.0-unitTests' } -ParameterFilter { $Service -eq 'Processes' }
       Mock _getDefaultProject { return "MockProject"}
    }
@@ -16,7 +16,7 @@ Describe 'VSTeamWorkItemBehavior' {
    Context 'Get-VSTeamWorkItemBehavior' {
       BeforeAll {
          ## Arrange
-         Mock Get-VSTeamWorkItemType { 
+         Mock Get-VSTeamWorkItemType {
             [PSCustomObject]@{name = "Epic"; behaviors = @(
                [PSCustomObject]@{isdefault = $true; behavior = [PSCustomObject]@{
                      id  = 'Microsoft.VSTS.Scrum.EpicBacklogBehavior'
@@ -40,8 +40,8 @@ Describe 'VSTeamWorkItemBehavior' {
 
          ## Assert
          Should -Invoke Get-VSTeamWorkItemType -Scope It -ParameterFilter {$Expand -eq 'Behaviors'} -Times 1 -Exactly
-         
-         
+
+
          $behavior.ProcessTemplate      | Should -Be      'Scrum'
          $behavior.WorkItemType         | Should -Be      'Epic'
       }

--- a/Tests/function/tests/Get-VSTeamWorkItemBehavior.Tests.ps1
+++ b/Tests/function/tests/Get-VSTeamWorkItemBehavior.Tests.ps1
@@ -1,0 +1,49 @@
+Set-StrictMode -Version Latest
+
+Describe 'VSTeamWorkItemBehavior' {
+   BeforeAll {
+      . "$PSScriptRoot\_testInitialize.ps1" $PSCommandPath
+      . "$PSScriptRoot\..\..\..\Source\Public\Get-VSTeamProcess.ps1"
+      . "$PSScriptRoot\..\..\..\Source\Public\Get-VSTeamWorkItemType.ps1"
+      ## Arrange
+      # Set the account to use for testing. A normal user would do this
+      # using the Set-VSTeamAccount function.
+      Mock _getInstance       { return 'https://dev.azure.com/test' }
+      Mock _getApiVersion     { return '1.0-unitTests' } -ParameterFilter { $Service -eq 'Processes' }
+      Mock _getDefaultProject { return "MockProject"}
+   }
+
+   Context 'Get-VSTeamWorkItemBehavior' {
+      BeforeAll {
+         ## Arrange
+         Mock Get-VSTeamWorkItemType { 
+            [PSCustomObject]@{name = "Epic"; behaviors = @(
+               [PSCustomObject]@{isdefault = $true; behavior = [PSCustomObject]@{
+                     id  = 'Microsoft.VSTS.Scrum.EpicBacklogBehavior'
+                     url = 'http://dummy.none'
+               }}
+            )}
+         }
+         Mock Get-VSTeamProcess { return @(
+              [PSCustomObject]@{
+                  Name = "Scrum"
+                  URL  = "https://dummy.none/_apis/work/processes/6b724908-ef14-45cf-84f8-768b5384da45"
+               }
+            )
+         }
+         [vsteam_lib.ProcessTemplateCache]::Invalidate()
+      }
+
+      It 'should get behaviors and set their type correctly' {
+         ## Act
+         $behavior = Get-VSTeamWorkItemBehavior -ProcessTemplate Scrum  -WorkItemType epic
+
+         ## Assert
+         Should -Invoke Get-VSTeamWorkItemType -Scope It -ParameterFilter {$Expand -eq 'Behaviors'} -Times 1 -Exactly
+         
+         
+         $behavior.ProcessTemplate      | Should -Be      'Scrum'
+         $behavior.WorkItemType         | Should -Be      'Epic'
+      }
+   }
+}

--- a/Tests/function/tests/Get-VSTeamWorkItemBehavior.Tests.ps1
+++ b/Tests/function/tests/Get-VSTeamWorkItemBehavior.Tests.ps1
@@ -46,4 +46,9 @@ Describe 'VSTeamWorkItemBehavior' {
          $behavior.WorkItemType         | Should -Be      'Epic'
       }
    }
+
+   AfterAll {
+      [vsteam_lib.Versions]::Account = 'https://dev.azure.com/test'
+   }
+
 }

--- a/Tests/function/tests/Get-VSTeamWorkItemIconList.Tests.ps1
+++ b/Tests/function/tests/Get-VSTeamWorkItemIconList.Tests.ps1
@@ -1,0 +1,25 @@
+Set-StrictMode -Version Latest
+
+Describe "VSTeam" {
+   BeforeAll {
+      . "$PSScriptRoot\_testInitialize.ps1" $PSCommandPath
+   }
+
+   Context "Get-VSTeamWorkItemIconList" {
+   
+      BeforeAll {
+         Mock _getInstance { return 'https://dev.azure.com/test' }
+         Mock _getApiVersion { return '1.0-unitTests' } 
+         Mock _callApi {return [pscustomObject]@{value="Dummy"}}
+      }
+      It 'Should call the API correctly' {
+
+         ## Act
+         Get-VSTeamWorkItemIconList
+         ## Assert
+         Should -Invoke _callApi -Exactly 1 -ParameterFilter {
+               $Area -eq 'wit' -and   $Resource -eq 'workitemicons' -and $IgnoreDefaultProject -eq $true
+         }
+      }
+   }
+}

--- a/Tests/function/tests/Get-VSTeamWorkItemType.Tests.ps1
+++ b/Tests/function/tests/Get-VSTeamWorkItemType.Tests.ps1
@@ -23,6 +23,7 @@ Describe 'VSTeamWorkItemType' {
          if ($name) { return $processes.where( { $_.name -like $name }) }
          else { return $processes }  
       }
+      [vsteam_lib.ProcessTemplateCache]::Invalidate()
    }
 
    Context 'Get-VSTeamWorkItemType' {

--- a/Tests/function/tests/Get-VSTeamWorkItemType.Tests.ps1
+++ b/Tests/function/tests/Get-VSTeamWorkItemType.Tests.ps1
@@ -3,7 +3,7 @@ Set-StrictMode -Version Latest
 Describe 'VSTeamWorkItemType' {
    BeforeAll {
       . "$PSScriptRoot\_testInitialize.ps1" $PSCommandPath
-      . "$PSScriptRoot\..\..\..\Source\Public\Get-VSteamProcess.ps1"
+      . "$PSScriptRoot\..\..\..\Source\Public\Get-VSTeamProcess.ps1"
 
       $Global:PSDefaultParameterValues.Remove("*-vsteam*:projectName")
 

--- a/Tests/function/tests/Get-VSTeamWorkItemType.Tests.ps1
+++ b/Tests/function/tests/Get-VSTeamWorkItemType.Tests.ps1
@@ -3,6 +3,7 @@ Set-StrictMode -Version Latest
 Describe 'VSTeamWorkItemType' {
    BeforeAll {
       . "$PSScriptRoot\_testInitialize.ps1" $PSCommandPath
+      . "$PSScriptRoot\..\..\..\Source\Public\Get-VSteamProcess.ps1"
 
       $Global:PSDefaultParameterValues.Remove("*-vsteam*:projectName")
 
@@ -10,51 +11,84 @@ Describe 'VSTeamWorkItemType' {
       # Set the account to use for testing. A normal user would do this
       # using the Set-VSTeamAccount function.
       Mock _getInstance { return 'https://dev.azure.com/test' }
-      Mock _getApiVersion { return '1.0-unitTests' } -ParameterFilter { $Service -eq 'Core' }
+      Mock _getApiVersion { return '1.0-unitTests' } 
+      Mock Get-VSTeamProcess {
+         $processes = @(
+            [PSCustomObject]@{Name = "Scrum"; url = 'http://bogus.none/1'; ID = "6b724908-ef14-45cf-84f8-768b5384da45" },
+            [PSCustomObject]@{Name = "Basic"; url = 'http://bogus.none/2'; ID = "b8a3a935-7e91-48b8-a94c-606d37c3e9f2" },
+            [PSCustomObject]@{Name = "CMMI"; url = 'http://bogus.none/3'; ID = "27450541-8e31-4150-9947-dc59f998fc01" },
+            [PSCustomObject]@{Name = "Agile"; url = 'http://bogus.none/4'; ID = "adcc42ab-9882-485e-a3ed-7678f01f66bc" },
+            [PSCustomObject]@{Name = "Scrum With Space"; url = 'http://bogus.none/5'; ID = "12345678-0000-0000-0000-000000000000" }
+         )
+         if ($name) { return $processes.where( { $_.name -like $name }) }
+         else { return $processes }  
+      }
    }
 
    Context 'Get-VSTeamWorkItemType' {
       BeforeAll {
-         Mock Invoke-RestMethod { Open-SampleFile 'get-vsteamworkitemtype.json' -Json }
+         Mock Invoke-RestMethod { Get-Content "$sampleFiles\get-vsteamworkitemtype.json" -Raw  } ##<<This file doesn't properly read as JSON!!!
          Mock Invoke-RestMethod { Open-SampleFile 'bug.json' -Json } -ParameterFilter {
             $Uri -like "*bug*" 
          }
+         Mock Invoke-RestMethod { ( Get-Content "$sampleFiles\get-vsteamworkitemtype.json" -Raw ).Replace('"":', '"_end":') | ConvertFrom-Json  } -ParameterFilter {
+            $Uri -like "*processes*" 
+         }
+         Mock Invoke-RestMethod {@() } -ParameterFilter {
+            $Uri -like "*workitemtypecategories*" 
+         }
+       
       }
 
-      It 'with project only should return all work item types' {
+      It 'should return all work item types when called with project only' {
          ## Act
-         Get-VSTeamWorkItemType -ProjectName VSTeamWorkItemType
+         $wit = Get-VSTeamWorkItemType -ProjectName VSTeamWorkItemType
 
          ## Assert
          Should -Invoke Invoke-RestMethod -Exactly -Scope It -Times 1 -ParameterFilter {
             $Uri -eq "https://dev.azure.com/test/VSTeamWorkItemType/_apis/wit/workitemtypes?api-version=$(_getApiVersion Core)"
          }
+         $wit.count | should -BeGreaterThan 1
       }
 
-      It 'by type with default project should return 1 work item type' {
+
+      It 'should return 1 work item type when called with type & default project ' {
          ## Arrange
          $Global:PSDefaultParameterValues["*-vsteam*:projectName"] = 'VSTeamWorkItemType'
 
          ## Act
-         Get-VSTeamWorkItemType -WorkItemType bug
+         $wit = Get-VSTeamWorkItemType -WorkItemType bug
 
          ## Assert
          Should -Invoke Invoke-RestMethod -Exactly -Scope It -Times 1 -ParameterFilter {
-            $Uri -eq "https://dev.azure.com/test/VSTeamWorkItemType/_apis/wit/workitemtypes/bug?api-version=$(_getApiVersion Core)"
+            $Uri -eq "https://dev.azure.com/test/VSTeamWorkItemType/_apis/wit/workitemtypes?api-version=$(_getApiVersion Core)"
          }
+         $wit.count | Should -BeExactly 1
       }
 
-      It 'by type with explicit project should return 1 work item type' {
+      It 'should return 1 work item type when by with type & explicit project ' {
          ## Arrange
          $Global:PSDefaultParameterValues.Remove("*-vsteam*:projectName")
 
          ## Act
-         Get-VSTeamWorkItemType -ProjectName VSTeamWorkItemType -WorkItemType bug
+         $wit = Get-VSTeamWorkItemType -ProjectName VSTeamWorkItemType -WorkItemType bug
 
          ## Assert
          Should -Invoke Invoke-RestMethod -Exactly -Scope It -Times 1 -ParameterFilter {
-            $Uri -eq "https://dev.azure.com/test/VSTeamWorkItemType/_apis/wit/workitemtypes/bug?api-version=$(_getApiVersion Core)"
+            $Uri -eq "https://dev.azure.com/test/VSTeamWorkItemType/_apis/wit/workitemtypes?api-version=$(_getApiVersion Core)"
          }
+         $wit.count | should -BeExactly 1
       }
-   }
+
+      It 'should return all work item types when with processTemplate' {
+         ## Act   
+         $wit = Get-VSTeamWorkItemType -ProcessTemplate Scrum
+
+         ##Assert
+         Should -Invoke Invoke-RestMethod -Exactly -Scope It -Times 1 -ParameterFilter {
+            $Uri -like "https://dev.azure.com/test/_apis/work/processes/6b724908-ef14-45cf-84f8-768b5384da45/workitemtypes?api-version=$(_getApiVersion Processes)"
+         }
+         $wit.count | should -BeGreaterThan 1
+      }
+  }
 }

--- a/Tests/function/tests/Remove-VSTeamProcess.Tests.ps1
+++ b/Tests/function/tests/Remove-VSTeamProcess.Tests.ps1
@@ -38,4 +38,9 @@ Describe 'VSTeamProcess' {
          }
       }
    }
+
+   AfterAll {
+      [vsteam_lib.Versions]::Account = 'https://dev.azure.com/test'
+   }
+
 }

--- a/Tests/function/tests/Remove-VSTeamProcess.Tests.ps1
+++ b/Tests/function/tests/Remove-VSTeamProcess.Tests.ps1
@@ -1,0 +1,41 @@
+Set-StrictMode -Version Latest
+
+Describe 'VSTeamProcess' {
+   BeforeAll {
+      . "$PSScriptRoot\_testInitialize.ps1" $PSCommandPath
+      . "$PSScriptRoot\..\..\..\Source\Public\Get-VSTeamProcess.ps1"
+
+      ## Arrange
+      # Set the account to use for testing. A normal user would do this
+      # using the Set-VSTeamAccount function.
+      Mock _getInstance      { return 'https://dev.azure.com/test' }
+      Mock _getApiVersion    { return '1.0-unitTests' }
+
+      Mock _callApi          { return }
+      Mock Get-VSTeamProcess {
+         $processes =  @(
+            [PSCustomObject]@{Name = "Scrum";            ID = "6b724908-ef14-45cf-84f8-768b5384da45"},
+            [PSCustomObject]@{Name = "Basic";            ID = "b8a3a935-7e91-48b8-a94c-606d37c3e9f2"},
+            [PSCustomObject]@{Name = "CMMI";             ID = "27450541-8e31-4150-9947-dc59f998fc01"},
+            [PSCustomObject]@{Name = "Agile";            ID = "adcc42ab-9882-485e-a3ed-7678f01f66bc"},
+            [PSCustomObject]@{Name = "Scrum With Space"; ID = "12345678-0000-0000-0000-000000000000"}
+         )
+         if ($name) {return $processes.where({$_.name -like $name})}
+         else       {return $processes}
+      }
+
+
+     [vsteam_lib.ProcessTemplateCache]::Invalidate()
+   }
+
+   Context 'Remove VSTeamProcess' {
+
+      It 'Calls the Correct API  ' {
+         Remove-VsteamProcess -ProcessTemplate "Scrum" -Force
+         Should -Invoke _callApi -Exactly -Times 1 -Scope It -ParameterFilter {
+            $Url    -like     '*/_apis/work/processes/6b724908-ef14-45cf-84f8-768b5384da45?*'       -and
+            $Method -eq       'Delete'
+         }
+      }
+   }
+}

--- a/Tests/function/tests/Remove-VSTeamProcess.Tests.ps1
+++ b/Tests/function/tests/Remove-VSTeamProcess.Tests.ps1
@@ -8,7 +8,7 @@ Describe 'VSTeamProcess' {
       ## Arrange
       # Set the account to use for testing. A normal user would do this
       # using the Set-VSTeamAccount function.
-      Mock _getInstance      { return 'https://dev.azure.com/test' }
+      [vsteam_lib.Versions]::Account = 'https://dev.azure.com/test'
       Mock _getApiVersion    { return '1.0-unitTests' }
 
       Mock _callApi          { return }

--- a/Tests/function/tests/Remove-VSTeamProcessBehavior.Tests.ps1
+++ b/Tests/function/tests/Remove-VSTeamProcessBehavior.Tests.ps1
@@ -8,8 +8,8 @@ Describe 'VSTeamProcessBehavior' {
       ## Arrange
       # Set the account to use for testing. A normal user would do this
       # using the Set-VSTeamAccount function.
-      Mock _getInstance       { return 'https://dev.azure.com/test' }
-      Mock _getApiVersion     { return '1.0-unitTests' } 
+      [vsteam_lib.Versions]::Account = 'https://dev.azure.com/test'
+      Mock _getApiVersion     { return '1.0-unitTests' }
       Mock _getDefaultProject { return "MockProject"}
    }
 
@@ -38,7 +38,7 @@ Describe 'VSTeamProcessBehavior' {
          ## Assert
          Should -Invoke _callapi -Scope It -ParameterFilter {
                 $method -eq 'delete' -and
-                $url     -match "https://dummy.none/_apis/work/processes/6b724908-ef14-45cf-84f8-768b5384da45/behaviors/TestReferenceName" -and 
+                $url     -match "https://dummy.none/_apis/work/processes/6b724908-ef14-45cf-84f8-768b5384da45/behaviors/TestReferenceName" -and
                 $body   -eq $null
          } -Times 1 -Exactly
       }

--- a/Tests/function/tests/Remove-VSTeamProcessBehavior.Tests.ps1
+++ b/Tests/function/tests/Remove-VSTeamProcessBehavior.Tests.ps1
@@ -43,4 +43,9 @@ Describe 'VSTeamProcessBehavior' {
          } -Times 1 -Exactly
       }
    }
+
+   AfterAll {
+      [vsteam_lib.Versions]::Account = 'https://dev.azure.com/test'
+   }
+
 }

--- a/Tests/function/tests/Remove-VSTeamProcessBehavior.Tests.ps1
+++ b/Tests/function/tests/Remove-VSTeamProcessBehavior.Tests.ps1
@@ -1,0 +1,46 @@
+Set-StrictMode -Version Latest
+
+Describe 'VSTeamProcessBehavior' {
+   BeforeAll {
+      . "$PSScriptRoot\_testInitialize.ps1" $PSCommandPath
+      . "$PSScriptRoot\..\..\..\Source\Public\Get-VSTeamProcess.ps1"
+      . "$PSScriptRoot\..\..\..\Source\Public\Get-VSTeamProcessBehavior.ps1"
+      ## Arrange
+      # Set the account to use for testing. A normal user would do this
+      # using the Set-VSTeamAccount function.
+      Mock _getInstance       { return 'https://dev.azure.com/test' }
+      Mock _getApiVersion     { return '1.0-unitTests' } 
+      Mock _getDefaultProject { return "MockProject"}
+   }
+
+   Context 'Remove-VSTeamProcessBehavior' {
+      BeforeAll {
+         ## Arrange
+         Mock _callAPi {return $null} -ParameterFilter {$method -eq "delete"}
+         Mock Get-VSTeamProcess { return @(
+              [PSCustomObject]@{
+                  Name = "Scrum"
+                  URL  = "https://dummy.none/_apis/work/processes/6b724908-ef14-45cf-84f8-768b5384da45"
+               }
+            )
+         }
+         Mock Get-VSTeamProcessBehavior { return [PSCustomObject]@{
+            Name = "Test"
+            url = "https://dummy.none/_apis/work/processes/6b724908-ef14-45cf-84f8-768b5384da45/behaviors/TestReferenceName" }
+         }
+         [vsteam_lib.ProcessTemplateCache]::Invalidate()
+      }
+
+      It 'Calls the right API to add a process behavior' {
+         ## Act
+         Remove-VSTeamProcessBehavior -ProcessTemplate Scrum -Name "Test" -Force
+
+         ## Assert
+         Should -Invoke _callapi -Scope It -ParameterFilter {
+                $method -eq 'delete' -and
+                $url     -match "https://dummy.none/_apis/work/processes/6b724908-ef14-45cf-84f8-768b5384da45/behaviors/TestReferenceName" -and 
+                $body   -eq $null
+         } -Times 1 -Exactly
+      }
+   }
+}

--- a/Tests/function/tests/Remove-VSTeamWorkItemType.Tests.ps1
+++ b/Tests/function/tests/Remove-VSTeamWorkItemType.Tests.ps1
@@ -52,6 +52,7 @@ Describe 'RemoveVSTeamWorkItemType' {
          else               { return $wits }  
       } 
       [vsteam_lib.IconCache]::Invalidate()
+      [vsteam_lib.ProcessTemplateCache]::Invalidate()
    }
 
    Context 'Delete workItem Type' {

--- a/Tests/function/tests/Remove-VSTeamWorkItemType.Tests.ps1
+++ b/Tests/function/tests/Remove-VSTeamWorkItemType.Tests.ps1
@@ -1,9 +1,9 @@
 Set-StrictMode -Version Latest
 
-Describe 'VSTeamWorkItemType' {
+Describe 'RemoveVSTeamWorkItemType' {
    BeforeAll {
       . "$PSScriptRoot\_testInitialize.ps1" $PSCommandPath
-      . "$PSScriptRoot\..\..\..\Source\Public\Get-VSteamProcess.ps1" 
+      . "$PSScriptRoot\..\..\..\Source\Public\Get-VSTeamProcess.ps1" 
       . "$PSScriptRoot\..\..\..\Source\Public\Get-VSTeamWorkItemType.ps1"
 
       $Global:PSDefaultParameterValues.Remove("*-vsteam*:projectName")

--- a/Tests/function/tests/Remove-VSTeamWorkItemType.Tests.ps1
+++ b/Tests/function/tests/Remove-VSTeamWorkItemType.Tests.ps1
@@ -1,0 +1,76 @@
+Set-StrictMode -Version Latest
+
+Describe 'VSTeamWorkItemType' {
+   BeforeAll {
+      . "$PSScriptRoot\_testInitialize.ps1" $PSCommandPath
+      . "$PSScriptRoot\..\..\..\Source\Public\Get-VSteamProcess.ps1" 
+      . "$PSScriptRoot\..\..\..\Source\Public\Get-VSTeamWorkItemType.ps1"
+
+      $Global:PSDefaultParameterValues.Remove("*-vsteam*:projectName")
+
+      ## Arrange
+      # Set the account to use for testing. A normal user would do this
+      # using the Set-VSTeamAccount function.
+      Mock _getInstance { return 'https://dev.azure.com/test' }
+      Mock _getApiVersion { return '1.0-unitTests' } -ParameterFilter { $Service -eq 'Processes' }
+
+      Mock Get-VSTeamProcess {
+         $processes = @(
+            [PSCustomObject]@{Name = "Scrum"; url = 'http://bogus.none/1'; ID = "6b724908-ef14-45cf-84f8-768b5384da45" },
+            [PSCustomObject]@{Name = "Basic"; url = 'http://bogus.none/2'; ID = "b8a3a935-7e91-48b8-a94c-606d37c3e9f2" },
+            [PSCustomObject]@{Name = "CMMI"; url = 'http://bogus.none/3'; ID = "27450541-8e31-4150-9947-dc59f998fc01" },
+            [PSCustomObject]@{Name = "Agile"; url = 'http://bogus.none/4'; ID = "adcc42ab-9882-485e-a3ed-7678f01f66bc" },
+            [PSCustomObject]@{Name = "Scrum With Space"; url = 'http://bogus.none/5'; ID = "12345678-0000-0000-0000-000000000000" }
+         )
+         if ($name) { return $processes.where( { $_.name -like $name }) }
+         else { return $processes }  
+      }
+      Mock _callApi -ParameterFilter {$Method -eq 'Delete'} {
+            return $null
+      }
+      Mock Get-VSTeamWorkItemType {
+            $wits = @(
+                  [psCustomObject]@{name          = 'Bug'
+                                    customization = 'system'
+                                    referenceName = 'Microsoft.VSTS.WorkItemTypes.Bug'
+                                    icon          = 'icon_insect'
+                                    color         = 'cc293d'
+                                    isDisabled    =  $false
+                                    description   = 'A divergence...' 
+                                    url           = 'http://bogus.none/98'
+                  }
+                  [psCustomObject]@{name          = 'Gub'
+                                    customization = 'custom'
+                                    icon          = 'icon_book'
+                                    color         = 'ff0000'
+                                    isDisabled    =  $false
+                                    description   = 'Test Item' 
+                                    url           = 'http://bogus.none/99';
+                  }
+               )
+         if ($WorkItemType) { return $wits.where( { $_.name -like $WorkItemType }) }
+         else               { return $wits }  
+      } 
+      [vsteam_lib.IconCache]::Invalidate()
+   }
+
+   Context 'Delete workItem Type' {
+
+      It 'Catches invalid WorkItem type names.' {
+         Remove-VSTeamWorkItemType -ProcessTemplate "Scrum With Space" -WorkItemType NewWit -WarningVariable "Warn" -warningAction SilentlyContinue
+         # Should not call the rest API from the function body, but may populate the work-item icons cache 
+         Should -Invoke _callApi -Exactly -Times 0 -Scope It {-not ($resource -eq "workitemicons")} 
+         $warn | Should -Be "'NewWit' does not appear to be a valid Workitem type."
+      }
+      It 'Deletes custom WorkItem types.' {
+         Remove-VSTeamWorkItemType -ProcessTemplate "Scrum With Space" -WorkItemType Gub -Force
+         Should -Invoke _callApi -Exactly -Times 1 -Scope It -ParameterFilter {
+            $Url    -like     '*99?api-version=*'           -and  #found expected item
+            $Method -eq       'Delete'
+         }
+      }
+       It 'Rejects deletion for system WorkItem Types' {
+         {Remove-VSTeamWorkItemType -ProcessTemplate "Scrum With Space" -WorkItemType Bug } | should -Throw
+      }
+   }
+}

--- a/Tests/function/tests/Remove-VSTeamWorkItemType.Tests.ps1
+++ b/Tests/function/tests/Remove-VSTeamWorkItemType.Tests.ps1
@@ -3,7 +3,7 @@ Set-StrictMode -Version Latest
 Describe 'RemoveVSTeamWorkItemType' {
    BeforeAll {
       . "$PSScriptRoot\_testInitialize.ps1" $PSCommandPath
-      . "$PSScriptRoot\..\..\..\Source\Public\Get-VSTeamProcess.ps1" 
+      . "$PSScriptRoot\..\..\..\Source\Public\Get-VSTeamProcess.ps1"
       . "$PSScriptRoot\..\..\..\Source\Public\Get-VSTeamWorkItemType.ps1"
 
       $Global:PSDefaultParameterValues.Remove("*-vsteam*:projectName")
@@ -23,7 +23,7 @@ Describe 'RemoveVSTeamWorkItemType' {
             [PSCustomObject]@{Name = "Scrum With Space"; url = 'http://bogus.none/5'; ID = "12345678-0000-0000-0000-000000000000" }
          )
          if ($name) { return $processes.where( { $_.name -like $name }) }
-         else { return $processes }  
+         else { return $processes }
       }
       Mock _callApi -ParameterFilter {$Method -eq 'Delete'} {
             return $null
@@ -36,7 +36,7 @@ Describe 'RemoveVSTeamWorkItemType' {
                                     icon          = 'icon_insect'
                                     color         = 'cc293d'
                                     isDisabled    =  $false
-                                    description   = 'A divergence...' 
+                                    description   = 'A divergence...'
                                     url           = 'http://bogus.none/98'
                   }
                   [psCustomObject]@{name          = 'Gub'
@@ -44,13 +44,13 @@ Describe 'RemoveVSTeamWorkItemType' {
                                     icon          = 'icon_book'
                                     color         = 'ff0000'
                                     isDisabled    =  $false
-                                    description   = 'Test Item' 
+                                    description   = 'Test Item'
                                     url           = 'http://bogus.none/99';
                   }
                )
          if ($WorkItemType) { return $wits.where( { $_.name -like $WorkItemType }) }
-         else               { return $wits }  
-      } 
+         else               { return $wits }
+      }
       [vsteam_lib.IconCache]::Invalidate()
       [vsteam_lib.ProcessTemplateCache]::Invalidate()
    }
@@ -59,9 +59,9 @@ Describe 'RemoveVSTeamWorkItemType' {
 
       It 'Catches invalid WorkItem type names.' {
          Remove-VSTeamWorkItemType -ProcessTemplate "Scrum With Space" -WorkItemType NewWit -WarningVariable "Warn" -warningAction SilentlyContinue
-         # Should not call the rest API from the function body, but may populate the work-item icons cache 
-         Should -Invoke _callApi -Exactly -Times 0 -Scope It {-not ($resource -eq "workitemicons")} 
-         $warn | Should -Be "'NewWit' does not appear to be a valid Workitem type."
+         # Should not call the rest API from the function body, but may populate the work-item icons cache
+         Should -Invoke _callApi -Exactly -Times 0 -Scope It {-not ($resource -eq "workitemicons")}
+         $warn | Should -Match "'NewWit'.*Workitem type."
       }
       It 'Deletes custom WorkItem types.' {
          Remove-VSTeamWorkItemType -ProcessTemplate "Scrum With Space" -WorkItemType Gub -Force
@@ -71,7 +71,10 @@ Describe 'RemoveVSTeamWorkItemType' {
          }
       }
        It 'Rejects deletion for system WorkItem Types' {
-         {Remove-VSTeamWorkItemType -ProcessTemplate "Scrum With Space" -WorkItemType Bug } | should -Throw
+         Remove-VSTeamWorkItemType -ProcessTemplate "Scrum With Space" -WorkItemType Bug -WarningVariable "Warn" -warningAction SilentlyContinue
+         Should -Invoke _callApi -Exactly -Times 0  -Scope It {-not ($resource -eq "workitemicons")}
+         $warn | Should -Match "'Bug'.*Workitem type."
+
       }
    }
 }

--- a/Tests/function/tests/Set-VSTeamDefaultProject.Tests.ps1
+++ b/Tests/function/tests/Set-VSTeamDefaultProject.Tests.ps1
@@ -3,9 +3,9 @@ Set-StrictMode -Version Latest
 Describe 'VSTeamDefaultProject' {
    BeforeAll {
       . "$PSScriptRoot\_testInitialize.ps1" $PSCommandPath
-
+      . "$PSScriptRoot\_testInitialize.ps1" Get-VSTeamProcess
       Mock _getInstance { return 'https://dev.azure.com/test' }
-      Mock Invoke-RestMethod { return @() } -ParameterFilter {$Uri -like "*_apis/work/processes*" }
+      Mock Get-VSTeamProcess { return @() }
    }
 
    Context 'Set-VSTeamDefaultProject' {

--- a/Tests/function/tests/Set-VSTeamDefaultProject.Tests.ps1
+++ b/Tests/function/tests/Set-VSTeamDefaultProject.Tests.ps1
@@ -5,6 +5,7 @@ Describe 'VSTeamDefaultProject' {
       . "$PSScriptRoot\_testInitialize.ps1" $PSCommandPath
 
       Mock _getInstance { return 'https://dev.azure.com/test' }
+      Mock Invoke-RestMethod { return @() } -ParameterFilter {$Uri -like "*_apis/work/processes*" }
    }
 
    Context 'Set-VSTeamDefaultProject' {

--- a/Tests/function/tests/Set-VSTeamProcess.Tests.ps1
+++ b/Tests/function/tests/Set-VSTeamProcess.Tests.ps1
@@ -1,0 +1,75 @@
+Set-StrictMode -Version Latest
+
+Describe 'Set-VSTeamProcess' {
+   BeforeAll {
+      . "$PSScriptRoot\_testInitialize.ps1" $PSCommandPath
+      . "$PSScriptRoot\..\..\..\Source\Public\Get-VSTeamProcess.ps1"
+    
+
+      ## Arrange
+      # Set the account to use for testing. A normal user would do this
+      # using the Set-VSTeamAccount function.
+      Mock _getInstance      { return 'https://dev.azure.com/test' }
+      Mock _getApiVersion    { return '1.0-unitTests' }
+
+      Mock _callApi          {
+            #Return a single process object. Any process will do. 
+            return ([psCustomObject]@{
+               typeId              = '6b724908-ef14-45cf-84f8-768b5384da45'
+               name                = 'Scrum' 
+               referenceName       = ''
+               description         = 'This template is for teams who follow the Scrum framework.'
+               parentProcessTypeId = '00000000-0000-0000-0000-000000000000' 
+               isEnabled           = $True 
+               isDefault           = $True
+               customizationType   = 'system'
+               })
+      }
+      Mock Get-VSTeamProcess {
+         $processes =  @(
+            [PSCustomObject]@{Name = "Scrum";            ID = "6b724908-ef14-45cf-84f8-768b5384da45"},
+            [PSCustomObject]@{Name = "Basic";            ID = "b8a3a935-7e91-48b8-a94c-606d37c3e9f2"},
+            [PSCustomObject]@{Name = "CMMI";             ID = "27450541-8e31-4150-9947-dc59f998fc01"},
+            [PSCustomObject]@{Name = "Agile";            ID = "adcc42ab-9882-485e-a3ed-7678f01f66bc"},
+            [PSCustomObject]@{Name = "Scrum With Space"; ID = "12345678-0000-0000-0000-000000000000"}
+         )
+         if ($name) {return $processes.where({$_.name -like $name})}
+         else       {return $processes}  
+      }
+      [vsteam_lib.ProcessTemplateCache]::Invalidate()
+   }
+
+   Context 'Enable / Disable, set as Default, Set Description' {
+
+      It 'Calls set-as-default. ' {
+         Set-VsteamProcess -ProcessTemplate "Scrum" -AsDefault -Force
+         Should -Invoke _callApi -Exactly -Times 1 -Scope It -ParameterFilter {
+            $Url    -like     '*/_apis/work/processes/6b724908-ef14-45cf-84f8-768b5384da45?*'       -and
+            $Body   -match    '"IsDefault":\s+true'        -and  
+            $Body   -notmatch 'IsEnabled|Description|Name' -and
+            $Method -eq       'Patch'
+         }
+      }
+      It 'Calls Enabled and uses multiple processes. ' {
+         Set-VsteamProcess -ProcessTemplate "Agile" -Enabled -Force
+
+         Should -Invoke _callApi -Exactly -Times 1 -Scope It -ParameterFilter {
+            $Url    -like  '*/_apis/work/processes/adcc42ab-9882-485e-a3ed-7678f01f66bc*' -and
+            $Body   -match '"IsEnabled":\s+true'              -and
+            $Body   -notmatch 'IsDefault|Description|Name'    -and 
+            $Method -eq    'Patch'
+         }
+      }
+      It 'Calls Disabled , Name and Description. ' {
+         Set-VsteamProcess -ProcessTemplate "Scrum With Space" -Disabled -Description "Do Not Use" -NewName "Old Version of Scrum" -Force
+
+         Should -Invoke _callApi -Exactly -Times 1 -Scope It -ParameterFilter {
+            $Url    -like  '*/_apis/work/processes/12345678-0000-0000-0000-000000000000*' -and
+            $Body   -match '"IsEnabled":\s+false'             -and
+            $Body   -match '"name":\s+"Old Version of Scrum"' -and
+            $Body   -match '"Description":\s+"Do Not Use"'    -and
+            $Method -eq    'Patch'
+         }
+      }
+   }
+}

--- a/Tests/function/tests/Set-VSTeamProcess.Tests.ps1
+++ b/Tests/function/tests/Set-VSTeamProcess.Tests.ps1
@@ -1,10 +1,10 @@
 Set-StrictMode -Version Latest
 
-Describe 'Set-VSTeamProcess' {
+Describe 'VSTeamProcess' {
    BeforeAll {
       . "$PSScriptRoot\_testInitialize.ps1" $PSCommandPath
       . "$PSScriptRoot\..\..\..\Source\Public\Get-VSTeamProcess.ps1"
-    
+
 
       ## Arrange
       # Set the account to use for testing. A normal user would do this
@@ -13,14 +13,14 @@ Describe 'Set-VSTeamProcess' {
       Mock _getApiVersion    { return '1.0-unitTests' }
 
       Mock _callApi          {
-            #Return a single process object. Any process will do. 
+            #Return a single process object. Any process will do.
             return ([psCustomObject]@{
                typeId              = '6b724908-ef14-45cf-84f8-768b5384da45'
-               name                = 'Scrum' 
+               name                = 'Scrum'
                referenceName       = ''
                description         = 'This template is for teams who follow the Scrum framework.'
-               parentProcessTypeId = '00000000-0000-0000-0000-000000000000' 
-               isEnabled           = $True 
+               parentProcessTypeId = '00000000-0000-0000-0000-000000000000'
+               isEnabled           = $True
                isDefault           = $True
                customizationType   = 'system'
                })
@@ -34,41 +34,41 @@ Describe 'Set-VSTeamProcess' {
             [PSCustomObject]@{Name = "Scrum With Space"; ID = "12345678-0000-0000-0000-000000000000"}
          )
          if ($name) {return $processes.where({$_.name -like $name})}
-         else       {return $processes}  
+         else       {return $processes}
       }
       [vsteam_lib.ProcessTemplateCache]::Invalidate()
    }
 
-   Context 'Enable / Disable, set as Default, Set Description' {
+   Context 'Set-VSTeamProcess' {
 
       It 'Calls set-as-default. ' {
          Set-VsteamProcess -ProcessTemplate "Scrum" -AsDefault -Force
          Should -Invoke _callApi -Exactly -Times 1 -Scope It -ParameterFilter {
-            $Url    -like     '*/_apis/work/processes/6b724908-ef14-45cf-84f8-768b5384da45?*'       -and
-            $Body   -match    '"IsDefault":\s+true'        -and  
+            $Method -eq       'Patch'                      -and
+            $Body   -match    '"IsDefault":\s+true'        -and
             $Body   -notmatch 'IsEnabled|Description|Name' -and
-            $Method -eq       'Patch'
+            $Url    -like     '*/_apis/work/processes/6b724908-ef14-45cf-84f8-768b5384da45?*'
          }
       }
       It 'Calls Enabled and uses multiple processes. ' {
          Set-VsteamProcess -ProcessTemplate "Agile" -Enabled -Force
 
          Should -Invoke _callApi -Exactly -Times 1 -Scope It -ParameterFilter {
-            $Url    -like  '*/_apis/work/processes/adcc42ab-9882-485e-a3ed-7678f01f66bc*' -and
+            $Method -eq    'Patch'                            -and
             $Body   -match '"IsEnabled":\s+true'              -and
-            $Body   -notmatch 'IsDefault|Description|Name'    -and 
-            $Method -eq    'Patch'
+            $Body   -notmatch 'IsDefault|Description|Name'    -and
+            $Url    -like  '*/_apis/work/processes/adcc42ab-9882-485e-a3ed-7678f01f66bc*'
          }
       }
       It 'Calls Disabled , Name and Description. ' {
          Set-VsteamProcess -ProcessTemplate "Scrum With Space" -Disabled -Description "Do Not Use" -NewName "Old Version of Scrum" -Force
 
          Should -Invoke _callApi -Exactly -Times 1 -Scope It -ParameterFilter {
-            $Url    -like  '*/_apis/work/processes/12345678-0000-0000-0000-000000000000*' -and
+            $Method -eq    'Patch'                            -and
             $Body   -match '"IsEnabled":\s+false'             -and
             $Body   -match '"name":\s+"Old Version of Scrum"' -and
             $Body   -match '"Description":\s+"Do Not Use"'    -and
-            $Method -eq    'Patch'
+            $Url    -like  '*/_apis/work/processes/12345678-0000-0000-0000-000000000000*'
          }
       }
    }

--- a/Tests/function/tests/Set-VSTeamProcess.Tests.ps1
+++ b/Tests/function/tests/Set-VSTeamProcess.Tests.ps1
@@ -72,4 +72,9 @@ Describe 'VSTeamProcess' {
          }
       }
    }
+
+   AfterAll {
+      [vsteam_lib.Versions]::Account = 'https://dev.azure.com/test'
+   }
+
 }

--- a/Tests/function/tests/Set-VSTeamProcess.Tests.ps1
+++ b/Tests/function/tests/Set-VSTeamProcess.Tests.ps1
@@ -9,7 +9,7 @@ Describe 'VSTeamProcess' {
       ## Arrange
       # Set the account to use for testing. A normal user would do this
       # using the Set-VSTeamAccount function.
-      Mock _getInstance      { return 'https://dev.azure.com/test' }
+      [vsteam_lib.Versions]::Account = 'https://dev.azure.com/test'
       Mock _getApiVersion    { return '1.0-unitTests' }
 
       Mock _callApi          {

--- a/Tests/function/tests/Set-VSTeamProcessBehavior.Tests.ps1
+++ b/Tests/function/tests/Set-VSTeamProcessBehavior.Tests.ps1
@@ -46,4 +46,9 @@ Describe 'VSTeamProcessBehavior' {
          $behavior.ProcessTemplate      | Should -Be      'Scrum'
       }
    }
+
+   AfterAll {
+      [vsteam_lib.Versions]::Account = 'https://dev.azure.com/test'
+   }
+
 }

--- a/Tests/function/tests/Set-VSTeamProcessBehavior.Tests.ps1
+++ b/Tests/function/tests/Set-VSTeamProcessBehavior.Tests.ps1
@@ -8,8 +8,8 @@ Describe 'VSTeamProcessBehavior' {
       ## Arrange
       # Set the account to use for testing. A normal user would do this
       # using the Set-VSTeamAccount function.
-      Mock _getInstance       { return 'https://dev.azure.com/test' }
-      Mock _getApiVersion     { return '1.0-unitTests' } 
+      [vsteam_lib.Versions]::Account = 'https://dev.azure.com/test'
+      Mock _getApiVersion     { return '1.0-unitTests' }
       Mock _getDefaultProject { return "MockProject"}
    }
 
@@ -38,7 +38,7 @@ Describe 'VSTeamProcessBehavior' {
          ## Assert
          Should -Invoke _callapi -Scope It -ParameterFilter {
                 $method -eq 'Put' -and
-                $url     -match "https://dummy.none/_apis/work/processes/6b724908-ef14-45cf-84f8-768b5384da45/behaviors/TestReferenceName" -and 
+                $url     -match "https://dummy.none/_apis/work/processes/6b724908-ef14-45cf-84f8-768b5384da45/behaviors/TestReferenceName" -and
                 $body   -match '"name":\s*"NewName"' -and
                 $body   -match '"color":\s*"0000ff"' #Green translated
          } -Times 1 -Exactly

--- a/Tests/function/tests/Set-VSTeamProcessBehavior.Tests.ps1
+++ b/Tests/function/tests/Set-VSTeamProcessBehavior.Tests.ps1
@@ -1,0 +1,49 @@
+Set-StrictMode -Version Latest
+
+Describe 'VSTeamProcessBehavior' {
+   BeforeAll {
+      . "$PSScriptRoot\_testInitialize.ps1" $PSCommandPath
+      . "$PSScriptRoot\..\..\..\Source\Public\Get-VSTeamProcess.ps1"
+      . "$PSScriptRoot\..\..\..\Source\Public\Get-VSTeamProcessBehavior.ps1"
+      ## Arrange
+      # Set the account to use for testing. A normal user would do this
+      # using the Set-VSTeamAccount function.
+      Mock _getInstance       { return 'https://dev.azure.com/test' }
+      Mock _getApiVersion     { return '1.0-unitTests' } 
+      Mock _getDefaultProject { return "MockProject"}
+   }
+
+   Context 'Set-VSTeamProcessBehavior' {
+      BeforeAll {
+         ## Arrange
+         Mock _callAPi {return [pscustomobject]@{name="Dummy"}} -ParameterFilter {$method -eq "put"}
+         Mock Get-VSTeamProcess { return @(
+              [PSCustomObject]@{
+                  Name = "Scrum"
+                  URL  = "https://dummy.none/_apis/work/processes/6b724908-ef14-45cf-84f8-768b5384da45"
+               }
+            )
+         }
+         Mock Get-VSTeamProcessBehavior { return [PSCustomObject]@{
+            Name = "Test"
+            url = "https://dummy.none/_apis/work/processes/6b724908-ef14-45cf-84f8-768b5384da45/behaviors/TestReferenceName" }
+         }
+         [vsteam_lib.ProcessTemplateCache]::Invalidate()
+      }
+
+      It 'Calls the right API to add a process behavior' {
+         ## Act
+         $behavior = Set-VSTeamProcessBehavior -ProcessTemplate Scrum -Name "Test" -Color Blue -NewName "NewName" -Force
+
+         ## Assert
+         Should -Invoke _callapi -Scope It -ParameterFilter {
+                $method -eq 'Put' -and
+                $url     -match "https://dummy.none/_apis/work/processes/6b724908-ef14-45cf-84f8-768b5384da45/behaviors/TestReferenceName" -and 
+                $body   -match '"name":\s*"NewName"' -and
+                $body   -match '"color":\s*"0000ff"' #Green translated
+         } -Times 1 -Exactly
+         $behavior.psobject.Typenames   | Should -Contain 'vsteam_lib.Processbehavior'
+         $behavior.ProcessTemplate      | Should -Be      'Scrum'
+      }
+   }
+}

--- a/Tests/function/tests/Set-VSTeamSetting.Tests.ps1
+++ b/Tests/function/tests/Set-VSTeamSetting.Tests.ps1
@@ -19,7 +19,7 @@ Describe 'VSTeamSetting' {
 
       It 'should get make the correct api call to get settings' {
          ## Act
-         $settings = Set-VSTeamSetting -project "MockProject" -WorkingDays saturday -BugsBehavior asTasks
+         $settings = Set-VSTeamSetting -project "MockProject" -WorkingDays saturday -BugsBehavior asTasks -force
 
          ## Assert
          Should -Invoke _callapi -Scope It -ParameterFilter {

--- a/Tests/function/tests/Set-VSTeamSetting.Tests.ps1
+++ b/Tests/function/tests/Set-VSTeamSetting.Tests.ps1
@@ -6,7 +6,7 @@ Describe 'VSTeamSetting' {
       ## Arrange
       # Set the account to use for testing. A normal user would do this
       # using the Set-VSTeamAccount function.
-      Mock _getInstance       { return 'https://dev.azure.com/test' }
+      [vsteam_lib.Versions]::Account = 'https://dev.azure.com/test'
       Mock _getApiVersion     { return '1.0-unitTests' } -ParameterFilter { $Service -eq 'Processes' }
       Mock _getDefaultProject { return "MockProject"}
    }

--- a/Tests/function/tests/Set-VSTeamSetting.Tests.ps1
+++ b/Tests/function/tests/Set-VSTeamSetting.Tests.ps1
@@ -19,7 +19,7 @@ Describe 'VSTeamSetting' {
 
       It 'should get make the correct api call to get settings' {
          ## Act
-         $settings = Set-VSTeamSetting -project "MockProject" -WorkingDays saturday -BugsBehavior asTasks -force
+         $null = Set-VSTeamSetting -project "MockProject" -WorkingDays saturday -BugsBehavior asTasks -force
 
          ## Assert
          Should -Invoke _callapi -Scope It -ParameterFilter {
@@ -27,4 +27,9 @@ Describe 'VSTeamSetting' {
 
       }
    }
+
+   AfterAll {
+      [vsteam_lib.Versions]::Account = 'https://dev.azure.com/test'
+   }
+
 }

--- a/Tests/function/tests/Set-VSTeamSetting.Tests.ps1
+++ b/Tests/function/tests/Set-VSTeamSetting.Tests.ps1
@@ -1,0 +1,30 @@
+Set-StrictMode -Version Latest
+
+Describe 'VSTeamSetting' {
+   BeforeAll {
+      . "$PSScriptRoot\_testInitialize.ps1" $PSCommandPath
+      ## Arrange
+      # Set the account to use for testing. A normal user would do this
+      # using the Set-VSTeamAccount function.
+      Mock _getInstance       { return 'https://dev.azure.com/test' }
+      Mock _getApiVersion     { return '1.0-unitTests' } -ParameterFilter { $Service -eq 'Processes' }
+      Mock _getDefaultProject { return "MockProject"}
+   }
+
+   Context 'set-VSTeamSetting' {
+      BeforeAll {
+         ## Arrange
+         Mock _callAPi {}
+      }
+
+      It 'should get make the correct api call to get settings' {
+         ## Act
+         $settings = Set-VSTeamSetting -project "MockProject" -WorkingDays saturday -BugsBehavior asTasks
+
+         ## Assert
+         Should -Invoke _callapi -Scope It -ParameterFilter {
+            $resource -eq "teamsettings" -and  $area -eq "work"} -Times 1 -Exactly
+
+      }
+   }
+}

--- a/Tests/function/tests/Set-VSTeamWorkItemBehavior.Tests.ps1
+++ b/Tests/function/tests/Set-VSTeamWorkItemBehavior.Tests.ps1
@@ -9,7 +9,7 @@ Describe 'VSTeamWorkItemBehavior' {
       ## Arrange
       # Set the account to use for testing. A normal user would do this
       # using the Set-VSTeamAccount function.
-      Mock _getInstance       { return 'https://dev.azure.com/test' }
+      [vsteam_lib.Versions]::Account = 'https://dev.azure.com/test'
       Mock _getApiVersion     { return '1.0-unitTests' } -ParameterFilter { $Service -eq 'Processes' }
       Mock _getDefaultProject { return "MockProject"}
    }

--- a/Tests/function/tests/Set-VSTeamWorkItemBehavior.Tests.ps1
+++ b/Tests/function/tests/Set-VSTeamWorkItemBehavior.Tests.ps1
@@ -5,7 +5,7 @@ Describe 'VSTeamWorkItemBehavior' {
       . "$PSScriptRoot\_testInitialize.ps1" $PSCommandPath
       . "$PSScriptRoot\..\..\..\Source\Public\Get-VSTeamProcess.ps1"
       . "$PSScriptRoot\..\..\..\Source\Public\Get-VSTeamWorkItemType.ps1"
-      . "$PSScriptRoot\..\..\..\Source\Public\Get-VSTeamProcessBehavior"
+      . "$PSScriptRoot\..\..\..\Source\Public\Get-VSTeamProcessBehavior.ps1"
       ## Arrange
       # Set the account to use for testing. A normal user would do this
       # using the Set-VSTeamAccount function.
@@ -22,10 +22,10 @@ Describe 'VSTeamWorkItemBehavior' {
                      url = 'http://dummy.none'
          }}}
          Mock Write-Warning {}
-         Mock Get-VSTeamWorkItemType  -ParameterFilter { $WorkItemType -eq 'Custom' } { 
+         Mock Get-VSTeamWorkItemType  -ParameterFilter { $WorkItemType -eq 'Custom' } {
             [PSCustomObject]@{name = 'Custom'; url = 'http://dummy.none/workItemTypes/Microsoft.VSTS.WorkItemTypes.Custom/'; behaviors = @()}
          }
-         Mock Get-VSTeamWorkItemType  -ParameterFilter { $WorkItemType -eq 'Epic' } { 
+         Mock Get-VSTeamWorkItemType  -ParameterFilter { $WorkItemType -eq 'Epic' } {
             [PSCustomObject]@{name = 'Epic';   url = 'http://dummy.none/workItemTypes/Microsoft.VSTS.WorkItemTypes.Epic';  behaviors = @(
                [PSCustomObject]@{isdefault = $true; behavior = [PSCustomObject]@{
                      id  = 'Microsoft.VSTS.Scrum.EpicBacklogBehavior'
@@ -44,8 +44,8 @@ Describe 'VSTeamWorkItemBehavior' {
                   name          = 'Epics'
                   referenceName = 'Microsoft.VSTS.Scrum.EpicBacklogBehavior'
                   rank          = 40
-         }} 
-         
+         }}
+
          [vsteam_lib.ProcessTemplateCache]::Invalidate()
       }
 
@@ -55,8 +55,8 @@ Describe 'VSTeamWorkItemBehavior' {
 
          ## Assert
          Should -Invoke Get-VSTeamWorkItemType    -Scope It -Exactly -Times 1  -ParameterFilter {$Expand -eq 'Behaviors'}
-         Should -Invoke Get-VSTeamProcessBehavior -Scope It -Exactly -Times 0 #not called on remove 
-         Should -Invoke Write-Warning             -Scope It -Exactly -Times 1 
+         Should -Invoke Get-VSTeamProcessBehavior -Scope It -Exactly -Times 0 #not called on remove
+         Should -Invoke Write-Warning             -Scope It -Exactly -Times 1
       }
       It 'should call the correct api to clear a behavior' {
          ## Act
@@ -78,7 +78,7 @@ Describe 'VSTeamWorkItemBehavior' {
          Should -Invoke Get-VSTeamWorkItemType    -Scope It -Exactly -Times 1  -ParameterFilter {$Expand -eq 'Behaviors'}
          Should -Invoke Get-VSTeamProcessBehavior -Scope It -Exactly -Times 1  #called on add
          Should -Invoke Write-Warning             -Scope It -Exactly -Times 1 # warning that it can't change default
-         
+
       }
       It 'should call the correct api to add a behavior and return the correct object' {
          ## Act

--- a/Tests/function/tests/Set-VSTeamWorkItemBehavior.Tests.ps1
+++ b/Tests/function/tests/Set-VSTeamWorkItemBehavior.Tests.ps1
@@ -98,6 +98,11 @@ Describe 'VSTeamWorkItemBehavior' {
       }
 
    }
+
+   AfterAll {
+      [vsteam_lib.Versions]::Account = 'https://dev.azure.com/test'
+   }
+
 }
 
 <#

--- a/Tests/function/tests/Set-VSTeamWorkItemBehavior.Tests.ps1
+++ b/Tests/function/tests/Set-VSTeamWorkItemBehavior.Tests.ps1
@@ -1,0 +1,107 @@
+Set-StrictMode -Version Latest
+
+Describe 'VSTeamWorkItemBehavior' {
+   BeforeAll {
+      . "$PSScriptRoot\_testInitialize.ps1" $PSCommandPath
+      . "$PSScriptRoot\..\..\..\Source\Public\Get-VSTeamProcess.ps1"
+      . "$PSScriptRoot\..\..\..\Source\Public\Get-VSTeamWorkItemType.ps1"
+      . "$PSScriptRoot\..\..\..\Source\Public\Get-VSTeamProcessBehavior"
+      ## Arrange
+      # Set the account to use for testing. A normal user would do this
+      # using the Set-VSTeamAccount function.
+      Mock _getInstance       { return 'https://dev.azure.com/test' }
+      Mock _getApiVersion     { return '1.0-unitTests' } -ParameterFilter { $Service -eq 'Processes' }
+      Mock _getDefaultProject { return "MockProject"}
+   }
+
+   Context 'Set-VSTeamWorkItemBehavior' {
+      BeforeAll {
+         ## Arrange
+         Mock _callApi { return  [PSCustomObject]@{isdefault = $false; behavior = [PSCustomObject]@{
+                     id  = 'Microsoft.VSTS.Scrum.EpicBacklogBehavior'
+                     url = 'http://dummy.none'
+         }}}
+         Mock Write-Warning {}
+         Mock Get-VSTeamWorkItemType  -ParameterFilter { $WorkItemType -eq 'Custom' } { 
+            [PSCustomObject]@{name = 'Custom'; url = 'http://dummy.none/workItemTypes/Microsoft.VSTS.WorkItemTypes.Custom/'; behaviors = @()}
+         }
+         Mock Get-VSTeamWorkItemType  -ParameterFilter { $WorkItemType -eq 'Epic' } { 
+            [PSCustomObject]@{name = 'Epic';   url = 'http://dummy.none/workItemTypes/Microsoft.VSTS.WorkItemTypes.Epic';  behaviors = @(
+               [PSCustomObject]@{isdefault = $true; behavior = [PSCustomObject]@{
+                     id  = 'Microsoft.VSTS.Scrum.EpicBacklogBehavior'
+                     url = 'http://dummy.none'
+               }}
+            )}
+         }
+         Mock Get-VSTeamProcess { return @(
+              [PSCustomObject]@{
+                  Name = 'Scrum'
+                  URL  = 'https://dummy.none/_apis/work/processes/6b724908-ef14-45cf-84f8-768b5384da45'
+               }
+            )
+         }
+         Mock Get-VSTeamProcessBehavior { return [PSCustomObject]@{
+                  name          = 'Epics'
+                  referenceName = 'Microsoft.VSTS.Scrum.EpicBacklogBehavior'
+                  rank          = 40
+         }} 
+         
+         [vsteam_lib.ProcessTemplateCache]::Invalidate()
+      }
+
+      It 'should raise a warning when trying to clear an empty behavior' {
+         ## Act
+         Set-VSTeamWorkItemBehavior -ProcessTemplate Scrum  -WorkItemType Custom -Remove -Force
+
+         ## Assert
+         Should -Invoke Get-VSTeamWorkItemType    -Scope It -Exactly -Times 1  -ParameterFilter {$Expand -eq 'Behaviors'}
+         Should -Invoke Get-VSTeamProcessBehavior -Scope It -Exactly -Times 0 #not called on remove 
+         Should -Invoke Write-Warning             -Scope It -Exactly -Times 1 
+      }
+      It 'should call the correct api to clear a behavior' {
+         ## Act
+         Set-VSTeamWorkItemBehavior -ProcessTemplate Scrum  -WorkItemType Epic -Remove  -Force
+
+         ## Assert
+         Should -Invoke Get-VSTeamWorkItemType    -Scope It -Exactly -Times 1  -ParameterFilter {$Expand -eq 'Behaviors'}
+         Should -Invoke Get-VSTeamProcessBehavior -Scope It -Exactly -Times 0  #not called on remove
+         Should -Invoke Write-Warning             -Scope It -Exactly -Times 0 # no warning this time
+         Should -Invoke _callApi                  -Scope It -Exactly -Times 1  -ParameterFilter {
+               $method -eq   'Delete'
+               $url    -like '*/workitemtypesbehaviors/Microsoft.VSTS.WorkItemTypes.Epic/behaviors/Microsoft.VSTS.Scrum.EpicBacklogBehavior*'}
+      }
+      It 'should warn on double adding the same behavior' {
+         ## Act
+         Set-VSTeamWorkItemBehavior -ProcessTemplate Scrum  -WorkItemType EPIC -Behavior "Epics"  -Force
+
+         ## Assert
+         Should -Invoke Get-VSTeamWorkItemType    -Scope It -Exactly -Times 1  -ParameterFilter {$Expand -eq 'Behaviors'}
+         Should -Invoke Get-VSTeamProcessBehavior -Scope It -Exactly -Times 1  #called on add
+         Should -Invoke Write-Warning             -Scope It -Exactly -Times 1 # warning that it can't change default
+         
+      }
+      It 'should call the correct api to add a behavior and return the correct object' {
+         ## Act
+         $behavior = Set-VSTeamWorkItemBehavior -ProcessTemplate Scrum  -WorkItemType Custom -Behavior "Epics"  -Force
+
+         ## Assert
+         Should -Invoke Get-VSTeamWorkItemType    -Scope It -Exactly -Times 1  -ParameterFilter {$Expand -eq 'Behaviors'}
+         Should -Invoke Get-VSTeamProcessBehavior -Scope It -Exactly -Times 1  #called on add
+         Should -Invoke Write-Warning             -Scope It -Exactly -Times 0 # no warning this this time
+         Should -Invoke _callApi                  -Scope It -Exactly -Times 1 {
+               $method -eq   'Delete'
+               $url    -like '*/workitemtypesbehaviors/Microsoft.VSTS.WorkItemTypes.Custom/behaviors/Microsoft.VSTS.Scrum.EpicBacklogBehavior*'}
+         $behavior.ProcessTemplate    | Should -BeExactly 'Scrum'
+         $behavior.WorkItemType       | Should -BeExactly 'Custom'
+         $behavior.Behavior           | Should -BeExactly 'Microsoft.VSTS.Scrum.EpicBacklogBehavior'
+         $behavior.psobject.Typenames | Should -Contain   'vsteam_lib.WorkItembehavior'
+      }
+
+   }
+}
+
+<#
+$behavior.psobject.Typenames   | Should -Contain 'vsteam_lib.WorkItembehavior'
+         $behavior.ProcessTemplate      | Should -Be      'Scrum'
+         $behavior.WorkItemType         | Should -Be      'Epic'
+#>

--- a/Tests/function/tests/Set-VSTeamWorkItemType.Tests.ps1
+++ b/Tests/function/tests/Set-VSTeamWorkItemType.Tests.ps1
@@ -49,7 +49,7 @@ Describe 'VSTeamWorkItemType' {
                                     color         = 'cc293d'
                                     isDisabled    =  $false
                                     description   = 'A divergence...'
-                                    url           = 'http://bogus.none/98'
+                                    url           = 'http://bogus.none/workitemTypes/98'
                   }
                   [psCustomObject]@{name          = 'Gub'
                                     customization = 'custom'
@@ -57,7 +57,7 @@ Describe 'VSTeamWorkItemType' {
                                     color         = 'ff0000'
                                     isDisabled    =  $false
                                     description   = 'Test Item'
-                                    url           = 'http://bogus.none/99';
+                                    url           = 'http://bogus.none/workitemTypes/99';
                   }
                )
          if ($WorkItemType) { return $wits.where( { $_.name -like $WorkItemType }) }
@@ -89,7 +89,7 @@ Describe 'VSTeamWorkItemType' {
        It 'Posts changes for system WorkItem Types' {
          Set-VSTeamWorkItemType -ProcessTemplate "Scrum With Space" -WorkItemType Bug -Disabled -Force
          Should -Invoke _callApi -Exactly -Times 1 -Scope It -ParameterFilter {
-            $Url    -like     '*98?api-version=*'           -and  #found expected item
+            $Url    -like     '*workitemTypes?api-version=*'           -and  #found expected item
             $Body   -match    '"isDisabled":\s+true'        -and
             $Body   -match    '"inheritsFrom":\s+"Microsoft.VSTS.WorkItemTypes.Bug"' -and
             $Method -eq       'Post'

--- a/Tests/function/tests/Set-VSTeamWorkItemType.Tests.ps1
+++ b/Tests/function/tests/Set-VSTeamWorkItemType.Tests.ps1
@@ -1,0 +1,98 @@
+Set-StrictMode -Version Latest
+
+Describe 'VSTeamWorkItemType' {
+   BeforeAll {
+      . "$PSScriptRoot\_testInitialize.ps1" $PSCommandPath
+      . "$PSScriptRoot\..\..\..\Source\Public\Get-VSteamProcess.ps1"
+      . "$PSScriptRoot\..\..\..\Source\Public\Get-VSTeamWorkItemIconList"
+      . "$PSScriptRoot\..\..\..\Source\Public\Get-VSTeamWorkItemType.ps1"
+
+      $Global:PSDefaultParameterValues.Remove("*-vsteam*:projectName")
+
+      ## Arrange
+      # Set the account to use for testing. A normal user would do this
+      # using the Set-VSTeamAccount function.
+      Mock _getInstance { return 'https://dev.azure.com/test' }
+      Mock _getApiVersion { return '1.0-unitTests' } -ParameterFilter { $Service -eq 'Processes' }
+
+      Mock Get-VSTeamProcess {
+         $processes = @(
+            [PSCustomObject]@{Name = "Scrum"; url = 'http://bogus.none/1'; ID = "6b724908-ef14-45cf-84f8-768b5384da45" },
+            [PSCustomObject]@{Name = "Basic"; url = 'http://bogus.none/2'; ID = "b8a3a935-7e91-48b8-a94c-606d37c3e9f2" },
+            [PSCustomObject]@{Name = "CMMI"; url = 'http://bogus.none/3'; ID = "27450541-8e31-4150-9947-dc59f998fc01" },
+            [PSCustomObject]@{Name = "Agile"; url = 'http://bogus.none/4'; ID = "adcc42ab-9882-485e-a3ed-7678f01f66bc" },
+            [PSCustomObject]@{Name = "Scrum With Space"; url = 'http://bogus.none/5'; ID = "12345678-0000-0000-0000-000000000000" }
+         )
+         if ($name) { return $processes.where( { $_.name -like $name }) }
+         else { return $processes }  
+      }
+      Mock _callApi -ParameterFilter { $resource -eq 'workitemicons' }  -MockWith {
+        return [pscustomobject]@{'Value' = @(
+               [pscustomobject]@{'ID' = 'icon_airplane' }
+               [pscustomobject]@{'ID' = 'icon_asterisk' }
+               [pscustomobject]@{'ID' = 'icon_book' }
+            ) 
+         }
+      }
+      Mock _callApi -ParameterFilter { $Method -eq 'Post' } -MockWith {
+         return ([psCustomObject]@{name = 'Dummy' })
+      }
+      Mock _callApi -ParameterFilter { $Method -eq 'Patch' } -MockWith {
+         return ([psCustomObject]@{name = 'Dummy' })
+      }
+      Mock Get-VSTeamWorkItemType   {
+            $wits = @(
+                  [psCustomObject]@{name          = 'Bug'
+                                    customization = 'system'
+                                    referenceName = 'Microsoft.VSTS.WorkItemTypes.Bug'
+                                    icon          = 'icon_insect'
+                                    color         = 'cc293d'
+                                    isDisabled    =  $false
+                                    description   = 'A divergence...' 
+                                    url           = 'http://bogus.none/98'
+                  }
+                  [psCustomObject]@{name          = 'Gub'
+                                    customization = 'custom'
+                                    icon          = 'icon_book'
+                                    color         = 'ff0000'
+                                    isDisabled    =  $false
+                                    description   = 'Test Item' 
+                                    url           = 'http://bogus.none/99';
+                  }
+               )
+         if ($WorkItemType) { return $wits.where( { $_.name -like $WorkItemType }) }
+         else               { return $wits }  
+      } 
+      [vsteam_lib.IconCache]::Invalidate()
+   }
+
+   Context 'Update WorkItem Types' {
+
+      It 'Catches invalid WorkItem Type names.' {
+         Set-VSTeamWorkItemType -ProcessTemplate "Scrum With Space" -WorkItemType NewWit -Description "New Work item Type" -Color ff0000  -Icon icon_asterisk  -WarningVariable "Warn" -warningAction SilentlyContinue 
+         # Should not call the rest API from the function body, but may populate the work-item icons cache 
+         Should -Invoke _callApi -Exactly -Times 0 -Scope It {-not ($resource -eq "workitemicons")} 
+         $warn | Should -Be "'NewWit' does not appear to be a valid Workitem type."
+      }
+      It 'Patches custom WorkItem Types.' {
+         Set-VSTeamWorkItemType -ProcessTemplate "Scrum With Space" -WorkItemType Gub -Description 'New Text' -Color Green  -Icon icon_book    -Force
+         Should -Invoke _callApi -Exactly -Times 1 -Scope It -ParameterFilter {
+            $Url    -like     '*99?api-version=*'           -and  #found expected item
+            $Body   -match    '"isDisabled":\s+false'       -and  #Should expressly set   
+            $Body   -match    '"color":\s+"008000"'         -and  #Should convert from green
+            $Body   -match    '"icon":\s+"icon_book"'       -and  
+            $Body   -match    '"description":\s+"New Text'  -and  
+            $Method -eq       'Patch'
+         }
+      }
+       It 'Posts changes for system WorkItem Types' {
+         Set-VSTeamWorkItemType -ProcessTemplate "Scrum With Space" -WorkItemType Bug -Disabled -Force
+         Should -Invoke _callApi -Exactly -Times 1 -Scope It -ParameterFilter {
+            $Url    -like     '*98?api-version=*'           -and  #found expected item
+            $Body   -match    '"isDisabled":\s+true'        -and   
+            $Body   -match    '"inheritsFrom":\s+"Microsoft.VSTS.WorkItemTypes.Bug"' -and  
+            $Method -eq       'Post'
+         }
+      }
+   }
+}

--- a/Tests/function/tests/Set-VSTeamWorkItemType.Tests.ps1
+++ b/Tests/function/tests/Set-VSTeamWorkItemType.Tests.ps1
@@ -64,6 +64,7 @@ Describe 'VSTeamWorkItemType' {
          else               { return $wits }  
       } 
       [vsteam_lib.IconCache]::Invalidate()
+      [vsteam_lib.ProcessTemplateCache]::Invalidate()
    }
 
    Context 'Update WorkItem Types' {

--- a/Tests/function/tests/Set-VSTeamWorkItemType.Tests.ps1
+++ b/Tests/function/tests/Set-VSTeamWorkItemType.Tests.ps1
@@ -24,14 +24,14 @@ Describe 'VSTeamWorkItemType' {
             [PSCustomObject]@{Name = "Scrum With Space"; url = 'http://bogus.none/5'; ID = "12345678-0000-0000-0000-000000000000" }
          )
          if ($name) { return $processes.where( { $_.name -like $name }) }
-         else { return $processes }  
+         else { return $processes }
       }
       Mock _callApi -ParameterFilter { $resource -eq 'workitemicons' }  -MockWith {
         return [pscustomobject]@{'Value' = @(
                [pscustomobject]@{'ID' = 'icon_airplane' }
                [pscustomobject]@{'ID' = 'icon_asterisk' }
                [pscustomobject]@{'ID' = 'icon_book' }
-            ) 
+            )
          }
       }
       Mock _callApi -ParameterFilter { $Method -eq 'Post' } -MockWith {
@@ -48,7 +48,7 @@ Describe 'VSTeamWorkItemType' {
                                     icon          = 'icon_insect'
                                     color         = 'cc293d'
                                     isDisabled    =  $false
-                                    description   = 'A divergence...' 
+                                    description   = 'A divergence...'
                                     url           = 'http://bogus.none/98'
                   }
                   [psCustomObject]@{name          = 'Gub'
@@ -56,13 +56,13 @@ Describe 'VSTeamWorkItemType' {
                                     icon          = 'icon_book'
                                     color         = 'ff0000'
                                     isDisabled    =  $false
-                                    description   = 'Test Item' 
+                                    description   = 'Test Item'
                                     url           = 'http://bogus.none/99';
                   }
                )
          if ($WorkItemType) { return $wits.where( { $_.name -like $WorkItemType }) }
-         else               { return $wits }  
-      } 
+         else               { return $wits }
+      }
       [vsteam_lib.IconCache]::Invalidate()
       [vsteam_lib.ProcessTemplateCache]::Invalidate()
    }
@@ -70,19 +70,19 @@ Describe 'VSTeamWorkItemType' {
    Context 'Update WorkItem Types' {
 
       It 'Catches invalid WorkItem Type names.' {
-         Set-VSTeamWorkItemType -ProcessTemplate "Scrum With Space" -WorkItemType NewWit -Description "New Work item Type" -Color ff0000  -Icon icon_asterisk  -WarningVariable "Warn" -warningAction SilentlyContinue 
-         # Should not call the rest API from the function body, but may populate the work-item icons cache 
-         Should -Invoke _callApi -Exactly -Times 0 -Scope It {-not ($resource -eq "workitemicons")} 
-         $warn | Should -Be "'NewWit' does not appear to be a valid Workitem type."
+         Set-VSTeamWorkItemType -ProcessTemplate "Scrum With Space" -WorkItemType NewWit -Description "New Work item Type" -Color ff0000  -Icon icon_asterisk  -WarningVariable "Warn" -warningAction SilentlyContinue
+         # Should not call the rest API from the function body, but may populate the work-item icons cache
+         Should -Invoke _callApi -Exactly -Times 0 -Scope It {-not ($resource -eq "workitemicons")}
+         $warn | Should -Match "'NewWit'"
       }
       It 'Patches custom WorkItem Types.' {
          Set-VSTeamWorkItemType -ProcessTemplate "Scrum With Space" -WorkItemType Gub -Description 'New Text' -Color Green  -Icon icon_book    -Force
          Should -Invoke _callApi -Exactly -Times 1 -Scope It -ParameterFilter {
             $Url    -like     '*99?api-version=*'           -and  #found expected item
-            $Body   -match    '"isDisabled":\s+false'       -and  #Should expressly set   
+            $Body   -match    '"isDisabled":\s+false'       -and  #Should expressly set
             $Body   -match    '"color":\s+"008000"'         -and  #Should convert from green
-            $Body   -match    '"icon":\s+"icon_book"'       -and  
-            $Body   -match    '"description":\s+"New Text'  -and  
+            $Body   -match    '"icon":\s+"icon_book"'       -and
+            $Body   -match    '"description":\s+"New Text'  -and
             $Method -eq       'Patch'
          }
       }
@@ -90,8 +90,8 @@ Describe 'VSTeamWorkItemType' {
          Set-VSTeamWorkItemType -ProcessTemplate "Scrum With Space" -WorkItemType Bug -Disabled -Force
          Should -Invoke _callApi -Exactly -Times 1 -Scope It -ParameterFilter {
             $Url    -like     '*98?api-version=*'           -and  #found expected item
-            $Body   -match    '"isDisabled":\s+true'        -and   
-            $Body   -match    '"inheritsFrom":\s+"Microsoft.VSTS.WorkItemTypes.Bug"' -and  
+            $Body   -match    '"isDisabled":\s+true'        -and
+            $Body   -match    '"inheritsFrom":\s+"Microsoft.VSTS.WorkItemTypes.Bug"' -and
             $Method -eq       'Post'
          }
       }

--- a/Tests/function/tests/Set-VSTeamWorkItemType.Tests.ps1
+++ b/Tests/function/tests/Set-VSTeamWorkItemType.Tests.ps1
@@ -3,8 +3,8 @@ Set-StrictMode -Version Latest
 Describe 'VSTeamWorkItemType' {
    BeforeAll {
       . "$PSScriptRoot\_testInitialize.ps1" $PSCommandPath
-      . "$PSScriptRoot\..\..\..\Source\Public\Get-VSteamProcess.ps1"
-      . "$PSScriptRoot\..\..\..\Source\Public\Get-VSTeamWorkItemIconList"
+      . "$PSScriptRoot\..\..\..\Source\Public\Get-VSTeamProcess.ps1"
+      . "$PSScriptRoot\..\..\..\Source\Public\Get-VSTeamWorkItemIconList.ps1"
       . "$PSScriptRoot\..\..\..\Source\Public\Get-VSTeamWorkItemType.ps1"
 
       $Global:PSDefaultParameterValues.Remove("*-vsteam*:projectName")

--- a/Tests/function/tests/Unlock-VSTeamWorkItemType.Tests.ps1
+++ b/Tests/function/tests/Unlock-VSTeamWorkItemType.Tests.ps1
@@ -1,0 +1,60 @@
+Set-StrictMode -Version Latest
+
+Describe 'VSTeamWorkItemType' {
+   BeforeAll {
+      . "$PSScriptRoot\_testInitialize.ps1" $PSCommandPath
+
+      ## Arrange
+      # Set the account to use for testing. A normal user would do this
+      # using the Set-VSTeamAccount function.
+      Mock _getInstance { return 'https://dev.azure.com/test' }
+      Mock _getApiVersion { return '1.0-unitTests' }
+      Mock _callApi -ParameterFilter { $Method -eq 'Post' } -MockWith {
+         return ([psCustomObject]@{name = 'Dummy' })
+      }
+   }
+
+   Context 'Update WorkItem Types' {
+
+
+      It 'Returns custom WorkItem Types untouched.' {
+
+         $wit = [psCustomObject]@{
+            name          = 'Gub'
+            customization = 'custom'
+            icon          = 'icon_book'
+            color         = 'ff0000'
+            isDisabled    =  $false
+            description   = 'Test Item'
+            url           = 'http://bogus.none/workItemTypes/99';
+         }
+         $x = $wit | Unlock-VSTeamWorkItemType -Force
+
+         Should -Invoke _callApi -Exactly -Times 0 -Scope It
+         $x.customization | should -BeExactly $wit.customization
+         $x.url | should -BeExactly $wit.url
+      }
+
+      It 'Posts changes for system WorkItem Types' {
+         $wit =   [psCustomObject]@{
+            name          = 'Bug'
+            customization = 'system'
+            referenceName = 'Microsoft.VSTS.WorkItemTypes.Bug'
+            icon          = 'icon_insect'
+            color         = 'cc293d'
+            isDisabled    =  $false
+            description   = 'A divergence...'
+            url           = 'http://bogus.none/workItemTypes/98'
+         }
+
+         $x = $wit | Unlock-VSTeamWorkItemType -Force
+         Should -Invoke _callApi -Exactly -Times 1 -Scope It -ParameterFilter {
+            $Url    -like     '*workitemTypes?api-version=*'           -and  #found expected item
+            $Body   -match    '"inheritsFrom":\s+"Microsoft.VSTS.WorkItemTypes.Bug"' -and
+            $Method -eq       'Post'
+         }
+         $x.psobject.TypeNames | Should -Contain 'vsteam_lib.WorkItemType'
+         $x.name               | Should -Be 'Dummy'
+      }
+   }
+}

--- a/Tests/function/tests/_testInitialize.ps1
+++ b/Tests/function/tests/_testInitialize.ps1
@@ -11,7 +11,7 @@ Import-Module SHiPS
 
 $baseFolder = "$PSScriptRoot/../../.."
 $sampleFiles = "$PSScriptRoot/../../SampleFiles"
-      
+
 Add-Type -Path "$baseFolder/dist/bin/vsteam-lib.dll"
 
 $sut = (Split-Path -Leaf $testPath).Replace(".Tests.", ".")
@@ -22,7 +22,7 @@ $sut = (Split-Path -Leaf $testPath).Replace(".Tests.", ".")
 if ($private.IsPresent) {
    . "$baseFolder/Source/Private/$sut"
 }
-else {   
+else {
    . "$baseFolder/Source/Public/$sut"
 }
 
@@ -31,7 +31,7 @@ if ($doNotPrimeCache.IsPresent) {
 }
 
 # Prime the project cache with an empty list. This will make sure
-# any project name used will pass validation and Get-VSTeamProject 
+# any project name used will pass validation and Get-VSTeamProject
 # will not need to be called.
 [vsteam_lib.ProjectCache]::Update([string[]]@(), 120)
 
@@ -41,13 +41,13 @@ function Open-SampleFile {
       [string] $file,
       [switch] $ReturnValue,
       # The index of the value array to return
-      [int] $index = -1, 
+      [int] $index = -1,
       [switch] $Json
    )
    if ($Json.IsPresent) {
-      return $(Get-Content "$sampleFiles\$file" -Raw | ConvertTo-Json)
+      return $(Get-Content "$sampleFiles\$file" -Raw ) #had convertTo-json but this files are json text, caused warning with PS 7.1
    }
-   
+
    if ($ReturnValue.IsPresent) {
       return $(Get-Content "$sampleFiles\$file" -Raw | ConvertFrom-Json).value
    }

--- a/Tests/library/Provider/ProcessTests.cs
+++ b/Tests/library/Provider/ProcessTests.cs
@@ -17,16 +17,44 @@ namespace vsteam_lib.Test.Provider
          var target = new Process(obj[0]);
 
          // Assert
+         Assert.IsNull(target.Projects, "Projects");
          Assert.AreEqual("Scrum", target.Name, "Name");
          Assert.AreEqual("system", target.Type, "Type");
          Assert.AreEqual(true, target.IsEnabled, "IsEnabled");
          Assert.AreEqual(false, target.IsDefault, "IsDefault");
          Assert.AreEqual("Scrum", target.ToString(), "ToString()");
+         Assert.AreEqual("test", target.ReferenceName, "ReferenceName");
          Assert.AreEqual("Scrum", target.ProcessTemplate, "ProcessTemplate");
          Assert.AreEqual("6b724908-ef14-45cf-84f8-768b5384da45", target.Id, "Id");
          Assert.AreEqual("6b724908-ef14-45cf-84f8-768b5384da45", target.TypeId, "TypeId");
          Assert.AreEqual("00000000-0000-0000-0000-000000000000", target.ParentProcessTypeId, "ParentProcessTypeId");
          Assert.AreEqual("This template is for teams who follow the Scrum framework.", target.Description, "Description");
+      }
+
+      [TestMethod]
+      public void Process_Constructor_WithProjects()
+      {
+         // Arrange
+         var obj = BaseTests.LoadJson("Get-VSTeamProcess.json");
+
+         // Act
+         var target = new Process(obj[1]);
+
+         // Assert
+         Assert.IsNotNull(target.Projects, "Projects");
+         Assert.AreEqual("Agile", target.Name, "Name");
+         Assert.AreEqual("system", target.Type, "Type");
+         Assert.IsNull(target.ReferenceName, "ReferenceName");
+         Assert.AreEqual(true, target.IsEnabled, "IsEnabled");
+         Assert.AreEqual(true, target.IsDefault, "IsDefault");
+         Assert.AreEqual("Agile", target.ToString(), "ToString()");
+         Assert.AreEqual("Agile", target.ProcessTemplate, "ProcessTemplate");
+         Assert.AreEqual("adcc42ab-9882-485e-a3ed-7678f01f66bc", target.Id, "Id");
+         Assert.AreEqual("adcc42ab-9882-485e-a3ed-7678f01f66bc", target.TypeId, "TypeId");
+         Assert.AreEqual("00000000-0000-0000-0000-000000000000", target.ParentProcessTypeId, "ParentProcessTypeId");
+         Assert.AreEqual("This template is flexible and will work great for most teams using Agile planning methods, including those practicing Scrum.", 
+                         target.Description, 
+                         "Description");
       }
    }
 }


### PR DESCRIPTION
# PR Summary

1.  Added Commands `Add-` and `Set-` `-VSTeamProcess`. `Add-` creates a process template based on a pre-existing one, Set- enables/disables, sets the default for new projects and changes the name / description.
2.  Added Commands `Get-` `Set-` `Add-` `-Remove` `-VSTeamProcessBehavior` and a format XML file for process behaviors. (a.k.a boards). Combined with (1) allows creation of a custom process template with its own boards. 
3.  Added Commands `Get-` `Set-` `-VSTeamWorkItemBehavior` and a format XML file  for WorkItem behaviors. These work with boards from (2) or with a custom-templates built-in boards to add work item types to a board. 
4.  Changed command `Get-VSTeamIteration` adding a switch -Expand to return all the iterations returned by the -Depth option, rather than one with a children node where each element may have children. 
5.  Added Commmands Get- and Set- -VSTeamSetting - to allow bug behavior and visibile boards (and things set with them) to be set. Otherwise the boards from (2) can't be seen. 

## PR Checklist

- [x] [Write Help](https://github.com/DarqueWarrior/vsteam/blob/master/.github/CONTRIBUTING.md#write-help)
- [x] [Write Unit Test](https://github.com/DarqueWarrior/vsteam/blob/master/.github/CONTRIBUTING.md#write-unit-test)
- [x] [Update CHANGELOG.md](https://github.com/DarqueWarrior/vsteam/blob/master/.github/CONTRIBUTING.md#update-changelogmd) 

Test count now at 735. Tests for settings are fairly simple, others more sophisticated. Text above is in the change log. Note that this depends on  #361 but not on #362 


