### PR TITLE
Addressing Issue #373

### DIFF
--- a/.docs/Clear-VSTeamDefaultProjectCount.md
+++ b/.docs/Clear-VSTeamDefaultProjectCount.md
@@ -1,0 +1,47 @@
+<!-- #include "./common/header.md" -->
+
+# Clear-VSTeamDefaultProjectCount
+
+## SYNOPSIS
+
+<!-- #include "./synopsis/Clear-VSTeamDefaultProjectCount.md" -->
+
+## SYNTAX
+
+## DESCRIPTION
+
+<!-- #include "./synopsis/Clear-VSTeamDefaultProjectCount.md" -->
+
+Clearing this value will only return the top 100 projects. This could have a negative effect on project name tab completion and validation if you have more than 100 projects.
+
+## EXAMPLES
+
+### Example 1
+
+```powershell
+Clear-VSTeamDefaultProjectCount
+```
+
+This will clear the default project count parameter value. You will now only get the top 100 projects back.
+
+## PARAMETERS
+
+### Level
+
+On Windows allows you to clear your default project at the Process, User or Machine levels.
+
+```yaml
+Type: String
+```
+
+## INPUTS
+
+## OUTPUTS
+
+## NOTES
+
+<!-- #include "./common/prerequisites.md" -->
+
+## RELATED LINKS
+
+<!-- #include "./common/related.md" -->

--- a/.docs/Set-VSTeamDefaultProjectCount.md
+++ b/.docs/Set-VSTeamDefaultProjectCount.md
@@ -1,0 +1,65 @@
+<!-- #include "./common/header.md" -->
+
+# Set-VSTeamDefaultProjectCount
+
+## SYNOPSIS
+
+<!-- #include "./synopsis/Set-VSTeamDefaultProjectCount.md" -->
+
+## SYNTAX
+
+## DESCRIPTION
+
+The majority of the functions in this module require a project name and you can tab complete it. Each project name if validated before used in a function call.
+
+By setting a default project count you can make sure all your projects are returned during tab completion and project name parameter validation if you have more than 100 projects.
+
+## EXAMPLES
+
+### Example 1
+
+```powershell
+Set-VSTeamDefaultProjectCount 500
+```
+
+This command sets 500 as the default project count to return.
+
+## PARAMETERS
+
+### Count
+
+Specifies the number of projects to return by default.
+
+```yaml
+Type: int
+Required: True
+Accept pipeline input: true (ByPropertyName)
+```
+
+### Level
+
+On Windows allows you to store your default project count at the Process, User or Machine levels.
+
+When saved at the User or Machine level your default project count will be in any future PowerShell processes.
+
+```yaml
+Type: String
+```
+
+<!-- #include "./params/forcegroup.md" -->
+
+## INPUTS
+
+### System.String
+
+## OUTPUTS
+
+### System.Object
+
+## NOTES
+
+<!-- #include "./common/prerequisites.md" -->
+
+## RELATED LINKS
+
+<!-- #include "./common/related.md" -->

--- a/.docs/synopsis/Clear-VSTeamDefaultProjectCount.md
+++ b/.docs/synopsis/Clear-VSTeamDefaultProjectCount.md
@@ -1,0 +1,1 @@
+Clears the value stored in the default project count parameter value.

--- a/.docs/synopsis/Set-VSTeamDefaultProjectCount.md
+++ b/.docs/synopsis/Set-VSTeamDefaultProjectCount.md
@@ -1,0 +1,1 @@
+Sets the default project count to be used with other calls in the module. This is important if you have more than 100 projects.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ Changed Get-VSTeamProject to return all projects by default instead of just the 
 $Global:PSDefaultParameterValues["*-vsteam*:top"] = 500
 ```
 
-Fixed issue #360 but updating the way DateTimes are tested.
+Fixed issue #360 by updating the way DateTimes are tested.
 
 ## 7.1.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 7.1.3
+
+Added Clear-VSTeamDefaultProjectCount and Set-VSTeamDefaultProjectCount to control the default number of projects returned for tab completion and validation. By default only 100 projects are returned and the 100 returned is nondeterministic. But calling Set-VSTeamDefaultProjectCount you can increase the number of projects returned.
+
 ## 7.1.2
 
 Merged [Pull Request](https://github.com/DarqueWarrior/vsteam/pull/366) from [Jhoneill](https://github.com/jhoneill) which included the following:

--- a/Source/Private/common.ps1
+++ b/Source/Private/common.ps1
@@ -451,6 +451,46 @@ function _getWorkItemTypes {
    }
 }
 
+function _buildLevelDynamicParam {
+   param ()
+   # # Only add these options on Windows Machines
+   if (_isOnWindows) {
+      $ParameterName = 'Level'
+
+      # Create the dictionary
+      $RuntimeParameterDictionary = New-Object System.Management.Automation.RuntimeDefinedParameterDictionary
+
+      # Create the collection of attributes
+      $AttributeCollection = New-Object System.Collections.ObjectModel.Collection[System.Attribute]
+
+      # Create and set the parameters' attributes
+      $ParameterAttribute = New-Object System.Management.Automation.ParameterAttribute
+      $ParameterAttribute.Mandatory = $false
+      $ParameterAttribute.HelpMessage = "On Windows machines allows you to store the default project at the process, user or machine level. Not available on other platforms."
+
+      # Add the attributes to the attributes collection
+      $AttributeCollection.Add($ParameterAttribute)
+
+      # Generate and set the ValidateSet
+      if (_testAdministrator) {
+         $arrSet = "Process", "User", "Machine"
+      }
+      else {
+         $arrSet = "Process", "User"
+      }
+
+      $ValidateSetAttribute = New-Object System.Management.Automation.ValidateSetAttribute($arrSet)
+
+      # Add the ValidateSet to the attributes collection
+      $AttributeCollection.Add($ValidateSetAttribute)
+
+      # Create and return the dynamic parameter
+      $RuntimeParameter = New-Object System.Management.Automation.RuntimeDefinedParameter($ParameterName, [string], $AttributeCollection)
+      $RuntimeParameterDictionary.Add($ParameterName, $RuntimeParameter)
+      return $RuntimeParameterDictionary
+   }
+}
+
 function _buildProjectNameDynamicParam {
    param(
       [string] $ParameterName = 'ProjectName',
@@ -526,7 +566,6 @@ function _buildProjectNameDynamicParam {
       }
    #>
 }
-
 function _buildProcessNameDynamicParam {
    param(
       [string] $ParameterName = 'ProcessName',

--- a/Source/Public/Clear-VSTeamDefaultProject.ps1
+++ b/Source/Public/Clear-VSTeamDefaultProject.ps1
@@ -10,7 +10,7 @@ function Clear-VSTeamDefaultProject {
    begin {
       if (_isOnWindows) {
          # Bind the parameter to a friendly variable
-         $Level = $PSBoundParameters[$ParameterName]
+         $Level = $PSBoundParameters['Level']
       }
    }
 

--- a/Source/Public/Clear-VSTeamDefaultProject.ps1
+++ b/Source/Public/Clear-VSTeamDefaultProject.ps1
@@ -4,42 +4,7 @@ function Clear-VSTeamDefaultProject {
    param()
 
    DynamicParam {
-      # # Only add these options on Windows Machines
-      if (_isOnWindows) {
-         $ParameterName = 'Level'
-
-         # Create the dictionary
-         $RuntimeParameterDictionary = New-Object System.Management.Automation.RuntimeDefinedParameterDictionary
-
-         # Create the collection of attributes
-         $AttributeCollection = New-Object System.Collections.ObjectModel.Collection[System.Attribute]
-
-         # Create and set the parameters' attributes
-         $ParameterAttribute = New-Object System.Management.Automation.ParameterAttribute
-         $ParameterAttribute.Mandatory = $false
-         $ParameterAttribute.HelpMessage = "On Windows machines allows you to store the default project at the process, user or machine level. Not available on other platforms."
-
-         # Add the attributes to the attributes collection
-         $AttributeCollection.Add($ParameterAttribute)
-
-         # Generate and set the ValidateSet
-         if (_testAdministrator) {
-            $arrSet = "Process", "User", "Machine"
-         }
-         else {
-            $arrSet = "Process", "User"
-         }
-
-         $ValidateSetAttribute = New-Object System.Management.Automation.ValidateSetAttribute($arrSet)
-
-         # Add the ValidateSet to the attributes collection
-         $AttributeCollection.Add($ValidateSetAttribute)
-
-         # Create and return the dynamic parameter
-         $RuntimeParameter = New-Object System.Management.Automation.RuntimeDefinedParameter($ParameterName, [string], $AttributeCollection)
-         $RuntimeParameterDictionary.Add($ParameterName, $RuntimeParameter)
-         return $RuntimeParameterDictionary
-      }
+      _buildLevelDynamicParam
    }
 
    begin {

--- a/Source/Public/Clear-VSTeamDefaultProjectCount.ps1
+++ b/Source/Public/Clear-VSTeamDefaultProjectCount.ps1
@@ -1,0 +1,72 @@
+function Clear-VSTeamDefaultProjectCount {
+   [Diagnostics.CodeAnalysis.SuppressMessageAttribute("PSUseDeclaredVarsMoreThanAssignments", "")]
+   [CmdletBinding()]
+   param()
+
+   DynamicParam {
+      # # Only add these options on Windows Machines
+      if (_isOnWindows) {
+         $ParameterName = 'Level'
+
+         # Create the dictionary
+         $RuntimeParameterDictionary = New-Object System.Management.Automation.RuntimeDefinedParameterDictionary
+
+         # Create the collection of attributes
+         $AttributeCollection = New-Object System.Collections.ObjectModel.Collection[System.Attribute]
+
+         # Create and set the parameters' attributes
+         $ParameterAttribute = New-Object System.Management.Automation.ParameterAttribute
+         $ParameterAttribute.Mandatory = $false
+         $ParameterAttribute.HelpMessage = "On Windows machines allows you to store the default project at the process, user or machine level. Not available on other platforms."
+
+         # Add the attributes to the attributes collection
+         $AttributeCollection.Add($ParameterAttribute)
+
+         # Generate and set the ValidateSet
+         if (_testAdministrator) {
+            $arrSet = "Process", "User", "Machine"
+         }
+         else {
+            $arrSet = "Process", "User"
+         }
+
+         $ValidateSetAttribute = New-Object System.Management.Automation.ValidateSetAttribute($arrSet)
+
+         # Add the ValidateSet to the attributes collection
+         $AttributeCollection.Add($ValidateSetAttribute)
+
+         # Create and return the dynamic parameter
+         $RuntimeParameter = New-Object System.Management.Automation.RuntimeDefinedParameter($ParameterName, [string], $AttributeCollection)
+         $RuntimeParameterDictionary.Add($ParameterName, $RuntimeParameter)
+         return $RuntimeParameterDictionary
+      }
+   }
+
+   begin {
+      if (_isOnWindows) {
+         # Bind the parameter to a friendly variable
+         $Level = $PSBoundParameters[$ParameterName]
+      }
+   }
+
+   process {
+      if (_isOnWindows) {
+         if (-not $Level) {
+            $Level = "Process"
+         }
+      }
+      else {
+         $Level = "Process"
+      }
+
+      # You always have to set at the process level or they will Not
+      # be seen in your current session.
+      $env:TEAM_PROJECTCOUNT = $null
+
+      if (_isOnWindows) {
+         [System.Environment]::SetEnvironmentVariable("TEAM_PROJECTCOUNT", $null, $Level)
+      }
+
+      Write-Output "Default project count cleared"
+   }
+}

--- a/Source/Public/Clear-VSTeamDefaultProjectCount.ps1
+++ b/Source/Public/Clear-VSTeamDefaultProjectCount.ps1
@@ -4,42 +4,7 @@ function Clear-VSTeamDefaultProjectCount {
    param()
 
    DynamicParam {
-      # # Only add these options on Windows Machines
-      if (_isOnWindows) {
-         $ParameterName = 'Level'
-
-         # Create the dictionary
-         $RuntimeParameterDictionary = New-Object System.Management.Automation.RuntimeDefinedParameterDictionary
-
-         # Create the collection of attributes
-         $AttributeCollection = New-Object System.Collections.ObjectModel.Collection[System.Attribute]
-
-         # Create and set the parameters' attributes
-         $ParameterAttribute = New-Object System.Management.Automation.ParameterAttribute
-         $ParameterAttribute.Mandatory = $false
-         $ParameterAttribute.HelpMessage = "On Windows machines allows you to store the default project at the process, user or machine level. Not available on other platforms."
-
-         # Add the attributes to the attributes collection
-         $AttributeCollection.Add($ParameterAttribute)
-
-         # Generate and set the ValidateSet
-         if (_testAdministrator) {
-            $arrSet = "Process", "User", "Machine"
-         }
-         else {
-            $arrSet = "Process", "User"
-         }
-
-         $ValidateSetAttribute = New-Object System.Management.Automation.ValidateSetAttribute($arrSet)
-
-         # Add the ValidateSet to the attributes collection
-         $AttributeCollection.Add($ValidateSetAttribute)
-
-         # Create and return the dynamic parameter
-         $RuntimeParameter = New-Object System.Management.Automation.RuntimeDefinedParameter($ParameterName, [string], $AttributeCollection)
-         $RuntimeParameterDictionary.Add($ParameterName, $RuntimeParameter)
-         return $RuntimeParameterDictionary
-      }
+      _buildLevelDynamicParam
    }
 
    begin {

--- a/Source/Public/Clear-VSTeamDefaultProjectCount.ps1
+++ b/Source/Public/Clear-VSTeamDefaultProjectCount.ps1
@@ -10,7 +10,7 @@ function Clear-VSTeamDefaultProjectCount {
    begin {
       if (_isOnWindows) {
          # Bind the parameter to a friendly variable
-         $Level = $PSBoundParameters[$ParameterName]
+         $Level = $PSBoundParameters['Level']
       }
    }
 

--- a/Source/Public/Get-VSTeamInfo.ps1
+++ b/Source/Public/Get-VSTeamInfo.ps1
@@ -2,10 +2,11 @@ function Get-VSTeamInfo {
    [CmdletBinding(HelpUri='https://methodsandpractices.github.io/vsteam-docs/docs/modules/vsteam/commands/Get-VSTeamInfo')]
    param ()
    return @{
-      Account        = _getInstance
-      Version        = $(_getApiVersion -Target)
-      ModuleVersion  = [vsteam_lib.Versions]::ModuleVersion
-      DefaultProject = $Global:PSDefaultParameterValues['*-vsteam*:projectName']
-      DefaultTimeout = $Global:PSDefaultParameterValues['*-vsteam*:vsteamApiTimeout']
+      Account             = _getInstance
+      Version             = $(_getApiVersion -Target)
+      ModuleVersion       = [vsteam_lib.Versions]::ModuleVersion
+      DefaultProject      = $Global:PSDefaultParameterValues['*-vsteam*:projectName']
+      DefaultTimeout      = $Global:PSDefaultParameterValues['*-vsteam*:vsteamApiTimeout']
+      DefaultProjectCount = $env:TEAM_PROJECTCOUNT
    }
 }

--- a/Source/Public/Get-VSTeamProject.ps1
+++ b/Source/Public/Get-VSTeamProject.ps1
@@ -7,7 +7,7 @@ function Get-VSTeamProject {
       [string] $StateFilter = 'WellFormed',
 
       [Parameter(ParameterSetName = 'List')]
-      [int] $Top,
+      [int] $Top = $env:TEAM_PROJECTCOUNT,
 
       [Parameter(ParameterSetName = 'List')]
       [int] $Skip,

--- a/Source/Public/Set-VSTeamDefaultProject.ps1
+++ b/Source/Public/Set-VSTeamDefaultProject.ps1
@@ -10,35 +10,7 @@ function Set-VSTeamDefaultProject {
       [string] $Project
    )
    DynamicParam {
-      $dp = New-Object System.Management.Automation.RuntimeDefinedParameterDictionary
-
-      # Only add these options on Windows Machines
-      if (_isOnWindows) {
-         $ParameterName = 'Level'
-         # Create the collection of attributes
-         $AttributeCollection = New-Object System.Collections.ObjectModel.Collection[System.Attribute]
-         # Create and set the parameters' attributes
-         $ParameterAttribute = New-Object System.Management.Automation.ParameterAttribute
-         $ParameterAttribute.Mandatory = $false
-         $ParameterAttribute.HelpMessage = "On Windows machines allows you to store the default project at the process, user or machine level. Not available on other platforms."
-         # Add the attributes to the attributes collection
-         $AttributeCollection.Add($ParameterAttribute)
-         # Generate and set the ValidateSet
-         if (_testAdministrator) {
-            $arrSet = "Process", "User", "Machine"
-         }
-         else {
-            $arrSet = "Process", "User"
-         }
-         $ValidateSetAttribute = New-Object System.Management.Automation.ValidateSetAttribute($arrSet)
-         # Add the ValidateSet to the attributes collection
-         $AttributeCollection.Add($ValidateSetAttribute)
-         # Create and return the dynamic parameter
-         $RuntimeParameter = New-Object System.Management.Automation.RuntimeDefinedParameter($ParameterName, [string], $AttributeCollection)
-         $dp.Add($ParameterName, $RuntimeParameter)
-      }
-
-      return $dp
+      _buildLevelDynamicParam
    }
 
    begin {

--- a/Source/Public/Set-VSTeamDefaultProject.ps1
+++ b/Source/Public/Set-VSTeamDefaultProject.ps1
@@ -15,7 +15,7 @@ function Set-VSTeamDefaultProject {
 
    begin {
       if (_isOnWindows) {
-         $Level = $PSBoundParameters[$ParameterName]
+         $Level = $PSBoundParameters['Level']
       }
    }
 

--- a/Source/Public/Set-VSTeamDefaultProjectCount.ps1
+++ b/Source/Public/Set-VSTeamDefaultProjectCount.ps1
@@ -8,35 +8,7 @@ function Set-VSTeamDefaultProjectCount {
       [int] $Count
    )
    DynamicParam {
-      $dp = New-Object System.Management.Automation.RuntimeDefinedParameterDictionary
-
-      # Only add these options on Windows Machines
-      if (_isOnWindows) {
-         $ParameterName = 'Level'
-         # Create the collection of attributes
-         $AttributeCollection = New-Object System.Collections.ObjectModel.Collection[System.Attribute]
-         # Create and set the parameters' attributes
-         $ParameterAttribute = New-Object System.Management.Automation.ParameterAttribute
-         $ParameterAttribute.Mandatory = $false
-         $ParameterAttribute.HelpMessage = "On Windows machines allows you to store the default project at the process, user or machine level. Not available on other platforms."
-         # Add the attributes to the attributes collection
-         $AttributeCollection.Add($ParameterAttribute)
-         # Generate and set the ValidateSet
-         if (_testAdministrator) {
-            $arrSet = "Process", "User", "Machine"
-         }
-         else {
-            $arrSet = "Process", "User"
-         }
-         $ValidateSetAttribute = New-Object System.Management.Automation.ValidateSetAttribute($arrSet)
-         # Add the ValidateSet to the attributes collection
-         $AttributeCollection.Add($ValidateSetAttribute)
-         # Create and return the dynamic parameter
-         $RuntimeParameter = New-Object System.Management.Automation.RuntimeDefinedParameter($ParameterName, [string], $AttributeCollection)
-         $dp.Add($ParameterName, $RuntimeParameter)
-      }
-
-      return $dp
+      _buildLevelDynamicParam
    }
 
    begin {

--- a/Source/Public/Set-VSTeamDefaultProjectCount.ps1
+++ b/Source/Public/Set-VSTeamDefaultProjectCount.ps1
@@ -13,7 +13,7 @@ function Set-VSTeamDefaultProjectCount {
 
    begin {
       if (_isOnWindows) {
-         $Level = $PSBoundParameters[$ParameterName]
+         $Level = $PSBoundParameters['Level']
       }
    }
 

--- a/Source/Public/Set-VSTeamDefaultProjectCount.ps1
+++ b/Source/Public/Set-VSTeamDefaultProjectCount.ps1
@@ -1,0 +1,63 @@
+function Set-VSTeamDefaultProjectCount {
+   [Diagnostics.CodeAnalysis.SuppressMessageAttribute("PSUseDeclaredVarsMoreThanAssignments", "")]
+   [CmdletBinding(SupportsShouldProcess = $true, ConfirmImpact = "Low")]
+   param(
+      [switch] $Force,
+
+      [Parameter(Mandatory = $true, ValueFromPipelineByPropertyName = $true)]
+      [int] $Count
+   )
+   DynamicParam {
+      $dp = New-Object System.Management.Automation.RuntimeDefinedParameterDictionary
+
+      # Only add these options on Windows Machines
+      if (_isOnWindows) {
+         $ParameterName = 'Level'
+         # Create the collection of attributes
+         $AttributeCollection = New-Object System.Collections.ObjectModel.Collection[System.Attribute]
+         # Create and set the parameters' attributes
+         $ParameterAttribute = New-Object System.Management.Automation.ParameterAttribute
+         $ParameterAttribute.Mandatory = $false
+         $ParameterAttribute.HelpMessage = "On Windows machines allows you to store the default project at the process, user or machine level. Not available on other platforms."
+         # Add the attributes to the attributes collection
+         $AttributeCollection.Add($ParameterAttribute)
+         # Generate and set the ValidateSet
+         if (_testAdministrator) {
+            $arrSet = "Process", "User", "Machine"
+         }
+         else {
+            $arrSet = "Process", "User"
+         }
+         $ValidateSetAttribute = New-Object System.Management.Automation.ValidateSetAttribute($arrSet)
+         # Add the ValidateSet to the attributes collection
+         $AttributeCollection.Add($ValidateSetAttribute)
+         # Create and return the dynamic parameter
+         $RuntimeParameter = New-Object System.Management.Automation.RuntimeDefinedParameter($ParameterName, [string], $AttributeCollection)
+         $dp.Add($ParameterName, $RuntimeParameter)
+      }
+
+      return $dp
+   }
+
+   begin {
+      if (_isOnWindows) {
+         $Level = $PSBoundParameters[$ParameterName]
+      }
+   }
+
+   process {
+      if ($Force -or $pscmdlet.ShouldProcess($Count, "Set-VSTeamDefaultProjectCount")) {
+         if (_isOnWindows) {
+            if (-not $Level) {
+               $Level = "Process"
+            }
+
+            [System.Environment]::SetEnvironmentVariable("TEAM_PROJECTCOUNT", $Count, $Level)
+         }
+
+         # You always have to set at the process level or they will Not
+         # be seen in your current session.
+         $env:TEAM_PROJECTCOUNT = $Count
+      }
+   }
+}

--- a/Tests/function/tests/Clear-VSTeamDefaultProjectCount.Tests.ps1
+++ b/Tests/function/tests/Clear-VSTeamDefaultProjectCount.Tests.ps1
@@ -1,0 +1,65 @@
+Set-StrictMode -Version Latest
+
+Describe 'VSTeamDefaultProjectCount' {
+   BeforeAll {
+      . "$PSScriptRoot\_testInitialize.ps1" $PSCommandPath
+
+      Mock _getInstance { return 'https://dev.azure.com/test' }
+   }
+
+   Context 'Clear-VSTeamDefaultProjectCount on Non Windows' {
+      BeforeAll {
+         Mock _isOnWindows { return $false }
+      }
+
+      AfterAll {
+         $env:TEAM_PROJECTCOUNT = $null
+      }
+
+      It 'should clear default project' {
+         $env:TEAM_PROJECTCOUNT = "500"
+
+         Clear-VSTeamDefaultProjectCount
+
+         $env:TEAM_PROJECTCOUNT | Should -BeNullOrEmpty
+      }
+   }
+
+   Context 'Clear-VSTeamDefaultProjectCount as Non-Admin on Windows' {
+      BeforeAll {
+         Mock _isOnWindows { return $true }
+         Mock _testAdministrator { return $false }
+      }
+
+      AfterAll {
+         $env:TEAM_PROJECTCOUNT = $null
+      }
+
+      It 'should clear default project' {
+         $env:TEAM_PROJECTCOUNT = "500"
+
+         Clear-VSTeamDefaultProjectCount
+
+         $env:TEAM_PROJECTCOUNT | Should -BeNullOrEmpty
+      }
+   }
+
+   Context 'Clear-VSTeamDefaultProjectCount as Admin on Windows' {
+      BeforeAll {
+         Mock _isOnWindows { return $true }
+         Mock _testAdministrator { return $true }
+      }
+
+      AfterAll {
+         $env:TEAM_PROJECTCOUNT = $null
+      }
+
+      It 'should clear default project' {
+         $env:TEAM_PROJECTCOUNT = "500"
+
+         Clear-VSTeamDefaultProjectCount
+
+         $env:TEAM_PROJECTCOUNT | Should -BeNullOrEmpty
+      }
+   }
+}

--- a/Tests/function/tests/Set-VSTeamDefaultProjectCount.Tests.ps1
+++ b/Tests/function/tests/Set-VSTeamDefaultProjectCount.Tests.ps1
@@ -1,0 +1,64 @@
+Set-StrictMode -Version Latest
+
+Describe 'VSTeamDefaultProjectCount' {
+   BeforeAll {
+      . "$PSScriptRoot\_testInitialize.ps1" $PSCommandPath
+
+      Mock _getInstance { return 'https://dev.azure.com/test' }
+   }
+
+   Context 'Set-VSTeamDefaultProjectCount' {
+      AfterAll {
+         $env:TEAM_PROJECTCOUNT = $null
+      }
+
+      It 'should set default project' {
+         Set-VSTeamDefaultProjectCount 500
+
+         $env:TEAM_PROJECTCOUNT | Should -Be '500'
+      }
+
+      It 'should update default project' {
+         $env:TEAM_PROJECTCOUNT = '100'
+
+         Set-VSTeamDefaultProjectCount -Count 500
+
+         $env:TEAM_PROJECTCOUNT | Should -Be '500'
+      }
+   }
+
+   Context 'Set-VSTeamDefaultProjectCount on Non Windows' {
+      BeforeAll {
+         Mock _isOnWindows { return $false } -Verifiable
+      }
+
+      AfterAll {
+         $env:TEAM_PROJECTCOUNT = $null
+      }
+
+      It 'should set default project' {
+         Set-VSTeamDefaultProjectCount 700
+
+         Should -InvokeVerifiable
+         $env:TEAM_PROJECTCOUNT | Should -Be '700'
+      }
+   }
+
+   Context 'Set-VSTeamDefaultProjectCount As Admin on Windows' {
+      BeforeAll {
+         Mock _isOnWindows { return $true }
+         Mock _testAdministrator { return $true } -Verifiable
+      }
+
+      AfterAll {
+         $env:TEAM_PROJECTCOUNT = $null
+      }
+
+      It 'should set default project' {
+         Set-VSTeamDefaultProjectCount 450
+
+         Should -InvokeVerifiable
+         $env:TEAM_PROJECTCOUNT | Should -Be '450'
+      }
+   }
+}


### PR DESCRIPTION
# PR Summary

Azure DevOps only returns 100 projects unless you override the top value. This PR allows you to set a default value of projects to return. This will allow tab completion and validation to work on all projects. 

## PR Checklist

- [x] [Write Help](https://github.com/DarqueWarrior/vsteam/blob/master/.github/CONTRIBUTING.md#write-help)
- [x] [Write Unit Test](https://github.com/DarqueWarrior/vsteam/blob/master/.github/CONTRIBUTING.md#write-unit-test)
- [x] [Update CHANGELOG.md](https://github.com/DarqueWarrior/vsteam/blob/master/.github/CONTRIBUTING.md#update-changelogmd)
