### PR TITLE
✏️ Added work item tag cmdlets to Get, Remove and Update, also fixed typos and casing

### DIFF
--- a/.docs/Get-VSTeamWorkItemTag.md
+++ b/.docs/Get-VSTeamWorkItemTag.md
@@ -14,8 +14,6 @@ Returns a list of work item tags in a project.
 
 A single tag can be returned by providing the tag name or id.
 
-You must call `Set-VSTeamAccount` before calling this function.
-
 ## EXAMPLES
 
 ### Example 1

--- a/.docs/Get-VSTeamWorkItemTag.md
+++ b/.docs/Get-VSTeamWorkItemTag.md
@@ -1,0 +1,75 @@
+<!-- #include "./common/header.md" -->
+
+# Get-VSTeamWorkItemTag
+
+## SYNOPSIS
+
+<!-- #include "./synopsis/Get-VSTeamWorkItemTag.md" -->
+
+## SYNTAX
+
+## DESCRIPTION
+
+Returns a list of work item tags in a project.
+
+A single tag can be returned by providing the tag name or id.
+
+You must call `Set-VSTeamAccount` before calling this function.
+
+## EXAMPLES
+
+### Example 1
+
+```powershell
+Get-VSTeamWorkItemTag
+```
+
+This will return a list of all the work item tags within the current project
+
+### Example 2
+
+```powershell
+Get-VSTeamWorkItemTag -TagId my-tag
+```
+
+This will return a specific work item tag
+
+### Example 3
+
+```powershell
+Get-VSTeamWorkItemTag -TagName my-tag
+```
+
+This will return a specific work item tag
+
+## PARAMETERS
+
+<!-- #include "./params/projectName.md" -->
+
+### NameOrTagId
+
+Name or ID of the tag to return
+
+```yaml
+Type: String
+Required: True
+Position: named
+Aliases: TagName, TagId
+Parameter Sets: ByIdentifier
+```
+
+## INPUTS
+
+## OUTPUTS
+
+## NOTES
+
+<!-- #include "./common/prerequisites.md" -->
+
+## RELATED LINKS
+
+<!-- #include "./common/related.md" -->
+
+[Update-VSTeamWorkItemTag](Update-VSTeamWorkItemTag.md)
+
+[Remove-VSTeamWorkItemTag](Remove-VSTeamWorkItemTag.md)

--- a/.docs/Remove-VSTeamWorkItemTag.md
+++ b/.docs/Remove-VSTeamWorkItemTag.md
@@ -1,0 +1,57 @@
+<!-- #include "./common/header.md" -->
+
+# Remove-VSTeamWorkItemTag
+
+## SYNOPSIS
+
+<!-- #include "./synopsis/Get-VSTeamWorkItemTag.md" -->
+
+## SYNTAX
+
+## DESCRIPTION
+
+Removes a work item tag.
+
+You must call `Set-VSTeamAccount` before calling this function.
+
+## EXAMPLES
+
+### Example 1
+
+```powershell
+Remove-VSTeamWorkItemTag -TagName
+```
+
+This will remove a specific work item tag within the current project
+
+## PARAMETERS
+
+<!-- #include "./params/projectName.md" -->
+
+### NameOrTagId
+
+Name or ID of the tag to return
+
+```yaml
+Type: String
+Required: True
+Position: named
+Aliases: TagName, TagId
+Parameter Sets: ByIdentifier
+```
+
+## INPUTS
+
+## OUTPUTS
+
+## NOTES
+
+<!-- #include "./common/prerequisites.md" -->
+
+## RELATED LINKS
+
+<!-- #include "./common/related.md" -->
+
+[Get-VSTeamWorkItemTag](Get-VSTeamWorkItemTag.md)
+
+[Remove-VSTeamWorkItemTag](Remove-VSTeamWorkItemTag.md)

--- a/.docs/Remove-VSTeamWorkItemTag.md
+++ b/.docs/Remove-VSTeamWorkItemTag.md
@@ -12,8 +12,6 @@
 
 Removes a work item tag.
 
-You must call `Set-VSTeamAccount` before calling this function.
-
 ## EXAMPLES
 
 ### Example 1

--- a/.docs/Update-VSTeamWorkItemTag.md
+++ b/.docs/Update-VSTeamWorkItemTag.md
@@ -12,8 +12,6 @@
 
 Updates a work item tag.
 
-You must call `Set-VSTeamAccount` before calling this function.
-
 ## EXAMPLES
 
 ### Example 1

--- a/.docs/Update-VSTeamWorkItemTag.md
+++ b/.docs/Update-VSTeamWorkItemTag.md
@@ -1,0 +1,57 @@
+<!-- #include "./common/header.md" -->
+
+# Update-VSTeamWorkItemTag
+
+## SYNOPSIS
+
+<!-- #include "./synopsis/Get-VSTeamWorkItemTag.md" -->
+
+## SYNTAX
+
+## DESCRIPTION
+
+Updates a work item tag.
+
+You must call `Set-VSTeamAccount` before calling this function.
+
+## EXAMPLES
+
+### Example 1
+
+```powershell
+Update-VSTeamWorkItemTag -TagName
+```
+
+This will update a specific work item tag within the current project
+
+## PARAMETERS
+
+<!-- #include "./params/projectName.md" -->
+
+### NameOrTagId
+
+Name or ID of the tag to return
+
+```yaml
+Type: String
+Required: True
+Position: named
+Aliases: TagName, TagId
+Parameter Sets: ByIdentifier
+```
+
+## INPUTS
+
+## OUTPUTS
+
+## NOTES
+
+<!-- #include "./common/prerequisites.md" -->
+
+## RELATED LINKS
+
+<!-- #include "./common/related.md" -->
+
+[Get-VSTeamWorkItemTag](Get-VSTeamWorkItemTag.md)
+
+[Remove-VSTeamWorkItemTag](Remove-VSTeamWorkItemTag.md)

--- a/.docs/common/prerequisites.md
+++ b/.docs/common/prerequisites.md
@@ -1,6 +1,6 @@
 Prerequisites: 
 
-Set the account and version that all calls will use with Set-VSTeamAccount. If you do not set the version it default to 3.0, TFS2017. Using the default could limit API functionality.
+Set the account and version that all calls will use with Set-VSTeamAccount. If you do not set the version it will default to 3.0, TFS2017. Using the default could limit API functionality.
 
 You can check what version of the API that will be called with Get-VSTeamAPIVersion, or Get-VSTeamInfo.
 

--- a/.docs/params/version.md
+++ b/.docs/params/version.md
@@ -15,7 +15,7 @@ Specifies the version to use. The acceptable values for this parameter are:
 - VSTS
 - AzD
 
-If you are on AzD it will default to Azd otherwise it will default to TFS2017.
+If you are on AzD it will default to AzD otherwise it will default to TFS2017.
 
 ```yaml
 Type: String

--- a/.docs/synopsis/Get-VSTeamWorkItemTag.md
+++ b/.docs/synopsis/Get-VSTeamWorkItemTag.md
@@ -1,0 +1,1 @@
+Get a work item tag

--- a/.docs/synopsis/Get-VSTeamWorkItemTag.md
+++ b/.docs/synopsis/Get-VSTeamWorkItemTag.md
@@ -1,1 +1,1 @@
-Get a work item tag
+Gets a work item tag

--- a/.docs/synopsis/Remove-VSTeamWorkItemTag.md
+++ b/.docs/synopsis/Remove-VSTeamWorkItemTag.md
@@ -1,1 +1,1 @@
-Update a work item tag
+Removes a work item tag

--- a/.docs/synopsis/Remove-VSTeamWorkItemTag.md
+++ b/.docs/synopsis/Remove-VSTeamWorkItemTag.md
@@ -1,0 +1,1 @@
+Update a work item tag

--- a/.docs/synopsis/Update-VSTeamWorkItemTag.md
+++ b/.docs/synopsis/Update-VSTeamWorkItemTag.md
@@ -1,0 +1,1 @@
+Updates a work item tag

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,10 +2,14 @@
 
 ## 7.5.0
 
+Merged [Pull Request](https://github.com/DarqueWarrior/vsteam/pull/TBD) from [Sander Holvoet](https://github.com/smholvoet) which included the following:
+
+- Added `Get-VSTeamWorkItemTag`, `Update-VSTeamWorkItemTag` and `Remove-VSTeamWorkItemTag` cmdlets which  allow you to [manage work item tags]([#296](https://github.com/DarqueWarrior/vsteam/issues/296).
+
 Merged [Pull Request](https://github.com/DarqueWarrior/vsteam/pull/414) from [Guillermo Diaz](https://github.com/gm0d) which included the following:
 
 - Added Get-VSTeamWiki, Add-VSTeamWiki, Remove-VSTeamWiki, for interacting with Wikis
- 
+
 ## 7.4.0
 
 Merged [Pull Request](https://github.com/DarqueWarrior/vsteam/pull/400) from [Sebastian Schütze](https://github.com/SebastianSchuetze) which included the following:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,41 +2,41 @@
 
 ## 7.6.0
 
-Merged [Pull Request](https://github.com/DarqueWarrior/vsteam/pull/418) from [Sander Holvoet](https://github.com/smholvoet) which included the following:
+Merged [Pull Request](https://github.com/MethodsAndPractices/vsteam/pull/418) from [Sander Holvoet](https://github.com/smholvoet) which included the following:
 
-- Added `Get-VSTeamWorkItemTag`, `Update-VSTeamWorkItemTag` and `Remove-VSTeamWorkItemTag` cmdlets which  allow you to [manage work item tags]([#296](https://github.com/DarqueWarrior/vsteam/issues/296).
+- Added `Get-VSTeamWorkItemTag`, `Update-VSTeamWorkItemTag` and `Remove-VSTeamWorkItemTag` cmdlets which  allow you to [manage work item tags]([#419](https://github.com/MethodsAndPractices/vsteam/issues/419).
 
 ## 7.5.0
 
-Merged [Pull Request](https://github.com/DarqueWarrior/vsteam/pull/414) from [Guillermo Diaz](https://github.com/gm0d) which included the following:
+Merged [Pull Request](https://github.com/MethodsAndPractices/vsteam/pull/414) from [Guillermo Diaz](https://github.com/gm0d) which included the following:
 
 - Added Get-VSTeamWiki, Add-VSTeamWiki, Remove-VSTeamWiki, for interacting with Wikis
 
-Merged [Pull Request](https://github.com/DarqueWarrior/vsteam/pull/430) from [thahif Diaz](https://github.com/thahif) which included the following:
+Merged [Pull Request](https://github.com/MethodsAndPractices/vsteam/pull/430) from [thahif Diaz](https://github.com/thahif) which included the following:
 
 - Updated Update-VSTeamUserEntitlement to correctly use contentype application/json-patch+json
- 
+
 ## 7.4.0
 
-Merged [Pull Request](https://github.com/DarqueWarrior/vsteam/pull/400) from [Sebastian Schütze](https://github.com/SebastianSchuetze) which included the following:
+Merged [Pull Request](https://github.com/MethodsAndPractices/vsteam/pull/400) from [Sebastian Schütze](https://github.com/SebastianSchuetze) which included the following:
 
-- Fixes ambiguity of parameter sets in VSTeamUserEntitlement cmdlets [#393](https://github.com/DarqueWarrior/vsteam/issues/393)
+- Fixes ambiguity of parameter sets in VSTeamUserEntitlement cmdlets [#393](https://github.com/MethodsAndPractices/vsteam/issues/393)
 
-Merged [Pull Request](https://github.com/DarqueWarrior/vsteam/pull/406) from [Sebastian Schütze](https://github.com/SebastianSchuetze) which included the following:
+Merged [Pull Request](https://github.com/MethodsAndPractices/vsteam/pull/406) from [Sebastian Schütze](https://github.com/SebastianSchuetze) which included the following:
 
-- Fixes Get-VSTeamWiql with only one work item expanded causing and exception [#392](https://github.com/DarqueWarrior/vsteam/issues/392)
+- Fixes Get-VSTeamWiql with only one work item expanded causing and exception [#392](https://github.com/MethodsAndPractices/vsteam/issues/392)
 
-Merged [Pull Request](https://github.com/DarqueWarrior/vsteam/pull/408) from [Sebastian Schütze](https://github.com/SebastianSchuetze) which included the following:
+Merged [Pull Request](https://github.com/MethodsAndPractices/vsteam/pull/408) from [Sebastian Schütze](https://github.com/SebastianSchuetze) which included the following:
 
 - Added `Set-VSTeamPipelineAuthorization` to set pipeline authorizations.
 
 ## 7.3.0
 
-Merged [Pull Request](https://github.com/DarqueWarrior/vsteam/pull/396) from [Markus Blaschke](https://github.com/mblaschke) which included the following:
+Merged [Pull Request](https://github.com/MethodsAndPractices/vsteam/pull/396) from [Markus Blaschke](https://github.com/mblaschke) which included the following:
 
 - Fixed the problem of JSON serialization with the message "WARNING: Resulting JSON is truncated as serialization has exceeded the set depth of 2" for most the cmdlets that post complex json bodies.
 
-Merged [Pull Request](https://github.com/DarqueWarrior/vsteam/pull/384) from [Sebastian Schütze](https://github.com/SebastianSchuetze) which included the following:
+Merged [Pull Request](https://github.com/MethodsAndPractices/vsteam/pull/384) from [Sebastian Schütze](https://github.com/SebastianSchuetze) which included the following:
 
 - Add-VSTeamPool, Remove-VSTeamPool and Update-VSTeampool for handling agent pools on Azure DevOps
 
@@ -49,19 +49,19 @@ $buildId = Get-VSTeamBuild -Top 1
 Get-VSTeamRelease -artifactVersionId $buildId.Id
 ```
 
-Merged [Pull Request](https://github.com/DarqueWarrior/vsteam/pull/386) from [Sebastian Schütze](https://github.com/SebastianSchuetze) which included the following:
+Merged [Pull Request](https://github.com/MethodsAndPractices/vsteam/pull/386) from [Sebastian Schütze](https://github.com/SebastianSchuetze) which included the following:
 
 - added the cmdlet Add-VSTeamBuildPermission following the other cmdlet like Add-VSTeamProjectPermission
 - changed internal permission (ACL) functions to not have deny or allow permissions to be mandatory, because this caused not to be able to only add allow or deny permissions.
 - allowed to handle user accounts from typ 'srv' which are service accounts of Azure DevOps. Now these can be permitted as well to all functions using ACLs
 
-Merged [Pull Request](https://github.com/DarqueWarrior/vsteam/pull/397) from [Sebastian Schütze](https://github.com/SebastianSchuetze) which included the following:
+Merged [Pull Request](https://github.com/MethodsAndPractices/vsteam/pull/397) from [Sebastian Schütze](https://github.com/SebastianSchuetze) which included the following:
 
-- Fixes encoding problem with special charcters on Add-VSTeamWorkItem, Update-VSTeamWorkItem, Update-VSTeamUserEntitlement [#397](https://github.com/DarqueWarrior/vsteam/issues/365)
+- Fixes encoding problem with special charcters on Add-VSTeamWorkItem, Update-VSTeamWorkItem, Update-VSTeamUserEntitlement [#397](https://github.com/MethodsAndPractices/vsteam/issues/365)
 
 ## 7.2.0
 
-Merged [Pull Request](https://github.com/DarqueWarrior/vsteam/pull/371) and (https://github.com/DarqueWarrior/vsteam/pull/389) from [Sebastian Schütze](https://github.com/SebastianSchuetze) which included the following:
+Merged [Pull Request](https://github.com/MethodsAndPractices/vsteam/pull/371) and (https://github.com/MethodsAndPractices/vsteam/pull/389) from [Sebastian Schütze](https://github.com/SebastianSchuetze) which included the following:
 
 - Added Set-VSTeamPipelineBilling to buy or release Microsoft-hosted and self-hosted agents
 - Added Get-VSTeamAccounts to get the organizations where the user has access. Where the given user is either a member or an owner
@@ -78,7 +78,7 @@ Fixed issue #376
 
 ## 7.1.3
 
-Merged [Pull Request](https://github.com/DarqueWarrior/vsteam/pull/350) from [Daniel Silva](https://github.com/DanielSSilva) which included the following:
+Merged [Pull Request](https://github.com/MethodsAndPractices/vsteam/pull/350) from [Daniel Silva](https://github.com/DanielSSilva) which included the following:
 
 - Fixed exception thrown by the Update-VSTeamPullRequest when status is set to "completed", by adding the missing "lastMergeSourceCommit" property to body.
 
@@ -87,9 +87,9 @@ Also added Clear-VSTeamDefaultProjectCount and Set-VSTeamDefaultProjectCount to 
 
 ## 7.1.2
 
-Merged [Pull Request](https://github.com/DarqueWarrior/vsteam/pull/366) from [Jhoneill](https://github.com/jhoneill) which included the following:
+Merged [Pull Request](https://github.com/MethodsAndPractices/vsteam/pull/366) from [Jhoneill](https://github.com/jhoneill) which included the following:
 
-- Fix Query Cache [#365](https://github.com/DarqueWarrior/vsteam/issues/365)
+- Fix Query Cache [#365](https://github.com/MethodsAndPractices/vsteam/issues/365)
 
 Changed Get-VSTeamProject to return all projects by default instead of just the top 100. This change was made to address issue #363. If your project name was not in the top 100 projects validation would fail. Returning all projects can have performance issues. You can set the value for top used by setting a PowerShell default value:
 
@@ -114,7 +114,7 @@ Added:
 
 ## 7.0.1
 
-Merged [Pull Request](https://github.com/DarqueWarrior/vsteam/pull/354)
+Merged [Pull Request](https://github.com/MethodsAndPractices/vsteam/pull/354)
 
 - Fixed bug [353](https://github.com/MethodsAndPractices/vsteam/issues/353)
 - Added TriggerInfo to vsteam_lib.Build class
@@ -201,7 +201,7 @@ Added examples to all the help files.
 Fixed bug [337](https://github.com/MethodsAndPractices/vsteam/issues/337)
 Fixed bug [345](https://github.com/MethodsAndPractices/vsteam/issues/345)
 
-Merged [Pull Request](https://github.com/DarqueWarrior/vsteam/pull/335) from [Sebastian Schütze](https://github.com/SebastianSchuetze) which included the following:
+Merged [Pull Request](https://github.com/MethodsAndPractices/vsteam/pull/335) from [Sebastian Schütze](https://github.com/SebastianSchuetze) which included the following:
 
 - Fixed bug [326](https://github.com/MethodsAndPractices/vsteam/issues/326)
 
@@ -219,23 +219,23 @@ The versions for Azure DevOps were also updated to 6.0-preview where supported.
 Requires Pester 5.x
 All the tests have been upgraded to use Pester 5.
 
-Merged [Pull Request](https://github.com/DarqueWarrior/vsteam/pull/315) from [Jhoneill](https://github.com/jhoneill) which included the following:
+Merged [Pull Request](https://github.com/MethodsAndPractices/vsteam/pull/315) from [Jhoneill](https://github.com/jhoneill) which included the following:
 
-- Fix Get-VSTeamWiql [#314](https://github.com/DarqueWarrior/vsteam/issues/314)
+- Fix Get-VSTeamWiql [#314](https://github.com/MethodsAndPractices/vsteam/issues/314)
 
-Merged [Pull Request](https://github.com/DarqueWarrior/vsteam/pull/317) from [Brittan DeYoung](https://github.com/brittandeyoung) which included the following:
+Merged [Pull Request](https://github.com/MethodsAndPractices/vsteam/pull/317) from [Brittan DeYoung](https://github.com/brittandeyoung) which included the following:
 
 - Adds a new function Stop-VSTeamBuild which allows cancelling a build using the build id
 
-Merged [Pull Request](https://github.com/DarqueWarrior/vsteam/pull/322) from [Jhoneill](https://github.com/jhoneill) which included the following:
+Merged [Pull Request](https://github.com/MethodsAndPractices/vsteam/pull/322) from [Jhoneill](https://github.com/jhoneill) which included the following:
 
 - Enhance Get-VSTeamProcess
 
-Merged [Pull Request](https://github.com/DarqueWarrior/vsteam/pull/328) from [Sebastian Schütze](https://github.com/SebastianSchuetze) which included the following:
+Merged [Pull Request](https://github.com/MethodsAndPractices/vsteam/pull/328) from [Sebastian Schütze](https://github.com/SebastianSchuetze) which included the following:
 
 - Run unit tests in Docker containers Locally
 
-Merged [Pull Request](https://github.com/DarqueWarrior/vsteam/pull/333) from [Daniel Sturm](https://github.com/danstur) which included the following:
+Merged [Pull Request](https://github.com/MethodsAndPractices/vsteam/pull/333) from [Daniel Sturm](https://github.com/danstur) which included the following:
 
 - Adds -IncludeCommits switch to Get-VSTeamPullRequest
 
@@ -243,7 +243,7 @@ Merged [Pull Request](https://github.com/DarqueWarrior/vsteam/pull/333) from [Da
 
 You can now tab complete Area and Resource of Invoke-VSTeamRequest.
 
-Merged [Pull Request](https://github.com/DarqueWarrior/vsteam/pull/286) from [Sebastian Schütze](https://github.com/SebastianSchuetze) which included the following:
+Merged [Pull Request](https://github.com/MethodsAndPractices/vsteam/pull/286) from [Sebastian Schütze](https://github.com/SebastianSchuetze) which included the following:
 
 - Added cmdlets for add, get and remove for classification nodes, iterations and areas
 
@@ -253,14 +253,14 @@ Merged [Pull Request](https://github.com/DarqueWarrior/vsteam/pull/286) from [Se
 
 Addressed following issues:
 
-- Do not change the strict mode setting for the user's PowerShell session [#296](https://github.com/DarqueWarrior/vsteam/issues/296)
-- Consider reducing the scope of the default parameter "Project" from "_" to "_-VsTeam\*" [#297](https://github.com/DarqueWarrior/vsteam/issues/297)
+- Do not change the strict mode setting for the user's PowerShell session [#296](https://github.com/MethodsAndPractices/vsteam/issues/296)
+- Consider reducing the scope of the default parameter "Project" from "_" to "_-VsTeam\*" [#297](https://github.com/MethodsAndPractices/vsteam/issues/297)
 
-Merged [Pull Request](https://github.com/DarqueWarrior/vsteam/pull/275) from [Jhoneill](https://github.com/jhoneill) which included the following:
+Merged [Pull Request](https://github.com/MethodsAndPractices/vsteam/pull/275) from [Jhoneill](https://github.com/jhoneill) which included the following:
 
 - Removing Dynamic parameters for completer and validator attributes.
 
-Merged [Pull Request](https://github.com/DarqueWarrior/vsteam/pull/283) from [Sebastian Schütze](https://github.com/SebastianSchuetze) which included the following:
+Merged [Pull Request](https://github.com/MethodsAndPractices/vsteam/pull/283) from [Sebastian Schütze](https://github.com/SebastianSchuetze) which included the following:
 
 - Added Get-VSTeamBuildTimeline to get timeline of a build
 
@@ -272,90 +272,90 @@ Corrected a display issue were the List view was being used by default instead o
 
 All unit test now pass consistently.
 
-Merged [Pull Request](https://github.com/DarqueWarrior/vsteam/pull/265) from [Michel Zehnder](https://github.com/MichelZ) which included the following:
+Merged [Pull Request](https://github.com/MethodsAndPractices/vsteam/pull/265) from [Michel Zehnder](https://github.com/MichelZ) which included the following:
 
 - Simplify merging of files
 
-Merged [Pull Request](https://github.com/DarqueWarrior/vsteam/pull/272) from [Sebastian Schütze](https://github.com/SebastianSchuetze) which included the following:
+Merged [Pull Request](https://github.com/MethodsAndPractices/vsteam/pull/272) from [Sebastian Schütze](https://github.com/SebastianSchuetze) which included the following:
 
 - Add Test-VSTeamYamlPipeline to preview check changes for YAML pipelines. [See release sprint 165](https://docs.microsoft.com/azure/devops/release-notes/2020/sprint-165-update#azure-pipelines-1).
 
-Merged [Pull Request](https://github.com/DarqueWarrior/vsteam/pull/273) from [Lukas Wöhrl](https://github.com/woehrl01) which included the following:
+Merged [Pull Request](https://github.com/MethodsAndPractices/vsteam/pull/273) from [Lukas Wöhrl](https://github.com/woehrl01) which included the following:
 
 - Adds a new function Update-VSTeamAgent which allows to update the agent version
 
 ## 6.4.4
 
-Merged [Pull Request](https://github.com/DarqueWarrior/vsteam/pull/257) from [Michel Zehnder](https://github.com/MichelZ) which included the following:
+Merged [Pull Request](https://github.com/MethodsAndPractices/vsteam/pull/257) from [Michel Zehnder](https://github.com/MichelZ) which included the following:
 
 - Fix bug in Get-VSTeamBuildArtifact with additional "properties" property
 
-Merged [Pull Request](https://github.com/DarqueWarrior/vsteam/pull/245) from [Michel Zehnder](https://github.com/MichelZ) which included the following:
+Merged [Pull Request](https://github.com/MethodsAndPractices/vsteam/pull/245) from [Michel Zehnder](https://github.com/MichelZ) which included the following:
 
 - Add Get-VSTeamGitStats to retrieve statistics about branches
 
-Merged [Pull Request](https://github.com/DarqueWarrior/vsteam/pull/244) from [Michel Zehnder](https://github.com/MichelZ) which included the following:
+Merged [Pull Request](https://github.com/MethodsAndPractices/vsteam/pull/244) from [Michel Zehnder](https://github.com/MichelZ) which included the following:
 
 - Add support for licensingSource and msdnLicenseType to Add-VSTeamUserEntitlement / Update-VSTeamUserEntitlement
 
-Merged [Pull Request](https://github.com/DarqueWarrior/vsteam/pull/243) from [Michel Zehnder](https://github.com/MichelZ) which included the following:
+Merged [Pull Request](https://github.com/MethodsAndPractices/vsteam/pull/243) from [Michel Zehnder](https://github.com/MichelZ) which included the following:
 
 - Add additional filtering capabilities to Get-VSTeamPullRequest
 
-Merged [Pull Request](https://github.com/DarqueWarrior/vsteam/pull/242) from [Michel Zehnder](https://github.com/MichelZ) which included the following:
+Merged [Pull Request](https://github.com/MethodsAndPractices/vsteam/pull/242) from [Michel Zehnder](https://github.com/MichelZ) which included the following:
 
 - Added "-and" operator to the Membership tests
 
-Merged [Pull Request](https://github.com/DarqueWarrior/vsteam/pull/241) from [Michel Zehnder](https://github.com/MichelZ) which included the following:
+Merged [Pull Request](https://github.com/MethodsAndPractices/vsteam/pull/241) from [Michel Zehnder](https://github.com/MichelZ) which included the following:
 
 - Added Update-VSTeamPullRequest to manipulate some basics about Pull Requests
 - Added Add-VSTeamPullRequest to create Pull Requests
 
-Merged [Pull Request](https://github.com/DarqueWarrior/vsteam/pull/240) from [Michel Zehnder](https://github.com/MichelZ) which included the following:
+Merged [Pull Request](https://github.com/MethodsAndPractices/vsteam/pull/240) from [Michel Zehnder](https://github.com/MichelZ) which included the following:
 
 - Add option to add additional headers (-AdditionalHeaders) to the request generated by the `Invoke-VSTeamRequest` call
 
-Merged [Pull Request](https://github.com/DarqueWarrior/vsteam/pull/239) from [Michel Zehnder](https://github.com/MichelZ) which included the following:
+Merged [Pull Request](https://github.com/MethodsAndPractices/vsteam/pull/239) from [Michel Zehnder](https://github.com/MichelZ) which included the following:
 
 - Added ;charset=utf-8 to POST/PUT JSON requests
 
-Merged [Pull Request](https://github.com/DarqueWarrior/vsteam/pull/238) from [Michel Zehnder](https://github.com/MichelZ) which included the following:
+Merged [Pull Request](https://github.com/MethodsAndPractices/vsteam/pull/238) from [Michel Zehnder](https://github.com/MichelZ) which included the following:
 
 - Added Get-VSTeamGitCommit to retrieve commits
 
-Merged [Pull Request](https://github.com/DarqueWarrior/vsteam/pull/237) from [Michel Zehnder](https://github.com/MichelZ) which included the following:
+Merged [Pull Request](https://github.com/MethodsAndPractices/vsteam/pull/237) from [Michel Zehnder](https://github.com/MichelZ) which included the following:
 
 - Add -Filter, -FilterContains, -Top and -ContinuationToken to Get-VSTeamGitRefs
 
-Merged [Pull Request](https://github.com/DarqueWarrior/vsteam/pull/232) from [Mark Wragg](https://github.com/markwragg) which included the following:
+Merged [Pull Request](https://github.com/MethodsAndPractices/vsteam/pull/232) from [Mark Wragg](https://github.com/markwragg) which included the following:
 
 - Bug fix in Get-VSTeamBuildArtifact where an error is returned because the API returns an extra record along with the list of artifacts that is called 'build.sourceLabel' and contains a URL but no "properties" object.
 
-Merged [Pull Request](https://github.com/DarqueWarrior/vsteam/pull/231) from [Dave Neeley](https://github.com/daveneeley) which included the following:
+Merged [Pull Request](https://github.com/MethodsAndPractices/vsteam/pull/231) from [Dave Neeley](https://github.com/daveneeley) which included the following:
 
 - Removed a trailing slash from resource URIs generated by `_BuildRequestURI` when the ID parameter is not included in the function call.
 
-Merged [Pull Request](https://github.com/DarqueWarrior/vsteam/pull/225) from [Cadacious](https://github.com/Cadacious) which included the following:
+Merged [Pull Request](https://github.com/MethodsAndPractices/vsteam/pull/225) from [Cadacious](https://github.com/Cadacious) which included the following:
 
 - Added Get/Set-VSTeamPermissionInheritance
 
-Merged [Pull Request](https://github.com/DarqueWarrior/vsteam/pull/224) from [Cadacious](https://github.com/Cadacious) which included the following:
+Merged [Pull Request](https://github.com/MethodsAndPractices/vsteam/pull/224) from [Cadacious](https://github.com/Cadacious) which included the following:
 
 - Adds Remove-VSTeamAccessControlEntry
 
 ## 6.4.3
 
-Merged [Pull Request](https://github.com/DarqueWarrior/vsteam/pull/229) from [Asif Mithawala](https://github.com/asifma) which included the following:
+Merged [Pull Request](https://github.com/MethodsAndPractices/vsteam/pull/229) from [Asif Mithawala](https://github.com/asifma) which included the following:
 
 Added additional property checks in VSTeamJobRequest
 
 ## 6.4.2
 
-Merged [Pull Request](https://github.com/DarqueWarrior/vsteam/pull/226) from [Asif Mithawala](https://github.com/asifma) which included the following:
+Merged [Pull Request](https://github.com/MethodsAndPractices/vsteam/pull/226) from [Asif Mithawala](https://github.com/asifma) which included the following:
 
 Added property checks in VSTeamJobRequest
 
-Merged [Pull Request](https://github.com/DarqueWarrior/vsteam/pull/227) from [Sebastian Schütze](https://github.com/SebastianSchuetze) which included the following:
+Merged [Pull Request](https://github.com/MethodsAndPractices/vsteam/pull/227) from [Sebastian Schütze](https://github.com/SebastianSchuetze) which included the following:
 
 Added Remove-VSTeamWorkItem to delete work items
 
@@ -366,35 +366,35 @@ Added Remove-VSTeamWorkItem to delete work items
 
 ## 6.4.1
 
-Fixed issue [Description on variable groups is not a required field #208](https://github.com/DarqueWarrior/vsteam/issues/208).
+Fixed issue [Description on variable groups is not a required field #208](https://github.com/MethodsAndPractices/vsteam/issues/208).
 
 ## 6.4.0
 
-Merged [Pull Request](https://github.com/DarqueWarrior/vsteam/pull/214) from [Louis Tourtellotte](https://github.com/quintessential5) which included the following:
+Merged [Pull Request](https://github.com/MethodsAndPractices/vsteam/pull/214) from [Louis Tourtellotte](https://github.com/quintessential5) which included the following:
 
 Add/Update Var Group: Support for Body Param, so that json can be directly provided rather than a hashtable of variables. See the example in the documentation for more use case details.
 
-Merged [Pull Request](https://github.com/DarqueWarrior/vsteam/pull/213) from [Louis Tourtellotte](https://github.com/quintessential5) which included the following:
+Merged [Pull Request](https://github.com/MethodsAndPractices/vsteam/pull/213) from [Louis Tourtellotte](https://github.com/quintessential5) which included the following:
 
 Get-VSTeamVariableGroup fixes
 
-Merged [Pull Request](https://github.com/DarqueWarrior/vsteam/pull/212) from [Louis Tourtellotte](https://github.com/quintessential5) which included the following:
+Merged [Pull Request](https://github.com/MethodsAndPractices/vsteam/pull/212) from [Louis Tourtellotte](https://github.com/quintessential5) which included the following:
 
 Support for task groups
 
-Merged [Pull Request](https://github.com/DarqueWarrior/vsteam/pull/211) from [Dick van de Meulengraaf](https://github.com/dickvdm) which included the following:
+Merged [Pull Request](https://github.com/MethodsAndPractices/vsteam/pull/211) from [Dick van de Meulengraaf](https://github.com/dickvdm) which included the following:
 
 AzD2019 configuration, being Azure DevOps Server (on-prem) 2019 (17.143.28912.1)
 
-Merged [Pull Request](https://github.com/DarqueWarrior/vsteam/pull/209) from [Sebastian Schütze](https://github.com/SebastianSchuetze) which included the following:
+Merged [Pull Request](https://github.com/MethodsAndPractices/vsteam/pull/209) from [Sebastian Schütze](https://github.com/SebastianSchuetze) which included the following:
 
 Added Remove-VSTeamWorkItem to delete work items
 
-Merged [Pull Request](https://github.com/DarqueWarrior/vsteam/pull/204) from [Jeroen Janssen](https://github.com/japj) which included the following:
+Merged [Pull Request](https://github.com/MethodsAndPractices/vsteam/pull/204) from [Jeroen Janssen](https://github.com/japj) which included the following:
 
 maxParallelism to Disable/Enable-VSTeamAgent
 
-Merged [Pull Request](https://github.com/DarqueWarrior/vsteam/pull/205) from [Sebastian Schütze](https://github.com/SebastianSchuetze) which included the following:
+Merged [Pull Request](https://github.com/MethodsAndPractices/vsteam/pull/205) from [Sebastian Schütze](https://github.com/SebastianSchuetze) which included the following:
 
 Get-VSTeamWiql to get work items via [WIQL](https://docs.microsoft.com/rest/api/azure/devops/wit/wiql?view=azure-devops-rest-5.1&WT.mc_id=-github-dbrown) and also to expand the returned work items with all fields selected.
 
@@ -404,7 +404,7 @@ Changed signature of Get-VSTeamWorkItem to only have Id of type int[] instead of
 
 ## 6.3.6
 
-Merged [Pull Request](https://github.com/DarqueWarrior/vsteam/pull/200) from [Chris Gardner](https://github.com/ChrisLGardner) which included the following:
+Merged [Pull Request](https://github.com/MethodsAndPractices/vsteam/pull/200) from [Chris Gardner](https://github.com/ChrisLGardner) which included the following:
 
 Get-VSTeamPullRequest documentation was linking to Get-VSTeamWorkItem documentation
 
@@ -413,13 +413,13 @@ Get-VSTeamPullRequest documentation was linking to Get-VSTeamWorkItem documentat
 Updated Build-Module.ps1 to support static code analysis and running unit tests.
 Updated Merge-File.ps1 to clean trailing white-space.
 
-Merged [Pull Request](https://github.com/DarqueWarrior/vsteam/pull/199) from [Sebastian Schütze](https://github.com/SebastianSchuetze) which included the following:
+Merged [Pull Request](https://github.com/MethodsAndPractices/vsteam/pull/199) from [Sebastian Schütze](https://github.com/SebastianSchuetze) which included the following:
 
 bug fix for update and add workItem
 
 ## 6.3.4
 
-Merged [Pull Request](https://github.com/DarqueWarrior/vsteam/pull/193) from [Sebastian Schütze](https://github.com/SebastianSchuetze) which included the following:
+Merged [Pull Request](https://github.com/MethodsAndPractices/vsteam/pull/193) from [Sebastian Schütze](https://github.com/SebastianSchuetze) which included the following:
 
 Rename:
 VSTS --> AzD
@@ -427,25 +427,25 @@ VSTS --> AzD
 
 ## 6.3.3
 
-Merged [Pull Request](https://github.com/DarqueWarrior/vsteam/pull/191) from [Louis Tourtellotte](https://github.com/quintessential5) which included the following:
+Merged [Pull Request](https://github.com/MethodsAndPractices/vsteam/pull/191) from [Louis Tourtellotte](https://github.com/quintessential5) which included the following:
 
 Get-VSTeamVariableGroup: support for getting by name as well as by ID.
 
-Merged [Pull Request](https://github.com/DarqueWarrior/vsteam/pull/190) from [Sebastian Schütze](https://github.com/SebastianSchuetze) which included the following:
+Merged [Pull Request](https://github.com/MethodsAndPractices/vsteam/pull/190) from [Sebastian Schütze](https://github.com/SebastianSchuetze) which included the following:
 
 Updated Add-VSTeamWorkItem and Update-VSTeamWorkItem to support any work item field, also custom ones.
 
 ## 6.3.2
 
-Merged [Pull Request](https://github.com/DarqueWarrior/vsteam/pull/182) from [eosfor](https://github.com/eosfor) which included the following:
+Merged [Pull Request](https://github.com/MethodsAndPractices/vsteam/pull/182) from [eosfor](https://github.com/eosfor) which included the following:
 
 Invalidate cache on account change
 
-Merged [Pull Request](https://github.com/DarqueWarrior/vsteam/pull/181) from [Michael Erpenbeck](https://github.com/GitMje) which included the following:
+Merged [Pull Request](https://github.com/MethodsAndPractices/vsteam/pull/181) from [Michael Erpenbeck](https://github.com/GitMje) which included the following:
 
 Fixed typo in README.md file for better readability
 
-Merged [Pull Request](https://github.com/DarqueWarrior/vsteam/pull/179) from [Jim W](https://github.com/Seekatar) which included the following:
+Merged [Pull Request](https://github.com/MethodsAndPractices/vsteam/pull/179) from [Jim W](https://github.com/Seekatar) which included the following:
 
 Add PSDrive support for memberships
 
@@ -457,7 +457,7 @@ Add PSDrive support for memberships
 
 ## 6.3.1
 
-Merged [Pull Request](https://github.com/DarqueWarrior/vsteam/pull/178) from [Jim W](https://github.com/Seekatar) which included the following:
+Merged [Pull Request](https://github.com/MethodsAndPractices/vsteam/pull/178) from [Jim W](https://github.com/Seekatar) which included the following:
 
 - Add-VSTeamMembership
 - Remove-VSTeamMembership
@@ -476,7 +476,7 @@ Release definitions was added to the SHiPS provider.
 
 ## 6.2.9
 
-Merged [Pull Request](https://github.com/DarqueWarrior/vsteam/pull/176) from [Carlo Wahlstedt](https://github.com/carlowahlstedt) which included the following:
+Merged [Pull Request](https://github.com/MethodsAndPractices/vsteam/pull/176) from [Carlo Wahlstedt](https://github.com/carlowahlstedt) which included the following:
 
 Updated help to refer to Add-VSTeamProfile instead of Set-VSTeamProfile
 
@@ -501,7 +501,7 @@ $b = Get-VSTeamBuildDefinition 12 -Raw
 Add-VSTeamBuildDefinition -InFile $b
 ```
 
-Also merged [Pull Request](https://github.com/DarqueWarrior/vsteam/pull/170) from [Ignacio Galarza, Jr.](https://github.com/ignatz42) which included the following:
+Also merged [Pull Request](https://github.com/MethodsAndPractices/vsteam/pull/170) from [Ignacio Galarza, Jr.](https://github.com/ignatz42) which included the following:
 
 Added functions to deal with variable groups
 
@@ -535,23 +535,23 @@ Added code to log error if -UseWindowsAuthentication is used to connect to Azure
 
 ## 6.2.3
 
-Fixes issue [Get-VSTeamAccessControlList -IncludeExtendedInfo. Cannot convert value PSCustomObject to type Hashtable #159](https://github.com/DarqueWarrior/vsteam/issues/159)
+Fixes issue [Get-VSTeamAccessControlList -IncludeExtendedInfo. Cannot convert value PSCustomObject to type Hashtable #159](https://github.com/MethodsAndPractices/vsteam/issues/159)
 
 ## 6.2.2
 
-Merged [Pull Request](https://github.com/DarqueWarrior/vsteam/pull/158) from [Ryan](https://github.com/RPhay) which included the following:
+Merged [Pull Request](https://github.com/MethodsAndPractices/vsteam/pull/158) from [Ryan](https://github.com/RPhay) which included the following:
 
-Fixes issue [Get-VSTeamBuildDefinition fails #155](https://github.com/DarqueWarrior/vsteam/issues/155)
+Fixes issue [Get-VSTeamBuildDefinition fails #155](https://github.com/MethodsAndPractices/vsteam/issues/155)
 
 ## 6.2.1
 
-Merged [Pull Request](https://github.com/DarqueWarrior/vsteam/pull/156) from [Daniel Sturm](https://github.com/danstur) which included the following:
+Merged [Pull Request](https://github.com/MethodsAndPractices/vsteam/pull/156) from [Daniel Sturm](https://github.com/danstur) which included the following:
 
 Corrects error creating VSTeamBuildDefinitionProcessPhase object in later versions of Azure DevOps Server (TFS).
 
 ## 6.2.0
 
-Merged [Pull Request](https://github.com/DarqueWarrior/vsteam/pull/144) from [Michel Zehnder](https://github.com/MichelZ) which included the following:
+Merged [Pull Request](https://github.com/MethodsAndPractices/vsteam/pull/144) from [Michel Zehnder](https://github.com/MichelZ) which included the following:
 
 Added functions to deal with Security
 Note: Some of these are only supported in Azure DevOps (Online), not TFS and Azure DevOps Server due to unavailable APIs
@@ -583,7 +583,7 @@ Fixed issued with version 5.0 REST API JSON object for build definition. jobCanc
 
 ## 6.1.1
 
-Merged [Pull Request](https://github.com/DarqueWarrior/vsteam/pull/147) from [Joakim Bick](https://github.com/minimoe) which included the following:
+Merged [Pull Request](https://github.com/MethodsAndPractices/vsteam/pull/147) from [Joakim Bick](https://github.com/minimoe) which included the following:
 
 Fix interacting with large GIT repositories without hitting integer overflow.
 
@@ -591,7 +591,7 @@ Fix interacting with large GIT repositories without hitting integer overflow.
 
 The AzD API now defaults to the 5.x versions.
 
-Merged [Pull Request](https://github.com/DarqueWarrior/vsteam/pull/140) from [Michel Zehnder](https://github.com/MichelZ) which included the following:
+Merged [Pull Request](https://github.com/MethodsAndPractices/vsteam/pull/140) from [Michel Zehnder](https://github.com/MichelZ) which included the following:
 
 Added Get-VSTeamGroup to retrieve Groups
 Added Get-VSTeamDescriptor to resolve ID's to Descriptors
@@ -627,13 +627,13 @@ Changing the PAT parameter to SecurePersonalAccessToken of Set-VSTeamAccount.
 
 ## 5.0.2
 
-Merged [Pull Request](https://github.com/DarqueWarrior/vsteam/pull/129) from [Adam Murray](https://github.com/muzzar78) which included the following:
+Merged [Pull Request](https://github.com/MethodsAndPractices/vsteam/pull/129) from [Adam Murray](https://github.com/muzzar78) which included the following:
 
 - Added ParentId parameter to Add-VSTeamWorkItem to allow the parent work item to be set
 
 ## 5.0.1
 
-Merged [Pull Request](https://github.com/DarqueWarrior/vsteam/pull/128) from [Fifth Street Partners](https://github.com/fifthstreetpartners) which included the following:
+Merged [Pull Request](https://github.com/MethodsAndPractices/vsteam/pull/128) from [Fifth Street Partners](https://github.com/fifthstreetpartners) which included the following:
 
 - Added Get-VSTeamProcess
 - Modified Add-VSTeamProcess to allow for any Process Template to be used
@@ -671,15 +671,15 @@ Fixed bug where Get-VSTeamGitRepository was failing if you did not provide a pro
 
 ## 4.0.11
 
-Merged [Pull Request](https://github.com/DarqueWarrior/vsteam/pull/111) from [Brian Schmitt](https://github.com/brianschmitt) which included the following:
+Merged [Pull Request](https://github.com/MethodsAndPractices/vsteam/pull/111) from [Brian Schmitt](https://github.com/brianschmitt) which included the following:
 
 - Adding better error handling when response is null
 
-Merged [Pull Request](https://github.com/DarqueWarrior/vsteam/pull/108) from [Richard Diphoorn](https://github.com/rdtechie) which included the following:
+Merged [Pull Request](https://github.com/MethodsAndPractices/vsteam/pull/108) from [Richard Diphoorn](https://github.com/rdtechie) which included the following:
 
 - Added description, iteration path and assigned to, on Work items
 
-Merged [Pull Request](https://github.com/DarqueWarrior/vsteam/pull/110) from [Guillaume Pugnet](https://github.com/GPugnet) which included the following:
+Merged [Pull Request](https://github.com/MethodsAndPractices/vsteam/pull/110) from [Guillaume Pugnet](https://github.com/GPugnet) which included the following:
 
 - Add-VSTeamExtension
 - Get-VSTeamExtension
@@ -692,32 +692,32 @@ Fixed bug where you could not add a build by build definition name.
 
 ## 4.0.9
 
-Merged [Pull Request](https://github.com/DarqueWarrior/vsteam/pull/102) from [Brian Schmitt](https://github.com/brianschmitt) which included the following:
+Merged [Pull Request](https://github.com/MethodsAndPractices/vsteam/pull/102) from [Brian Schmitt](https://github.com/brianschmitt) which included the following:
 
 - Get-VSTeamPullRequest
 - Show-VSTeamPullRequest
 
 ## 4.0.8
 
-Merged [Pull Request](https://github.com/DarqueWarrior/vsteam/pull/93) from [Kai Walter](https://github.com/KaiWalter) which included the following:
+Merged [Pull Request](https://github.com/MethodsAndPractices/vsteam/pull/93) from [Kai Walter](https://github.com/KaiWalter) which included the following:
 
 - replaced {accountName}.visualStudio.com with dev.azure.com/{accountName}
 
 ## 4.0.7
 
-Setting the Top to 10,000 when searching by email in Update-VSTeamUser. If you have a large number of users you should use by ID instead of by email. This addresses issue [90](https://github.com/DarqueWarrior/vsteam/issues/90).
+Setting the Top to 10,000 when searching by email in Update-VSTeamUser. If you have a large number of users you should use by ID instead of by email. This addresses issue [90](https://github.com/MethodsAndPractices/vsteam/issues/90).
 
 ## 4.0.6
 
 Fixed bug where you could not Tab complete the build definition name when calling Add-VSTeamBuild.
 
-Merged [Pull Request](https://github.com/DarqueWarrior/vsteam/pull/92) from [Olivier](https://github.com/hangar18rip) which included the following:
+Merged [Pull Request](https://github.com/MethodsAndPractices/vsteam/pull/92) from [Olivier](https://github.com/hangar18rip) which included the following:
 
 - Added the Demands property to the VSTeamBuildDefinition type
 
 ## 4.0.5
 
-Merged [Pull Request](https://github.com/DarqueWarrior/vsteam/pull/89) from [Guillaume Pugnet](https://github.com/GPugnet) which included the following:
+Merged [Pull Request](https://github.com/MethodsAndPractices/vsteam/pull/89) from [Guillaume Pugnet](https://github.com/GPugnet) which included the following:
 
 - old license was not populated when updating a user by id
 
@@ -727,11 +727,11 @@ Fixed bug where the version would not be saved when storing account at User or A
 
 ## 4.0.3
 
-Merged [Pull Request](https://github.com/DarqueWarrior/vsteam/pull/84) from [Kai Walter](https://github.com/KaiWalter) which included the following:
+Merged [Pull Request](https://github.com/MethodsAndPractices/vsteam/pull/84) from [Kai Walter](https://github.com/KaiWalter) which included the following:
 
 - converted VSTeamQueue from format/type to class
 
-Merged [Pull Request](https://github.com/DarqueWarrior/vsteam/pull/86) from [Denny](https://github.com/dvankleef) which included the following:
+Merged [Pull Request](https://github.com/MethodsAndPractices/vsteam/pull/86) from [Denny](https://github.com/dvankleef) which included the following:
 
 - Added update User. Currently only can update license type
 
@@ -739,7 +739,7 @@ Merged [Pull Request](https://github.com/DarqueWarrior/vsteam/pull/86) from [Den
 
 Added Remove-VSTeamFeed
 
-Merged [Pull Request](https://github.com/DarqueWarrior/vsteam/pull/82) from [Kai Walter](https://github.com/KaiWalter) which included the following:
+Merged [Pull Request](https://github.com/MethodsAndPractices/vsteam/pull/82) from [Kai Walter](https://github.com/KaiWalter) which included the following:
 
 - removed output of objects returned from API to avoid misleading outputs for consumers
 - added GitRepository object to BuildDefinition
@@ -758,7 +758,7 @@ The @VSTeamVersionTable was removed and replaced with a static VSTeamVersions cl
 
 Due to this breaking change _Get-VSTeamAPIVersion_ was added to review the current version being used.
 
-Merged [Pull Request](https://github.com/DarqueWarrior/vsteam/pull/77) from [Kai Walter](https://github.com/KaiWalter) which included the following:
+Merged [Pull Request](https://github.com/MethodsAndPractices/vsteam/pull/77) from [Kai Walter](https://github.com/KaiWalter) which included the following:
 
 - Build Definition / Process / Phases / Steps are broken down into separate objects
 
@@ -779,12 +779,12 @@ Added Update-VSTeamProfile to allow easy updating of the PAT for each profile.
 
 ## 3.0.5
 
-Merged [Pull Request 70](https://github.com/DarqueWarrior/vsteam/pull/70) and [Pull Request 72](https://github.com/DarqueWarrior/vsteam/pull/72) from [Geert van der Cruijsen](https://github.com/Geertvdc) which included the following:
+Merged [Pull Request 70](https://github.com/MethodsAndPractices/vsteam/pull/70) and [Pull Request 72](https://github.com/MethodsAndPractices/vsteam/pull/72) from [Geert van der Cruijsen](https://github.com/Geertvdc) which included the following:
 
 - Added a function to remove vsts agents from a pool by calling Remove-Agent or Remove-VSTeamAgent
 - Disable & Enable agents in pool
 
-Add [Pull Request 70](https://github.com/DarqueWarrior/vsteam/pull/71) from [Kai Walter](https://github.com/KaiWalter) which included the following:
+Add [Pull Request 70](https://github.com/MethodsAndPractices/vsteam/pull/71) from [Kai Walter](https://github.com/KaiWalter) which included the following:
 
 - Integration tests for Build Definitions
 
@@ -794,7 +794,7 @@ The ProjectName dynamic parameter that enables Tab Complete of project names was
 
 ## 3.0.3
 
-Merged [Pull Request](https://github.com/DarqueWarrior/vsteam/pull/66) from [Kai Walter](https://github.com/KaiWalter) which included the following:
+Merged [Pull Request](https://github.com/MethodsAndPractices/vsteam/pull/66) from [Kai Walter](https://github.com/KaiWalter) which included the following:
 
 - Updated integration tests to account for the new hosted agent pool.
 
@@ -905,7 +905,7 @@ Additional change in this release include more unit tests which resulted in much
 
 ## 2.1.13
 
-Merged [Pull Request](https://github.com/DarqueWarrior/vsteam/pull/50) from [Markus Blaschke](https://github.com/mblaschke) which included the following:
+Merged [Pull Request](https://github.com/MethodsAndPractices/vsteam/pull/50) from [Markus Blaschke](https://github.com/mblaschke) which included the following:
 
 - Added functions for handling of service endpoints:
   - Add-VSTeamKubernetesEndpoint
@@ -914,7 +914,7 @@ Merged [Pull Request](https://github.com/DarqueWarrior/vsteam/pull/50) from [Mar
 
 ## 2.1.12
 
-Merged [Pull Request](https://github.com/DarqueWarrior/vsteam/pull/51) from [Steve Croxford](https://github.com/CodedBeard) which included the following:
+Merged [Pull Request](https://github.com/MethodsAndPractices/vsteam/pull/51) from [Steve Croxford](https://github.com/CodedBeard) which included the following:
 
 - Added support for creating service fabric endpoints.
 
@@ -924,47 +924,47 @@ Updated the delete confirmation message for Remove-VSTeamUser to show the user n
 
 ## 2.1.10
 
-Merged [Pull Request](https://github.com/DarqueWarrior/vsteam/pull/46) from [Michal Karpinski](https://github.com/karpis) which included the following:
+Merged [Pull Request](https://github.com/MethodsAndPractices/vsteam/pull/46) from [Michal Karpinski](https://github.com/karpis) which included the following:
 
 - Added -SourceBranch parameter to Add-VSTeamBuild
 
 ## 2.1.9
 
-Merged [Pull Request](https://github.com/DarqueWarrior/vsteam/pull/44) from [Michal Karpinski](https://github.com/karpis) which included the following:
+Merged [Pull Request](https://github.com/MethodsAndPractices/vsteam/pull/44) from [Michal Karpinski](https://github.com/karpis) which included the following:
 
 - Added functions for querying TFVC branches:
   - Get-VSTeamTfvcRootBranch
   - Get-VSTeamTfvcBranch
 
-Merged [Pull Request](https://github.com/DarqueWarrior/vsteam/pull/45) from [Michal Karpinski](https://github.com/karpis) which included the following:
+Merged [Pull Request](https://github.com/MethodsAndPractices/vsteam/pull/45) from [Michal Karpinski](https://github.com/karpis) which included the following:
 
 - Added ability to pass parameters when queueing builds
 
 ## 2.1.8
 
-Merged [Pull Request](https://github.com/DarqueWarrior/vsteam/pull/38) from [Jeffrey Opdam](https://github.com/jeffrey-opdam) which included the following:
+Merged [Pull Request](https://github.com/MethodsAndPractices/vsteam/pull/38) from [Jeffrey Opdam](https://github.com/jeffrey-opdam) which included the following:
 
 - Added support for assigner to be a group, when requesting approvals for a group
 
 ## 2.1.7
 
-Merged [Pull Request](https://github.com/DarqueWarrior/vsteam/pull/42) from [Michal Karpinski](https://github.com/karpis) which included the following:
+Merged [Pull Request](https://github.com/MethodsAndPractices/vsteam/pull/42) from [Michal Karpinski](https://github.com/karpis) which included the following:
 
 - Added a function for updating an existing build definition from an input json file
 
 ## 2.1.6
 
-Merged [Pull Request](https://github.com/DarqueWarrior/vsteam/pull/39) from [Francisco Cabral](https://github.com/franciscocabral) which included the following:
+Merged [Pull Request](https://github.com/MethodsAndPractices/vsteam/pull/39) from [Francisco Cabral](https://github.com/franciscocabral) which included the following:
 
 - Fix GET Approval filter by release ids
 
 ## 2.1.5
 
-Fixed issue [#40](https://github.com/DarqueWarrior/vsteam/issues/40) so adding a SonarQube or AzureRM Service Endpoint returns the endpoint.
+Fixed issue [#40](https://github.com/MethodsAndPractices/vsteam/issues/40) so adding a SonarQube or AzureRM Service Endpoint returns the endpoint.
 
 ## 2.1.4
 
-Merged [Pull Request](https://github.com/DarqueWarrior/vsteam/pull/37) from [David Roberts](https://github.com/davidroberts63) which included the following:
+Merged [Pull Request](https://github.com/MethodsAndPractices/vsteam/pull/37) from [David Roberts](https://github.com/davidroberts63) which included the following:
 
 - Add functions to get/edit code policies
 
@@ -975,7 +975,7 @@ Updated the ValidateSet for StatusFilter of Approvals
 
 ## 2.1.2
 
-Fixed issue [#36](https://github.com/DarqueWarrior/vsteam/issues/36) so all git repositories are returned when you do not provide an project.
+Fixed issue [#36](https://github.com/MethodsAndPractices/vsteam/issues/36) so all git repositories are returned when you do not provide an project.
 
 ## 2.1.1
 
@@ -1026,7 +1026,7 @@ You can update the version so try new versions of APIs. See Set-VSTeamAPIVersion
 
 Added support for Show-VSTeam that opens the configured TFS or VSTS in default browser.
 
-Merged [Pull Request](https://github.com/DarqueWarrior/vsteam/pull/26) from [Michel Perfetti](https://github.com/miiitch) which included the following:
+Merged [Pull Request](https://github.com/MethodsAndPractices/vsteam/pull/26) from [Michel Perfetti](https://github.com/miiitch) which included the following:
 
 - Remove deadlock when endpoint creation failed
 
@@ -1061,7 +1061,7 @@ The variable to test if you are on Mac OS changed from IsOSX to IsMacOS. Because
 
 ## 0.1.32
 
-Merged [Pull Request](https://github.com/DarqueWarrior/vsteam/pull/16) from [Fergal](https://github.com/ObsidianPhoenix) which included the following:
+Merged [Pull Request](https://github.com/MethodsAndPractices/vsteam/pull/16) from [Fergal](https://github.com/ObsidianPhoenix) which included the following:
 
 - Added Support for Build Tags
 - Added the ability to update KeepForever, and the Build Number
@@ -1069,19 +1069,19 @@ Merged [Pull Request](https://github.com/DarqueWarrior/vsteam/pull/16) from [Fer
 
 ## 0.1.31
 
-Merged [Pull Request](https://github.com/DarqueWarrior/vsteam/pull/17) from [Kees Verhaar](https://github.com/KeesV) which included the following:
+Merged [Pull Request](https://github.com/MethodsAndPractices/vsteam/pull/17) from [Kees Verhaar](https://github.com/KeesV) which included the following:
 
 - Add ProjectName as a property on team member so it can be used further down the pipeline
 
 ## 0.1.30
 
-Merged [Pull Request](https://github.com/DarqueWarrior/vsteam/pull/15) from [Kees Verhaar](https://github.com/KeesV) which included the following:
+Merged [Pull Request](https://github.com/MethodsAndPractices/vsteam/pull/15) from [Kees Verhaar](https://github.com/KeesV) which included the following:
 
 - Add support for teams
 
 ## 0.1.29
 
-Merged [Pull Request](https://github.com/DarqueWarrior/vsteam/pull/12) from [Andy Neillans](https://github.com/aneillans) which included the following:
+Merged [Pull Request](https://github.com/MethodsAndPractices/vsteam/pull/12) from [Andy Neillans](https://github.com/aneillans) which included the following:
 
 - Fixed for on-premise URLS being incorrectly classed as VSTS accounts
 - Fixed for projects validation if you have more than 100 projects
@@ -1096,7 +1096,7 @@ Clearing code analysis warnings
 
 ## 0.1.26
 
-Merged [Pull Request](https://github.com/DarqueWarrior/vsteam/pull/10) from [Roberto Peña](https://github.com/eulesv) which included the following:
+Merged [Pull Request](https://github.com/MethodsAndPractices/vsteam/pull/10) from [Roberto Peña](https://github.com/eulesv) which included the following:
 
 - Adding a regular expression to validate VSTS account
 
@@ -1110,7 +1110,7 @@ Merged [Pull Request](https://github.com/DarqueWarrior/vsteam/pull/10) from [Rob
 
 ## 0.1.23
 
-Merged [Pull Request](https://github.com/DarqueWarrior/vsteam/pull/8) from [Michel Perfetti](https://github.com/miiitch) which included the following:
+Merged [Pull Request](https://github.com/MethodsAndPractices/vsteam/pull/8) from [Michel Perfetti](https://github.com/miiitch) which included the following:
 
 - Support for the [SonarQube extension](https://marketplace.visualstudio.com/items?itemName=SonarSource.sonarqube)
 
@@ -1122,7 +1122,7 @@ Merged [Pull Request](https://github.com/DarqueWarrior/vsteam/pull/8) from [Mich
 
 - Added Get-VSTeamBuildLog that returns the logs of the provided build
 
-Merged [Pull Request](https://github.com/DarqueWarrior/vsteam/pull/6)from [Michel Perfetti](https://github.com/miiitch) which included the following:
+Merged [Pull Request](https://github.com/MethodsAndPractices/vsteam/pull/6)from [Michel Perfetti](https://github.com/miiitch) which included the following:
 
 - Added serviceEndpoint parameters to Add-VSTeamAzureRMServiceEndpoint cmdlet: if the serviceEndPoint parameters are not specified, the Automatic mode is used
 - The \_trackProgress function was changed too to reflect the return code of the api [endpoints](https://www.visualstudio.com/docs/integrate/api/endpoints/endpoints?WT.mc_id=-github-dbrown)
@@ -1134,19 +1134,19 @@ Removed test folder from module
 
 ## 0.1.18
 
-Merged [Pull Request](https://github.com/DarqueWarrior/vsteam/pull/5) from [Christopher Mank](https://github.com/ChristopherMank) which included the following:
+Merged [Pull Request](https://github.com/MethodsAndPractices/vsteam/pull/5) from [Christopher Mank](https://github.com/ChristopherMank) which included the following:
 
 - Created new function in the release module named 'Add-VSTeamReleaseEnvironment'. New function deploys an environment from an existing release.
 
 ## 0.1.16
 
-Merged [Pull Request](https://github.com/DarqueWarrior/vsteam/pull/4) from [Andy Neillans](https://github.com/aneillans) which included the following:
+Merged [Pull Request](https://github.com/MethodsAndPractices/vsteam/pull/4) from [Andy Neillans](https://github.com/aneillans) which included the following:
 
 - Bug fix for broken PAT code handling.
 
 ## 0.1.15
 
-Merged [Pull Request](https://github.com/DarqueWarrior/vsteam/pull/3) from [Andy Neillans](https://github.com/aneillans) which included the following:
+Merged [Pull Request](https://github.com/MethodsAndPractices/vsteam/pull/3) from [Andy Neillans](https://github.com/aneillans) which included the following:
 
 - Corrected typos in help files.
 - Refactored location of common methods.

--- a/Source/Classes/Versions.cs
+++ b/Source/Classes/Versions.cs
@@ -7,7 +7,7 @@ namespace vsteam_lib
       Build, Release, Core, Git, DistributedTask, DistributedTaskReleased,
       VariableGroups, Tfvc, Packaging, MemberEntitlementManagement,
       ExtensionsManagement, ServiceEndpoints, Graph, TaskGroups, Policy,
-      Processes, Version, HierarchyQuery, Pipelines, Billing, Wiki
+      Processes, Version, HierarchyQuery, Pipelines, Billing, Wiki, WorkItemTracking
    }
 
    public static class Versions
@@ -76,6 +76,9 @@ namespace vsteam_lib
             case APIs.Wiki:
                Wiki = version;
                break;
+            case APIs.WorkItemTracking:
+               WorkItemTracking = version;
+               break;
          }
       }
 
@@ -123,6 +126,8 @@ namespace vsteam_lib
                return Processes;
             case APIs.Wiki:
                return Wiki;
+            case APIs.WorkItemTracking:
+               return WorkItemTracking;
             default:
                return Version;
          }
@@ -161,5 +166,6 @@ namespace vsteam_lib
       public static string Policy { get; set; } = "3.0";
       public static string Processes { get; set; } = "";
       public static string Wiki { get; set; } = "6.0";
+      public static string WorkItemTracking { get; set; } = "6.0";
    }
 }

--- a/Source/Private/common.ps1
+++ b/Source/Private/common.ps1
@@ -200,7 +200,7 @@ function _getApiVersion {
          'DistributedTaskReleased', 'VariableGroups', 'Tfvc',
          'Packaging', 'MemberEntitlementManagement',
          'ExtensionsManagement', 'ServiceEndpoints', 'Graph',
-         'TaskGroups', 'Policy', 'Processes', 'HierarchyQuery', 'Pipelines', 'Billing', 'Wiki')]
+         'TaskGroups', 'Policy', 'Processes', 'HierarchyQuery', 'Pipelines', 'Billing', 'Wiki','WorkItemTracking')]
       [string] $Service,
 
       [parameter(ParameterSetName = 'Target')]

--- a/Source/Public/Get-VSTeamAPIVersion.ps1
+++ b/Source/Public/Get-VSTeamAPIVersion.ps1
@@ -8,7 +8,7 @@ function Get-VSTeamAPIVersion {
                    'Packaging', 'MemberEntitlementManagement',
                    'ExtensionsManagement', 'ServiceEndpoints', 'Graph',
                    'TaskGroups', 'Policy', 'Processes', 'HierarchyQuery',
-                   'Pipelines', 'Billing')]
+                   'Pipelines', 'Billing', 'Wiki', 'WorkItemTracking')]
       [string] $Service
    )
 
@@ -39,7 +39,9 @@ function Get-VSTeamAPIVersion {
          TaskGroups                  = $(_getApiVersion TaskGroups)
          Tfvc                        = $(_getApiVersion Tfvc)
          VariableGroups              = $(_getApiVersion VariableGroups)
-         Version                     = $(_getApiVersion -Target)
+         Version                     = $(_getApiVersion Version)
+         Wiki                        = $(_getApiVersion Wiki)
+         WorkItemTracking            = $(_getApiVersion WorkItemTracking)
       }
    }
 }

--- a/Source/Public/Get-VSTeamProcess.ps1
+++ b/Source/Public/Get-VSTeamProcess.ps1
@@ -34,7 +34,7 @@ function Get-VSTeamProcess {
       $commonArgs = @{
          # In later APIs you can get the process templates from the 'work'
          # area. For older APIs the process templates are in the 'processes'
-         # area. Default to the newer way of accessing process templates.
+         # area. Defaults to the newer way of accessing process templates.
          # Get-VSTeamOption -area 'work' -resource 'processes' returns nothing
          # this is odd but the call works.
          area      = 'work'

--- a/Source/Public/Get-VSTeamWorkItemTag.ps1
+++ b/Source/Public/Get-VSTeamWorkItemTag.ps1
@@ -1,8 +1,6 @@
 function Get-VSTeamWorkItemTag {
    [CmdletBinding(HelpUri='https://methodsandpractices.github.io/vsteam-docs/docs/modules/vsteam/commands/Get-VSTeamWorkItemTag')]
    param (
-
-
       [Parameter(Mandatory = $true, ValueFromPipelineByPropertyName = $true)]
       [Alias('TagName')]
       [Alias('TagId')]

--- a/Source/Public/Get-VSTeamWorkItemTag.ps1
+++ b/Source/Public/Get-VSTeamWorkItemTag.ps1
@@ -1,0 +1,38 @@
+function Get-VSTeamWorkItemTag {
+   [CmdletBinding(HelpUri='https://methodsandpractices.github.io/vsteam-docs/docs/modules/vsteam/commands/Get-VSTeamWorkItemTag')]
+   param (
+
+
+      [Parameter(Mandatory = $true, ValueFromPipelineByPropertyName = $true)]
+      [Alias('TagName')]
+      [Alias('TagId')]
+      [string] $TagIdOrName,
+
+      [Parameter(Mandatory = $true, ValueFromPipelineByPropertyName = $true )]
+      [vsteam_lib.ProjectValidateAttribute($false)]
+      [ArgumentCompleter([vsteam_lib.ProjectCompleter])]
+      [string] $ProjectName
+   )
+   process {
+      $commonArgs = @{         
+         area        = 'wit'
+         resource    = 'tags'
+         projectName = $ProjectName
+         version     = $(_getApiVersion WorkItemTracking)
+      }
+
+      if ($TagIdOrName) { # TagIdOrName was specified, fetch a specific tag    
+         $resp = _callAPI @commonArgs -id $TagIdOrName         
+         Write-Output $resp         
+      }
+      else { # TagIdOrName not specified, list all tags
+         $listurl = _buildRequestURI @commonArgs         
+         $resp = _callAPI -url $listurl
+         $objs = @()
+         foreach ($item in $resp.value) {         
+            $objs += $item
+         }
+         Write-Output $objs
+      }
+   }
+}

--- a/Source/Public/Get-VSTeamWorkItemTag.ps1
+++ b/Source/Public/Get-VSTeamWorkItemTag.ps1
@@ -1,7 +1,7 @@
 function Get-VSTeamWorkItemTag {
    [CmdletBinding(HelpUri='https://methodsandpractices.github.io/vsteam-docs/docs/modules/vsteam/commands/Get-VSTeamWorkItemTag')]
    param (
-      [Parameter(Mandatory = $true, ValueFromPipelineByPropertyName = $true)]
+      [Parameter(Mandatory = $false, ValueFromPipelineByPropertyName = $true)]
       [Alias('TagName')]
       [Alias('TagId')]
       [string] $TagIdOrName,
@@ -12,22 +12,22 @@ function Get-VSTeamWorkItemTag {
       [string] $ProjectName
    )
    process {
-      $commonArgs = @{         
+      $commonArgs = @{
          area        = 'wit'
          resource    = 'tags'
          projectName = $ProjectName
          version     = $(_getApiVersion WorkItemTracking)
       }
 
-      if ($TagIdOrName) { # TagIdOrName was specified, fetch a specific tag    
-         $resp = _callAPI @commonArgs -id $TagIdOrName         
-         Write-Output $resp         
+      if ($TagIdOrName) { # TagIdOrName was specified, fetch a specific tag
+         $resp = _callAPI @commonArgs -id $TagIdOrName
+         Write-Output $resp
       }
       else { # TagIdOrName not specified, list all tags
-         $listurl = _buildRequestURI @commonArgs         
+         $listurl = _buildRequestURI @commonArgs
          $resp = _callAPI -url $listurl
          $objs = @()
-         foreach ($item in $resp.value) {         
+         foreach ($item in $resp.value) {
             $objs += $item
          }
          Write-Output $objs

--- a/Source/Public/Remove-VSTeamWorkItemTag.ps1
+++ b/Source/Public/Remove-VSTeamWorkItemTag.ps1
@@ -1,0 +1,32 @@
+function Remove-VSTeamWorkItemTag {
+   [CmdletBinding(SupportsShouldProcess = $true, ConfirmImpact = "High", DefaultParameterSetName = 'ByID',
+    HelpUri='https://methodsandpractices.github.io/vsteam-docs/docs/modules/vsteam/commands/Remove-VSTeamWorkItemTag')]
+    param(
+      [Parameter(Mandatory = $true, ValueFromPipelineByPropertyName = $true)]
+      [string] $TagIdOrName,
+
+      [switch] $Force,
+
+      [Parameter(Mandatory = $true, ValueFromPipelineByPropertyName = $true)]
+      [vsteam_lib.ProjectValidateAttribute($false)]
+      [ArgumentCompleter([vsteam_lib.ProjectCompleter])]
+      [string] $ProjectName
+   )
+
+   Process {
+      if ($Force -or $pscmdlet.ShouldProcess($item, "Delete Work Item Tag")) {
+         try {
+            _callAPI -Method DELETE `
+               -Area "wit" `
+               -Resource "tags" `
+               -id $TagIdOrName `
+               -Version $(_getApiVersion WorkItemTracking) | Out-Null
+
+            Write-Output "Deleted tag $TagIdOrName"
+         }
+         catch {
+            _handleException $_
+         }
+      }    
+   }
+}

--- a/Source/Public/Remove-VSTeamWorkItemTag.ps1
+++ b/Source/Public/Remove-VSTeamWorkItemTag.ps1
@@ -14,7 +14,7 @@ function Remove-VSTeamWorkItemTag {
    )
 
    Process {
-      if ($Force -or $pscmdlet.ShouldProcess($item, "Delete Work Item Tag")) {
+      if ($Force -or $pscmdlet.ShouldProcess($item, "Delete work item tag from all work items in this team project")) {
          try {
             _callAPI -Method DELETE `
                -Area "wit" `

--- a/Source/Public/Remove-VSTeamWorkItemTag.ps1
+++ b/Source/Public/Remove-VSTeamWorkItemTag.ps1
@@ -17,7 +17,7 @@ function Remove-VSTeamWorkItemTag {
       if ($Force -or $pscmdlet.ShouldProcess($item, "Delete work item tag from all work items in this team project")) {
          try {
             _callAPI -Method DELETE `
-               -ProjectName $ProjectName
+               -ProjectName $ProjectName `
                -Area "wit" `
                -Resource "tags" `
                -id $TagIdOrName `

--- a/Source/Public/Remove-VSTeamWorkItemTag.ps1
+++ b/Source/Public/Remove-VSTeamWorkItemTag.ps1
@@ -17,6 +17,7 @@ function Remove-VSTeamWorkItemTag {
       if ($Force -or $pscmdlet.ShouldProcess($item, "Delete work item tag from all work items in this team project")) {
          try {
             _callAPI -Method DELETE `
+               -ProjectName $ProjectName
                -Area "wit" `
                -Resource "tags" `
                -id $TagIdOrName `
@@ -27,6 +28,6 @@ function Remove-VSTeamWorkItemTag {
          catch {
             _handleException $_
          }
-      }    
+      }
    }
 }

--- a/Source/Public/Set-VSTeamAPIVersion.ps1
+++ b/Source/Public/Set-VSTeamAPIVersion.ps1
@@ -51,6 +51,7 @@ function Set-VSTeamAPIVersion {
                [vsteam_lib.Versions]::Policy = '5.0'
                [vsteam_lib.Versions]::Processes = '5.0-preview'
                [vsteam_lib.Versions]::Billing = ''
+               [vsteam_lib.Versions]::WorkItemTracking = '5.0'
             }
             'AzD2019U1' {
                [vsteam_lib.Versions]::Version = 'AzD2019'
@@ -73,6 +74,7 @@ function Set-VSTeamAPIVersion {
                [vsteam_lib.Versions]::Policy = '5.1'
                [vsteam_lib.Versions]::Processes = '5.1-preview'
                [vsteam_lib.Versions]::Billing = ''
+               [vsteam_lib.Versions]::WorkItemTracking = '5.1-preview'
             }
             { $_ -eq 'TFS2018' -or $_ -eq 'TFS2018U1' } {
                [vsteam_lib.Versions]::Version = 'TFS2018'
@@ -95,6 +97,7 @@ function Set-VSTeamAPIVersion {
                [vsteam_lib.Versions]::Policy = '4.0'
                [vsteam_lib.Versions]::Processes = '4.0-preview'
                [vsteam_lib.Versions]::Billing = ''
+               [vsteam_lib.Versions]::WorkItemTracking = '4.0-preview'
             }
             { $_ -eq 'TFS2018U2' -or $_ -eq 'TFS2018U3' } {
                [vsteam_lib.Versions]::Version = 'TFS2018'
@@ -117,6 +120,7 @@ function Set-VSTeamAPIVersion {
                [vsteam_lib.Versions]::Policy = '4.1'
                [vsteam_lib.Versions]::Processes = '4.1-preview'
                [vsteam_lib.Versions]::Billing = ''
+               [vsteam_lib.Versions]::WorkItemTracking = '4.1-preview.1'
             }
             'TFS2017' {
                [vsteam_lib.Versions]::Version = 'TFS2017'
@@ -139,6 +143,7 @@ function Set-VSTeamAPIVersion {
                [vsteam_lib.Versions]::Policy = '3.0'
                [vsteam_lib.Versions]::Processes = ''
                [vsteam_lib.Versions]::Billing = ''
+               [vsteam_lib.Versions]::WorkItemTracking = '3.0'
             }
             'TFS2017U1' {
                [vsteam_lib.Versions]::Version = 'TFS2017'
@@ -161,6 +166,7 @@ function Set-VSTeamAPIVersion {
                [vsteam_lib.Versions]::Policy = '3.1'
                [vsteam_lib.Versions]::Processes = ''
                [vsteam_lib.Versions]::Billing = ''
+               [vsteam_lib.Versions]::WorkItemTracking = '3.1'
             }
             # Update 3 of TFS 2017 did not introduce a new API Version
             { $_ -eq 'TFS2017U2' -or $_ -eq 'TFS2017U3' } {
@@ -184,6 +190,7 @@ function Set-VSTeamAPIVersion {
                [vsteam_lib.Versions]::Policy = '3.2'
                [vsteam_lib.Versions]::Processes = ''
                [vsteam_lib.Versions]::Billing = ''
+               [vsteam_lib.Versions]::WorkItemTracking = '3.2'
             }
             # AZD, VSTS
             Default {
@@ -210,6 +217,7 @@ function Set-VSTeamAPIVersion {
                [vsteam_lib.Versions]::Policy = '5.1'
                [vsteam_lib.Versions]::Processes = '6.0-preview'
                [vsteam_lib.Versions]::Billing = '5.1-preview.1'
+               [vsteam_lib.Versions]::WorkItemTracking = '6.0-preview.1'
             }
          }
       }

--- a/Source/Public/Set-VSTeamAPIVersion.ps1
+++ b/Source/Public/Set-VSTeamAPIVersion.ps1
@@ -14,7 +14,7 @@ function Set-VSTeamAPIVersion {
                    'Packaging', 'MemberEntitlementManagement',
                    'ExtensionsManagement', 'ServiceEndpoints', 'Graph',
                    'TaskGroups', 'Policy', 'Processes', 'HierarchyQuery',
-                   'Pipelines', 'Billing')]
+                   'Pipelines', 'Billing', 'Wiki', 'WorkItemTracking')]
       [string] $Service,
 
       [parameter(ParameterSetName = 'Service', Mandatory = $true, Position = 1)]

--- a/Source/Public/Set-VSTeamAPIVersion.ps1
+++ b/Source/Public/Set-VSTeamAPIVersion.ps1
@@ -51,6 +51,7 @@ function Set-VSTeamAPIVersion {
                [vsteam_lib.Versions]::Policy = '5.0'
                [vsteam_lib.Versions]::Processes = '5.0-preview'
                [vsteam_lib.Versions]::Billing = ''
+               [vsteam_lib.Versions]::Wiki = '5.0'
                [vsteam_lib.Versions]::WorkItemTracking = '5.0'
             }
             'AzD2019U1' {
@@ -74,6 +75,7 @@ function Set-VSTeamAPIVersion {
                [vsteam_lib.Versions]::Policy = '5.1'
                [vsteam_lib.Versions]::Processes = '5.1-preview'
                [vsteam_lib.Versions]::Billing = ''
+               [vsteam_lib.Versions]::Wiki = '5.1'
                [vsteam_lib.Versions]::WorkItemTracking = '5.1-preview'
             }
             { $_ -eq 'TFS2018' -or $_ -eq 'TFS2018U1' } {
@@ -97,6 +99,7 @@ function Set-VSTeamAPIVersion {
                [vsteam_lib.Versions]::Policy = '4.0'
                [vsteam_lib.Versions]::Processes = '4.0-preview'
                [vsteam_lib.Versions]::Billing = ''
+               [vsteam_lib.Versions]::Wiki = ''
                [vsteam_lib.Versions]::WorkItemTracking = '4.0-preview'
             }
             { $_ -eq 'TFS2018U2' -or $_ -eq 'TFS2018U3' } {
@@ -120,6 +123,7 @@ function Set-VSTeamAPIVersion {
                [vsteam_lib.Versions]::Policy = '4.1'
                [vsteam_lib.Versions]::Processes = '4.1-preview'
                [vsteam_lib.Versions]::Billing = ''
+               [vsteam_lib.Versions]::Wiki = '4.1'
                [vsteam_lib.Versions]::WorkItemTracking = '4.1-preview.1'
             }
             'TFS2017' {
@@ -143,6 +147,7 @@ function Set-VSTeamAPIVersion {
                [vsteam_lib.Versions]::Policy = '3.0'
                [vsteam_lib.Versions]::Processes = ''
                [vsteam_lib.Versions]::Billing = ''
+               [vsteam_lib.Versions]::Wiki = ''
                [vsteam_lib.Versions]::WorkItemTracking = '3.0'
             }
             'TFS2017U1' {
@@ -166,6 +171,7 @@ function Set-VSTeamAPIVersion {
                [vsteam_lib.Versions]::Policy = '3.1'
                [vsteam_lib.Versions]::Processes = ''
                [vsteam_lib.Versions]::Billing = ''
+               [vsteam_lib.Versions]::Wiki = ''
                [vsteam_lib.Versions]::WorkItemTracking = '3.1'
             }
             # Update 3 of TFS 2017 did not introduce a new API Version
@@ -190,6 +196,7 @@ function Set-VSTeamAPIVersion {
                [vsteam_lib.Versions]::Policy = '3.2'
                [vsteam_lib.Versions]::Processes = ''
                [vsteam_lib.Versions]::Billing = ''
+               [vsteam_lib.Versions]::Wiki = ''
                [vsteam_lib.Versions]::WorkItemTracking = '3.2'
             }
             # AZD, VSTS
@@ -217,6 +224,7 @@ function Set-VSTeamAPIVersion {
                [vsteam_lib.Versions]::Policy = '5.1'
                [vsteam_lib.Versions]::Processes = '6.0-preview'
                [vsteam_lib.Versions]::Billing = '5.1-preview.1'
+               [vsteam_lib.Versions]::Wiki = '6.0'
                [vsteam_lib.Versions]::WorkItemTracking = '6.0-preview.1'
             }
          }

--- a/Source/Public/Update-VSTeamWorkItemTag.ps1
+++ b/Source/Public/Update-VSTeamWorkItemTag.ps1
@@ -14,7 +14,7 @@ function Update-VSTeamWorkItemTag {
    )
 
    process {
-      if ($Force -or $pscmdlet.ShouldProcess($Id, "Update Work Item Tag")) {
+      if ($Force -or $pscmdlet.ShouldProcess($Id, "Update work item tag in all work items in this team project")) {
          $resp = _callAPI -Method PATCH -ProjectName $ProjectName `
             -Area wit `
             -Resource tags `

--- a/Source/Public/Update-VSTeamWorkItemTag.ps1
+++ b/Source/Public/Update-VSTeamWorkItemTag.ps1
@@ -5,6 +5,9 @@ function Update-VSTeamWorkItemTag {
       [Parameter(Mandatory = $true, ValueFromPipelineByPropertyName = $true)]
       [string] $TagIdOrName,
 
+      [Parameter(Mandatory = $true, ValueFromPipelineByPropertyName = $true)]
+      [string] $NewTagName,
+
       [switch] $Force,
 
       [Parameter(Mandatory = $true, ValueFromPipelineByPropertyName = $true)]
@@ -15,6 +18,9 @@ function Update-VSTeamWorkItemTag {
 
    process {
       if ($Force -or $pscmdlet.ShouldProcess($Id, "Update work item tag in all work items in this team project")) {
+
+         $body = '{ "name": "' + $NewTagName + '" }'
+
          $resp = _callAPI -Method PATCH -ProjectName $ProjectName `
             -Area wit `
             -Resource tags `

--- a/Source/Public/Update-VSTeamWorkItemTag.ps1
+++ b/Source/Public/Update-VSTeamWorkItemTag.ps1
@@ -21,7 +21,8 @@ function Update-VSTeamWorkItemTag {
 
          $body = '{ "name": "' + $NewTagName + '" }'
 
-         $resp = _callAPI -Method PATCH -ProjectName $ProjectName `
+         $resp = _callAPI -Method PATCH `
+            -ProjectName $ProjectName `
             -Area wit `
             -Resource tags `
             -Id $TagIdOrName `

--- a/Source/Public/Update-VSTeamWorkItemTag.ps1
+++ b/Source/Public/Update-VSTeamWorkItemTag.ps1
@@ -1,0 +1,28 @@
+function Update-VSTeamWorkItemTag {
+   [CmdletBinding(SupportsShouldProcess = $true, ConfirmImpact = "Medium", DefaultParameterSetName = 'JSON',
+    HelpUri='https://methodsandpractices.github.io/vsteam-docs/docs/modules/vsteam/commands/Update-VSTeamWorkItemTag')]
+   Param(
+      [Parameter(Mandatory = $true, ValueFromPipelineByPropertyName = $true)]
+      [string] $TagIdOrName,
+
+      [switch] $Force,
+
+      [Parameter(Mandatory = $true, ValueFromPipelineByPropertyName = $true)]
+      [vsteam_lib.ProjectValidateAttribute($false)]
+      [ArgumentCompleter([vsteam_lib.ProjectCompleter])]
+      [string] $ProjectName
+   )
+
+   process {
+      if ($Force -or $pscmdlet.ShouldProcess($Id, "Update Work Item Tag")) {
+         $resp = _callAPI -Method PATCH -ProjectName $ProjectName `
+            -Area wit `
+            -Resource tags `
+            -Id $TagIdOrName `
+            -Body $body `
+            -Version $(_getApiVersion WorkItemTracking)
+
+         Write-Output $resp
+      }
+   }
+}

--- a/Tests/SampleFiles/Get-VSTeamWorkItemTag.json
+++ b/Tests/SampleFiles/Get-VSTeamWorkItemTag.json
@@ -1,0 +1,12 @@
+{
+   "count": 2,
+   "value": [{
+      "id": "fd3e6a65-7c0e-4603-8fcd-b9ef83802be5",
+      "name": "NewTagName",
+      "url": "https://dev.azure.com/myOrg/60379aa7-e8ee-45c3-ab98-74824f2f6d22/_apis/wit/tags/fd3e6a65-7c0e-4603-8fcd-b9ef83802be5"
+   }, {
+      "id": "5090a9ee-a6fa-4b46-9348-3c9fc8e26ebf",
+      "name": "tag2",
+      "url": "https://dev.azure.com/myOrg/60379aa7-e8ee-45c3-ab98-74824f2f6d22/_apis/wit/tags/5090a9ee-a6fa-4b46-9348-3c9fc8e26ebf"
+   }]
+}

--- a/Tests/function/tests/Add-VSTeamProfile.Tests.ps1
+++ b/Tests/function/tests/Add-VSTeamProfile.Tests.ps1
@@ -69,7 +69,7 @@ Describe 'VSTeamProfile' {
       }
    }
 
-   Context 'Add-VSTeamProfile TFS default to TFS2017 with Windows Auth' {
+   Context 'Add-VSTeamProfile TFS defaults to TFS2017 with Windows Auth' {
       BeforeAll {
          Mock _isOnWindows { return $true }
          Mock Get-VSTeamProfile { return '[{"Name":"test","URL":"https://dev.azure.com/test/","Type":"Pat","Pat":"12345","Version":"VSTS"}]' | ConvertFrom-Json | ForEach-Object { $_ } }
@@ -84,7 +84,7 @@ Describe 'VSTeamProfile' {
       }
    }
 
-   Context 'Add-VSTeamProfile TFS default to TFS2017' {
+   Context 'Add-VSTeamProfile TFS defaults to TFS2017' {
       BeforeAll {
          Mock Get-VSTeamProfile { return '[{"Name":"test","URL":"https://dev.azure.com/test/","Type":"Pat","Pat":"12345","Version":"VSTS"}]' | ConvertFrom-Json | ForEach-Object { $_ } }
       }

--- a/Tests/function/tests/Get-VSTeamWiql.Tests.ps1
+++ b/Tests/function/tests/Get-VSTeamWiql.Tests.ps1
@@ -114,7 +114,7 @@ Describe 'VSTeamWiql' {
       }
 
       It 'Get work items with query that returns only 1 work item and Expand' {
-         Mock Invoke-RestMethod { Write-Host $args; Open-SampleFile 'Get-VSTeamWiql-OneWorkItem.json' }
+         Mock Invoke-RestMethod { Open-SampleFile 'Get-VSTeamWiql-OneWorkItem.json' }
 
          Get-VSTeamWiql -ProjectName "test" -Team "test team" -Id 1 -Expand
 

--- a/Tests/function/tests/Get-VSTeamWorkItemTag.Tests.ps1
+++ b/Tests/function/tests/Get-VSTeamWorkItemTag.Tests.ps1
@@ -1,0 +1,59 @@
+Set-StrictMode -Version Latest
+
+Describe 'VSTeamWorkItemTag' {
+   BeforeAll {
+      $FakeOrg = 'myOrg'           
+      
+      . "$PSScriptRoot\_testInitialize.ps1" $PSCommandPath
+      
+      Mock _getInstance { return "https://dev.azure.com/$($FakeOrg)" }      
+      Mock _getApiVersion { return '1.0-unitTests' } -ParameterFilter { $Service -eq 'Work Item Tracking' }
+   }
+
+   Context 'Get-VSTeamWorkItemTag' {
+      BeforeAll {
+         $FakeProject = 'project'
+         $FakeId = 1111
+         $FakeName = 'tagName'
+
+         Mock Invoke-RestMethod { Open-SampleFile 'Get-VSTeamWorkItemTag.json' }
+         Mock Invoke-RestMethod { Open-SampleFile 'Get-VSTeamWorkItemTag.json' -Index 0 } -ParameterFilter { 
+            $Uri -like "*$FakeName*" 
+         }
+         Mock Invoke-RestMethod { Open-SampleFile 'Get-VSTeamWorkItemTag.json' -Index 0 } -ParameterFilter { 
+            $Uri -like "*$FakeId*" 
+         }
+      }
+      
+      It 'Project name parameter should return all work item tags for the selected project' {
+         ## Act
+         Get-VSTeamWorkItemTag -projectName $FakeProject
+
+         ## Assert
+         Should -Invoke Invoke-RestMethod -Exactly -Times 1 -Scope It -ParameterFilter {
+            $Uri -eq "https://dev.azure.com/$($FakeOrg)/$($FakeProject)/_apis/wit/tags?api-version=$(_getApiVersion Work Item Tracking)"            
+         }
+      }      
+
+      It 'Passing a name should return work item tag details' {
+         ## Act
+         Get-VSTeamWorkItemTag -projectName $FakeProject -name $FakeName
+
+         ## Assert
+         Should -Invoke Invoke-RestMethod -Exactly -Times 1 -Scope It -ParameterFilter {
+            $Uri -eq "https://dev.azure.com/$($FakeOrg)/$($FakeProject)/_apis/wit/tags/$($FakeName)?api-version=$(_getApiVersion Work Item Tracking)"           
+         }
+      }
+
+      It 'Passing an Id should return work item tag details' {
+         $FakeId = 1111
+         ## Act
+         Get-VSTeamWorkItemTag -projectName $FakeProject -id $FakeId
+
+         ## Assert
+         Should -Invoke Invoke-RestMethod -Exactly -Times 1 -Scope It -ParameterFilter {
+            $Uri -eq "https://dev.azure.com/$($FakeOrg)/$($FakeProject)/_apis/wit/tags/$($FakeId)?api-version=$(_getApiVersion Work Item Tracking)"           
+         }
+      }
+   }
+}

--- a/Tests/function/tests/Get-VSTeamWorkItemTag.Tests.ps1
+++ b/Tests/function/tests/Get-VSTeamWorkItemTag.Tests.ps1
@@ -2,12 +2,12 @@ Set-StrictMode -Version Latest
 
 Describe 'VSTeamWorkItemTag' {
    BeforeAll {
-      $FakeOrg = 'myOrg'           
-      
+      $FakeOrg = 'myOrg'
+
       . "$PSScriptRoot\_testInitialize.ps1" $PSCommandPath
-      
-      Mock _getInstance { return "https://dev.azure.com/$($FakeOrg)" }      
-      Mock _getApiVersion { return '1.0-unitTests' } -ParameterFilter { $Service -eq 'Work Item Tracking' }
+
+      Mock _getInstance { return "https://dev.azure.com/$($FakeOrg)" }
+      Mock _getApiVersion { return '1.0-unitTests' } -ParameterFilter { $Service -eq 'WorkItemTracking' }
    }
 
    Context 'Get-VSTeamWorkItemTag' {
@@ -17,23 +17,23 @@ Describe 'VSTeamWorkItemTag' {
          $FakeName = 'tagName'
 
          Mock Invoke-RestMethod { Open-SampleFile 'Get-VSTeamWorkItemTag.json' }
-         Mock Invoke-RestMethod { Open-SampleFile 'Get-VSTeamWorkItemTag.json' -Index 0 } -ParameterFilter { 
-            $Uri -like "*$FakeName*" 
+         Mock Invoke-RestMethod { Open-SampleFile 'Get-VSTeamWorkItemTag.json' -Index 0 } -ParameterFilter {
+            $Uri -like "*$FakeName*"
          }
-         Mock Invoke-RestMethod { Open-SampleFile 'Get-VSTeamWorkItemTag.json' -Index 0 } -ParameterFilter { 
-            $Uri -like "*$FakeId*" 
+         Mock Invoke-RestMethod { Open-SampleFile 'Get-VSTeamWorkItemTag.json' -Index 0 } -ParameterFilter {
+            $Uri -like "*$FakeId*"
          }
       }
-      
+
       It 'Project name parameter should return all work item tags for the selected project' {
          ## Act
          Get-VSTeamWorkItemTag -ProjectName $FakeProject
 
          ## Assert
          Should -Invoke Invoke-RestMethod -Exactly -Times 1 -Scope It -ParameterFilter {
-            $Uri -eq "https://dev.azure.com/$($FakeOrg)/$($FakeProject)/_apis/wit/tags?api-version=$(_getApiVersion Work Item Tracking)"            
+            $Uri -eq "https://dev.azure.com/$($FakeOrg)/$($FakeProject)/_apis/wit/tags?api-version=$(_getApiVersion WorkItemTracking)"
          }
-      }      
+      }
 
       It 'Passing a name should return work item tag details' {
          ## Act
@@ -41,7 +41,7 @@ Describe 'VSTeamWorkItemTag' {
 
          ## Assert
          Should -Invoke Invoke-RestMethod -Exactly -Times 1 -Scope It -ParameterFilter {
-            $Uri -eq "https://dev.azure.com/$($FakeOrg)/$($FakeProject)/_apis/wit/tags/$($FakeName)?api-version=$(_getApiVersion Work Item Tracking)"           
+            $Uri -eq "https://dev.azure.com/$($FakeOrg)/$($FakeProject)/_apis/wit/tags/$($FakeName)?api-version=$(_getApiVersion WorkItemTracking)"
          }
       }
 
@@ -52,7 +52,7 @@ Describe 'VSTeamWorkItemTag' {
 
          ## Assert
          Should -Invoke Invoke-RestMethod -Exactly -Times 1 -Scope It -ParameterFilter {
-            $Uri -eq "https://dev.azure.com/$($FakeOrg)/$($FakeProject)/_apis/wit/tags/$($FakeId)?api-version=$(_getApiVersion Work Item Tracking)"           
+            $Uri -eq "https://dev.azure.com/$($FakeOrg)/$($FakeProject)/_apis/wit/tags/$($FakeId)?api-version=$(_getApiVersion WorkItemTracking)"
          }
       }
    }

--- a/Tests/function/tests/Get-VSTeamWorkItemTag.Tests.ps1
+++ b/Tests/function/tests/Get-VSTeamWorkItemTag.Tests.ps1
@@ -27,7 +27,7 @@ Describe 'VSTeamWorkItemTag' {
       
       It 'Project name parameter should return all work item tags for the selected project' {
          ## Act
-         Get-VSTeamWorkItemTag -projectName $FakeProject
+         Get-VSTeamWorkItemTag -ProjectName $FakeProject
 
          ## Assert
          Should -Invoke Invoke-RestMethod -Exactly -Times 1 -Scope It -ParameterFilter {
@@ -37,7 +37,7 @@ Describe 'VSTeamWorkItemTag' {
 
       It 'Passing a name should return work item tag details' {
          ## Act
-         Get-VSTeamWorkItemTag -projectName $FakeProject -name $FakeName
+         Get-VSTeamWorkItemTag -ProjectName $FakeProject -TagIdOrName $FakeName
 
          ## Assert
          Should -Invoke Invoke-RestMethod -Exactly -Times 1 -Scope It -ParameterFilter {
@@ -48,7 +48,7 @@ Describe 'VSTeamWorkItemTag' {
       It 'Passing an Id should return work item tag details' {
          $FakeId = 1111
          ## Act
-         Get-VSTeamWorkItemTag -projectName $FakeProject -id $FakeId
+         Get-VSTeamWorkItemTag -ProjectName $FakeProject -TagIdOrName $FakeId
 
          ## Assert
          Should -Invoke Invoke-RestMethod -Exactly -Times 1 -Scope It -ParameterFilter {

--- a/Tests/function/tests/Remove-VSTeamPool.Tests.ps1
+++ b/Tests/function/tests/Remove-VSTeamPool.Tests.ps1
@@ -14,7 +14,7 @@ Describe 'VSTeamPool' {
 
    Context 'Remove-VSTeamPool with parameters' {
       BeforeAll {
-         Mock Invoke-RestMethod { Write-Host $ return $null }
+         Mock Invoke-RestMethod { return $null }
       }
 
       it 'with ID should be called' {

--- a/Tests/function/tests/Remove-VSTeamWorkItemTag.Tests.ps1
+++ b/Tests/function/tests/Remove-VSTeamWorkItemTag.Tests.ps1
@@ -26,7 +26,7 @@ Describe 'VSTeamWorkItemTag' {
 
          ## Assert
          Should -Invoke Invoke-RestMethod -Exactly -Times 1 -Scope It -ParameterFilter {
-            $Uri -eq "https://dev.azure.com/$($FakeOrg)/_apis/wit/tags/$($FakeTagId)?api-version=$(_getApiVersion WorkItemTracking)" -and
+            $Uri -eq "https://dev.azure.com/$($FakeOrg)/test/_apis/wit/tags/$($FakeTagId)?api-version=$(_getApiVersion WorkItemTracking)" -and
             $Method -eq 'DELETE'
          }
       }
@@ -37,7 +37,7 @@ Describe 'VSTeamWorkItemTag' {
 
          ## Assert
          Should -Invoke Invoke-RestMethod -Exactly -Times 1 -Scope It -ParameterFilter {
-            $Uri -eq "https://dev.azure.com/$($FakeOrg)/_apis/wit/tags/$($FakeTagName)?api-version=$(_getApiVersion WorkItemTracking)"  -and
+            $Uri -eq "https://dev.azure.com/$($FakeOrg)/test/_apis/wit/tags/$($FakeTagName)?api-version=$(_getApiVersion WorkItemTracking)"  -and
             $Method -eq 'DELETE'
          }
       }

--- a/Tests/function/tests/Remove-VSTeamWorkItemTag.Tests.ps1
+++ b/Tests/function/tests/Remove-VSTeamWorkItemTag.Tests.ps1
@@ -1,0 +1,45 @@
+Set-StrictMode -Version Latest
+
+Describe 'VSTeamWorkItemTag' {
+   BeforeAll {
+      $FakeOrg = 'myOrg'           
+      
+      . "$PSScriptRoot\_testInitialize.ps1" $PSCommandPath
+      
+      Mock _getInstance { return "https://dev.azure.com/$($FakeOrg)" }      
+      Mock _getApiVersion { return '1.0-unitTests' } -ParameterFilter { $Service -eq 'Work Item Tracking' }
+      Mock Get-VSTeamProject {return Open-SampleFile 'Get-VSTeamProject.json' }            
+   }
+
+   Context 'Remove-VSTeamWorkItemTag' {
+      BeforeAll {
+         $FakeProjectName = 'test'
+         $FakeTagId = '00000000-0000-0000-0000-000000000000'         
+         $FakeTagName = 'myTag'         
+         
+         #TODO
+      }
+      
+      It 'remove by id, should remove tag' {
+         ## Act                  
+         Remove-VSTeamWorkItemTag -ProjectName $FakeProjectName -TagIdOrName $FakeTagId
+         
+         ## Assert
+         Should -Invoke Invoke-RestMethod -Exactly -Times 1 -Scope It -ParameterFilter {
+            $Uri -eq "https://dev.azure.com/$($FakeOrg)/_apis/wit/tags/$($FakeCodeWikiId)?api-version=$(_getApiVersion Work Item Tracking)"  -and
+            $Method -eq 'DELETE' 
+         }
+      }
+
+      It 'remove by name, should remove tag' {
+         ## Act                  
+         Remove-VSTeamWorkItemTag -ProjectName $FakeProjectName -TagIdOrName $FakeTagName
+         
+         ## Assert
+         Should -Invoke Invoke-RestMethod -Exactly -Times 1 -Scope It -ParameterFilter {
+            $Uri -eq "https://dev.azure.com/$($FakeOrg)/_apis/wit/tags/$($FakeCodeWikiId)?api-version=$(_getApiVersion Work Item Tracking)"  -and
+            $Method -eq 'DELETE' 
+         }
+      }
+   }
+}

--- a/Tests/function/tests/Remove-VSTeamWorkItemTag.Tests.ps1
+++ b/Tests/function/tests/Remove-VSTeamWorkItemTag.Tests.ps1
@@ -2,49 +2,43 @@ Set-StrictMode -Version Latest
 
 Describe 'VSTeamWorkItemTag' {
    BeforeAll {
-      $FakeOrg = 'myOrg'           
-      
+      $FakeOrg = 'myOrg'
+
       . "$PSScriptRoot\_testInitialize.ps1" $PSCommandPath
-      
-      Mock _getInstance { return "https://dev.azure.com/$($FakeOrg)" }      
-      Mock _getApiVersion { return '1.0-unitTests' } -ParameterFilter { $Service -eq 'Work Item Tracking' }
-      Mock Get-VSTeamProject {return Open-SampleFile 'Get-VSTeamProject.json' }            
+
+      Mock _getInstance { return "https://dev.azure.com/$($FakeOrg)" }
+      Mock _getApiVersion { return '1.0-unitTests' } -ParameterFilter { $Service -eq 'WorkItemTracking' }
+      Mock Get-VSTeamProject {return Open-SampleFile 'Get-VSTeamProject.json' }
    }
 
    Context 'Remove-VSTeamWorkItemTag' {
       BeforeAll {
          $FakeProjectName = 'test'
-         $FakeTagId = '00000000-0000-0000-0000-000000000000'   
+         $FakeTagId = '00000000-0000-0000-0000-000000000000'
          $FakeTagName = 'myTag'
 
-         Mock Invoke-RestMethod { Open-SampleFile 'Get-VSTeamWorkItemTag.json' }
-         Mock Invoke-RestMethod { Open-SampleFile 'Get-VSTeamWorkItemTag.json' -Index 0 } -ParameterFilter { 
-            $Uri -like "*$FakeName*" 
-         }
-         Mock Invoke-RestMethod { Open-SampleFile 'Get-VSTeamWorkItemTag.json' -Index 0 } -ParameterFilter { 
-            $Uri -like "*$FakeId*" 
-         }
+         Mock Invoke-RestMethod { return $null }
       }
-      
+
       It 'remove by id, should remove tag' {
-         ## Act                  
-         Remove-VSTeamWorkItemTag -ProjectName $FakeProjectName -TagIdOrName $FakeTagId
-         
+         ## Act
+         Remove-VSTeamWorkItemTag -ProjectName $FakeProjectName -TagIdOrName $FakeTagId -Confirm:$False
+
          ## Assert
          Should -Invoke Invoke-RestMethod -Exactly -Times 1 -Scope It -ParameterFilter {
-            $Uri -eq "https://dev.azure.com/$($FakeOrg)/_apis/wit/tags/$($FakeTagId)?api-version=$(_getApiVersion Work Item Tracking)"  -and
-            $Method -eq 'DELETE' 
+            $Uri -eq "https://dev.azure.com/$($FakeOrg)/_apis/wit/tags/$($FakeTagId)?api-version=$(_getApiVersion WorkItemTracking)" -and
+            $Method -eq 'DELETE'
          }
       }
 
       It 'remove by name, should remove tag' {
-         ## Act                  
-         Remove-VSTeamWorkItemTag -ProjectName $FakeProjectName -TagIdOrName $FakeTagName
-         
+         ## Act
+         Remove-VSTeamWorkItemTag -ProjectName $FakeProjectName -TagIdOrName $FakeTagName -Confirm:$False
+
          ## Assert
          Should -Invoke Invoke-RestMethod -Exactly -Times 1 -Scope It -ParameterFilter {
-            $Uri -eq "https://dev.azure.com/$($FakeOrg)/_apis/wit/tags/$($FakeTagName)?api-version=$(_getApiVersion Work Item Tracking)"  -and
-            $Method -eq 'DELETE' 
+            $Uri -eq "https://dev.azure.com/$($FakeOrg)/_apis/wit/tags/$($FakeTagName)?api-version=$(_getApiVersion WorkItemTracking)"  -and
+            $Method -eq 'DELETE'
          }
       }
    }

--- a/Tests/function/tests/Remove-VSTeamWorkItemTag.Tests.ps1
+++ b/Tests/function/tests/Remove-VSTeamWorkItemTag.Tests.ps1
@@ -14,10 +14,8 @@ Describe 'VSTeamWorkItemTag' {
    Context 'Remove-VSTeamWorkItemTag' {
       BeforeAll {
          $FakeProjectName = 'test'
-         $FakeTagId = '00000000-0000-0000-0000-000000000000'         
-         $FakeTagName = 'myTag'         
-         
-         #TODO
+         $FakeTagId = '00000000-0000-0000-0000-000000000000'   
+         $FakeTagName = 'myTag'
       }
       
       It 'remove by id, should remove tag' {
@@ -26,7 +24,7 @@ Describe 'VSTeamWorkItemTag' {
          
          ## Assert
          Should -Invoke Invoke-RestMethod -Exactly -Times 1 -Scope It -ParameterFilter {
-            $Uri -eq "https://dev.azure.com/$($FakeOrg)/_apis/wit/tags/$($FakeCodeWikiId)?api-version=$(_getApiVersion Work Item Tracking)"  -and
+            $Uri -eq "https://dev.azure.com/$($FakeOrg)/_apis/wit/tags/$($FakeTagId)?api-version=$(_getApiVersion Work Item Tracking)"  -and
             $Method -eq 'DELETE' 
          }
       }
@@ -37,7 +35,7 @@ Describe 'VSTeamWorkItemTag' {
          
          ## Assert
          Should -Invoke Invoke-RestMethod -Exactly -Times 1 -Scope It -ParameterFilter {
-            $Uri -eq "https://dev.azure.com/$($FakeOrg)/_apis/wit/tags/$($FakeCodeWikiId)?api-version=$(_getApiVersion Work Item Tracking)"  -and
+            $Uri -eq "https://dev.azure.com/$($FakeOrg)/_apis/wit/tags/$($FakeTagName)?api-version=$(_getApiVersion Work Item Tracking)"  -and
             $Method -eq 'DELETE' 
          }
       }

--- a/Tests/function/tests/Remove-VSTeamWorkItemTag.Tests.ps1
+++ b/Tests/function/tests/Remove-VSTeamWorkItemTag.Tests.ps1
@@ -16,6 +16,14 @@ Describe 'VSTeamWorkItemTag' {
          $FakeProjectName = 'test'
          $FakeTagId = '00000000-0000-0000-0000-000000000000'   
          $FakeTagName = 'myTag'
+
+         Mock Invoke-RestMethod { Open-SampleFile 'Get-VSTeamWorkItemTag.json' }
+         Mock Invoke-RestMethod { Open-SampleFile 'Get-VSTeamWorkItemTag.json' -Index 0 } -ParameterFilter { 
+            $Uri -like "*$FakeName*" 
+         }
+         Mock Invoke-RestMethod { Open-SampleFile 'Get-VSTeamWorkItemTag.json' -Index 0 } -ParameterFilter { 
+            $Uri -like "*$FakeId*" 
+         }
       }
       
       It 'remove by id, should remove tag' {

--- a/Tests/function/tests/Set-VSTeamAccount.Tests.ps1
+++ b/Tests/function/tests/Set-VSTeamAccount.Tests.ps1
@@ -13,7 +13,7 @@ Describe 'VSTeamAccount' {
       Remove-VSTeamAccount
    }
 
-   Context 'You cannot use -UseWindowsAuthentication with Azd' {
+   Context 'You cannot use -UseWindowsAuthentication with AzD' {
       BeforeAll {
          # This is only supported on a Windows machine. So we have
          # to Mock the call to _isOnWindows so you can develop on a

--- a/Tests/function/tests/Update-VSTeamWorkItemTag.Tests.ps1
+++ b/Tests/function/tests/Update-VSTeamWorkItemTag.Tests.ps1
@@ -10,7 +10,7 @@ Describe "VSTeamWorkItemTag" {
       Context "services" {
          BeforeAll {
             Mock _getInstance { return 'https://dev.azure.com/test' }
-            Mock _getApiVersion { return '1.0-unitTests' } -ParameterFilter { $Service -eq 'Work Item Tracking' }
+            Mock _getApiVersion { return '1.0-unitTests' } -ParameterFilter { $Service -eq 'WorkItemTracking' }
             Mock Invoke-RestMethod { Open-SampleFile 'Get-VSTeamWorkItemTag.json' -Index 0 }
             Mock Get-VSTeam { return New-Object -TypeName PSObject -Prop @{
                   projectname = "TestProject"
@@ -20,8 +20,6 @@ Describe "VSTeamWorkItemTag" {
          }
 
          It 'Should update the tag with new tag name' {
-            ## Arrange
-            $expectedBody = '{ "name": "NewTagName" }'
 
             ## Act
             $tag = Update-VSTeamWorkItemTag -ProjectName "TestProject" -TagIdOrName "OldTagName" -NewTagName "NewTagName"
@@ -30,9 +28,9 @@ Describe "VSTeamWorkItemTag" {
             $tag.Name | Should -Be 'NewTagName' -Because 'Name should be set'
 
             Should -Invoke Invoke-RestMethod -Exactly 1 -ParameterFilter {
-               $Uri -eq "https://dev.azure.com/test/_apis/wit/tags/OldTagName?api-version=$(_getApiVersion Work Item Tracking)" -and
+               $Uri -eq "https://dev.azure.com/test/TestProject/_apis/wit/tags/OldTagName?api-version=$(_getApiVersion WorkItemTracking)" -and
                $Method -eq "Patch" -and
-               $Body -eq $expectedBody
+               $Body -like '*NewTagName*'
             }
          }
       }

--- a/Tests/function/tests/Update-VSTeamWorkItemTag.Tests.ps1
+++ b/Tests/function/tests/Update-VSTeamWorkItemTag.Tests.ps1
@@ -14,7 +14,7 @@ Describe "VSTeamWorkItemTag" {
             Mock Invoke-RestMethod { Open-SampleFile 'Get-VSTeamWorkItemTag.json' -Index 0 }
             Mock Get-VSTeam { return New-Object -TypeName PSObject -Prop @{
                   projectname = "TestProject"
-                  name        = "OldTeamName"
+                  name        = "OldTagName"
                }
             }
          }
@@ -24,10 +24,10 @@ Describe "VSTeamWorkItemTag" {
             $expectedBody = '{ "name": "NewTagName" }'
 
             ## Act
-            $team = Update-VSTeam -ProjectName Test -TeamToUpdate "OldTagName" -NewTeamName "NewTagName"
+            $tag = Update-VSTeamWorkItemTag -ProjectName "TestProject" -TagIdOrName "OldTagName" -NewTagName "NewTagName"
 
             ## Assert
-            $team.Name | Should -Be 'Test Team' -Because 'Name should be set'
+            $tag.Name | Should -Be 'NewTagName' -Because 'Name should be set'
 
             Should -Invoke Invoke-RestMethod -Exactly 1 -ParameterFilter {
                $Uri -eq "https://dev.azure.com/test/_apis/wit/tags/OldTagName?api-version=$(_getApiVersion Work Item Tracking)" -and

--- a/Tests/function/tests/Update-VSTeamWorkItemTag.ps1
+++ b/Tests/function/tests/Update-VSTeamWorkItemTag.ps1
@@ -1,0 +1,40 @@
+Set-StrictMode -Version Latest
+
+Describe "VSTeamWorkItemTag" {
+   BeforeAll {
+      . "$PSScriptRoot\_testInitialize.ps1" $PSCommandPath
+      . "$baseFolder/Source/Public/Get-VSTeam.ps1"
+   }
+
+   Context "Update-VSTeamWorkItemTag" {
+      Context "services" {
+         BeforeAll {
+            Mock _getInstance { return 'https://dev.azure.com/test' }
+            Mock _getApiVersion { return '1.0-unitTests' } -ParameterFilter { $Service -eq 'Work Item Tracking' }
+            Mock Invoke-RestMethod { Open-SampleFile 'Get-VSTeamWorkItemTag.json' -Index 0 }
+            Mock Get-VSTeam { return New-Object -TypeName PSObject -Prop @{
+                  projectname = "TestProject"
+                  name        = "OldTeamName"
+               }
+            }
+         }
+
+         It 'Should update the tag with new tag name' {
+            ## Arrange
+            $expectedBody = '{ "name": "NewTagName" }'
+
+            ## Act
+            $team = Update-VSTeam -ProjectName Test -TeamToUpdate "OldTagName" -NewTeamName "NewTagName"
+
+            ## Assert
+            $team.Name | Should -Be 'Test Team' -Because 'Name should be set'
+
+            Should -Invoke Invoke-RestMethod -Exactly 1 -ParameterFilter {
+               $Uri -eq "https://dev.azure.com/test/_apis/wit/tags/OldTagName?api-version=$(_getApiVersion Work Item Tracking)" -and
+               $Method -eq "Patch" -and
+               $Body -eq $expectedBody
+            }
+         }
+      }
+   }
+}


### PR DESCRIPTION
# PR Summary

Fixed casing and a couple of minor typos.

_Update by Maintainer (@SebastianSchuetze): New cmdlets where added by @smholvoet_

## Suggestion

Another suggestion (which I have not yet pushed to my branch) is reworking the **Notes** section. I personally think it's very annoying seeing relevant cmdlets mentioned there, which are not clickable. Granted, they are mentioned a bit further down in the **Related links** section, but I think making the cmdlets clickable in the **Notes** section prevents a user from having to scroll further down and find the exact cmdlet he was looking for in a list of (sometimes) _many_ more cmdlets:

![image](https://user-images.githubusercontent.com/13507392/133841208-ab3965b5-aa35-4855-81cf-25fe84f87422.png)

I've noticed some cmdlets have related links which get added below the cmdlets which are displayed through the [prerequisites.md ](https://github.com/MethodsAndPractices/vsteam/blob/trunk/.docs/common/prerequisites.md)file, for example [Update-VSTeamPolicy](https://github.com/MethodsAndPractices/vsteam/blob/a5d2ebebe8277861904c71229c31ddd6a02f7fe9/.docs/Update-VSTeamPolicy.md), which I think is very useful.

In summary:

- Remove `<!-- #include "./common/related.md" -->` from the Related links section
- Rework the Notes section to include link, making things easier for users

Let me know what you think and I'll push additional changes to this branch should you agree with the above suggestion.

## PR Checklist

- [ ] [Write Help](https://github.com/DarqueWarrior/vsteam/blob/master/.github/CONTRIBUTING.md#write-help)
- [ ] [Write Unit Test](https://github.com/DarqueWarrior/vsteam/blob/master/.github/CONTRIBUTING.md#write-unit-test)
- [ ] [Update CHANGELOG.md](https://github.com/DarqueWarrior/vsteam/blob/master/.github/CONTRIBUTING.md#update-changelogmd)

