### PR TITLE
Exclude cmdlet Get-VSTeamAccounts from PSAnalyzer plural rule

### DIFF
--- a/Source/Public/Get-VSTeamAccounts.ps1
+++ b/Source/Public/Get-VSTeamAccounts.ps1
@@ -1,4 +1,5 @@
 function Get-VSTeamAccounts {
+   [Diagnostics.CodeAnalysis.SuppressMessageAttribute("PSUseSingularNouns", "")]
    [CmdletBinding(HelpUri = 'https://methodsandpractices.github.io/vsteam-docs/docs/modules/vsteam/commands/Get-VSTeamAccounts')]
    param(
       [Parameter(Mandatory = $true, ParameterSetName = "MemberId")]


### PR DESCRIPTION
# PR Summary

excluded cmdlet from PSAnalyzer as an exception
