### PR TITLE
Fix #365

### DIFF
--- a/Source/Classes/Cache/QueryCache.cs
+++ b/Source/Classes/Cache/QueryCache.cs
@@ -36,11 +36,10 @@ namespace vsteam_lib
                }
 
                // This will return just the names
-               list = Cache.Shell.AddArgument(queries)
-                                 .AddCommand("Select-Object")
+               list = Cache.Shell.AddCommand("Select-Object")
                                  .AddParameter("ExpandProperty", "Name")
                                  .AddCommand("Sort-Object")
-                                 .Invoke<string>();
+                                 .Invoke<string>(queries);
             }
          }
 

--- a/Tests/library/Cache/QueryCacheTests.cs
+++ b/Tests/library/Cache/QueryCacheTests.cs
@@ -45,6 +45,7 @@ namespace vsteam_lib.Test
          var expected = 2;
          var ps = BaseTests.PrepPowerShell();
          ps.Invoke().Returns(this._queries);
+         ps.Invoke<string>(this._queries).Returns(this._queryNames);
          ps.Invoke<string>().Returns(this._defaultProject, this._queryNames);
          QueryCache.Cache.Shell = ps;
 
@@ -62,6 +63,8 @@ namespace vsteam_lib.Test
          var expected = 2;
          var ps = BaseTests.PrepPowerShell();
          ps.Invoke().Returns(this._queries);
+         ps.Invoke<string>(this._queries).Returns(this._queryNames);
+
          ps.Invoke<string>().Returns(this._defaultProject, this._queryNames);
          QueryCache.Invalidate();
          QueryCache.Cache.Shell = ps;


### PR DESCRIPTION
# PR Summary

It appears this 
```
               list = Cache.Shell.AddArgument(queries)
                                 .AddCommand("Select-Object")
                                 .AddParameter("ExpandProperty", "Name")
                                 .AddCommand("Sort-Object")
                                 .Invoke<string>();
```
Is the wrong way to pass `queries` down the pipeline into `select-object` and causes 
`A command is required to add a parameter. A command must be added to the PowerShell instance before adding a parameter.`

It's fixed by changed to calling the command like this.
```
list = Cache.Shell.AddCommand("Select-Object")
                                 .AddParameter("ExpandProperty", "Name")
                                 .AddCommand("Sort-Object")
                                 .Invoke<string>(queries);
```

## PR Checklist

- [ ] [Write Help](https://github.com/DarqueWarrior/vsteam/blob/master/.github/CONTRIBUTING.md#write-help)
- [ ] [Write Unit Test](https://github.com/DarqueWarrior/vsteam/blob/master/.github/CONTRIBUTING.md#write-unit-test)
- [ ] [Update CHANGELOG.md](https://github.com/DarqueWarrior/vsteam/blob/master/.github/CONTRIBUTING.md#update-changelogmd)
