### PR TITLE
fixing Get-VSTeamWiql with only one work item returned and expanded

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ Merged [Pull Request](https://github.com/DarqueWarrior/vsteam/pull/400) from [Se
 
 - Fixes ambiguity of parameter sets in VSTeamUserEntitlement cmdlets [#393](https://github.com/DarqueWarrior/vsteam/issues/393)
 
+Merged [Pull Request](https://github.com/DarqueWarrior/vsteam/pull/406) from [Sebastian Schütze](https://github.com/SebastianSchuetze) which included the following:
+
+- Fixes Get-VSTeamWiql with only one work item expanded causing and exception [#392](https://github.com/DarqueWarrior/vsteam/issues/392)
+
 ## 7.3.0
 
 Merged [Pull Request](https://github.com/DarqueWarrior/vsteam/pull/396) from [Markus Blaschke](https://github.com/mblaschke) which included the following:

--- a/Source/Public/Get-VSTeamWiql.ps1
+++ b/Source/Public/Get-VSTeamWiql.ps1
@@ -1,6 +1,6 @@
 function Get-VSTeamWiql {
    [CmdletBinding(DefaultParameterSetName = 'ByID',
-    HelpUri='https://methodsandpractices.github.io/vsteam-docs/docs/modules/vsteam/commands/Get-VSTeamWiql')]
+      HelpUri = 'https://methodsandpractices.github.io/vsteam-docs/docs/modules/vsteam/commands/Get-VSTeamWiql')]
    param(
       [vsteam_lib.QueryTransformToIDAttribute()]
       [ArgumentCompleter([vsteam_lib.QueryCompleter])]
@@ -49,7 +49,8 @@ function Get-VSTeamWiql {
 
       $resp = _callAPI  @params
 
-      if ($Expand) {
+      #expand only when at least one workitem has been found
+      if ($Expand && $resp.workItems.Count -gt 0) {
          # Handle queries for work item links also allow for the tests not Setting the query result type.
          if ($resp.psobject.Properties['queryResultType'] -and $resp.queryResultType -eq 'workItemLink') {
             Add-Member -InputObject $resp -MemberType NoteProperty -Name Workitems -Value @()
@@ -62,14 +63,25 @@ function Get-VSTeamWiql {
          # splitting id array by 200, since a maximum of 200 ids are allowed per call
          $countIds = $Ids.Count
          $resp.workItems = for ($beginRange = 0; $beginRange -lt $countIds; $beginRange += 200) {
-            # in case strict mode is on,pick lesser of  0..199 and 0..count-1
-            $endRange = [math]::Min(($beginRange + 199), ($countIds - 1))
+
+            $endRange = 1
+            $workItemIds = @()
+            #for more than one work item being found, line below would return $endrange = 0 for one woritem
+            #in the accessed array it would result to $Ids[0..0] which is not valid
+            if ($countIds -gt 1) {
+               # in case strict mode is on,pick lesser of  0..199 and 0..count-1
+               $endRange = [math]::Min(($beginRange + 199), ($countIds - 1))
+               $workItemIds = $Ids[$beginRange..$endRange]
+            }else {
+               $workItemIds = $Ids
+            }
+
             # if query contains "*" don't specify fields, otherwise use fields returned.
             if ($Query -match "\*") {
-               Get-VSTeamWorkItem -Id $Ids[$beginRange..$endRange]
+               Get-VSTeamWorkItem -Id $workItemIds
             }
             else {
-               Get-VSTeamWorkItem -Id $Ids[$beginRange..$endRange] -Fields $resp.columns.referenceName
+               Get-VSTeamWorkItem -Id $workItemIds -Fields $resp.columns.referenceName
             }
          }
       }

--- a/Tests/SampleFiles/Get-VSTeamWiql-OneWorkItem.json
+++ b/Tests/SampleFiles/Get-VSTeamWiql-OneWorkItem.json
@@ -1,0 +1,26 @@
+{
+   "queryType": "flat",
+   "queryResultType": "workItem",
+   "asOf": "2020-09-09T17:41:59.82Z",
+   "columns": [{
+         "referenceName": "System.Id",
+         "name": "ID",
+         "url": "https://dev.azure.com/toolTester/_apis/wit/fields/System.Id"
+      },
+      {
+         "referenceName": "System.Title",
+         "name": "Title",
+         "url": "https://dev.azure.com/toolTester/_apis/wit/fields/System.Title"
+      },
+      {
+         "referenceName": "System.State",
+         "name": "State",
+         "url": "https://dev.azure.com/toolTester/_apis/wit/fields/System.State"
+      }
+   ],
+   "workItems": [{
+         "id": 179,
+         "url": "https://dev.azure.com/toolTester/00000000-0000-0000-0000-000000000000/_apis/wit/workItems/179"
+      }
+   ]
+}

--- a/Tests/function/tests/Get-VSTeamWiql.Tests.ps1
+++ b/Tests/function/tests/Get-VSTeamWiql.Tests.ps1
@@ -4,7 +4,7 @@ Describe 'VSTeamWiql' {
    BeforeAll {
       . "$PSScriptRoot\_testInitialize.ps1" $PSCommandPath
       . "$baseFolder/Source/Public/Get-VSTeamWorkItem.ps1"
-      
+
       Mock _getInstance { return 'https://dev.azure.com/test' }
    }
 
@@ -106,6 +106,16 @@ Describe 'VSTeamWiql' {
       }
 
       It 'Get work items with query ID query with expanded work items' {
+         Get-VSTeamWiql -ProjectName "test" -Team "test team" -Id 1 -Expand
+
+         Should -Invoke Invoke-RestMethod -Exactly -Scope It -Times 1 -ParameterFilter {
+            $Uri -eq "https://dev.azure.com/test/test/test team/_apis/wit/wiql/1?api-version=$(_getApiVersion Core)&`$top=100"
+         }
+      }
+
+      It 'Get work items with query that returns only 1 work item and Expand' {
+         Mock Invoke-RestMethod { Write-Host $args; Open-SampleFile 'Get-VSTeamWiql-OneWorkItem.json' }
+
          Get-VSTeamWiql -ProjectName "test" -Team "test team" -Id 1 -Expand
 
          Should -Invoke Invoke-RestMethod -Exactly -Scope It -Times 1 -ParameterFilter {


### PR DESCRIPTION
Fixes #392