### PR TITLE
Local Nuget Feed Workaround

### DIFF
--- a/.github/workflows/actions-pipeline.yml
+++ b/.github/workflows/actions-pipeline.yml
@@ -190,30 +190,35 @@ jobs:
         Write-Host "create temp path"
         New-Item -Path "$env:TEMP\InstallModuleWorkaround" -Type Directory | Out-Null
         New-Item -Path "$env:TEMP\InstallModuleWorkaround\repo" -Type Directory | Out-Null
-        Set-Location -Path "$env:TEMP\InstallModuleWorkaround"
+        # Set-Location -Path "$env:TEMP\InstallModuleWorkaround"
+        
+        # dotnet nuget add source --username USERNAME --password ${{ secrets.GITHUB_TOKEN }} --store-password-in-clear-text --name github $GitHubRepoVSTeamUri
+        
+        # Initialize the local nuget feed with local nupkg files
+        nuget init ./module "$env:TEMP\InstallModuleWorkaround"
 
-        dotnet nuget add source --username USERNAME --password ${{ secrets.GITHUB_TOKEN }} --store-password-in-clear-text --name github $GitHubRepoVSTeamUri
-
-        foreach ($ModuleName in $ModuleNames) {
-            nuget install $ModuleName -Source github
-        }
+        Get-ChildItem -Directory "$env:TEMP\InstallModuleWorkaround"
+        
+        # foreach ($ModuleName in $ModuleNames) {
+        #     nuget install $ModuleName -Source github
+        # }
 
         Write-Host "Register-PSRepository------"
         Register-PSRepository -Name "InstallModuleWorkaround" -SourceLocation "$env:TEMP\InstallModuleWorkaround\repo"
         Write-Host "nuget sources add ------"
         nuget sources add -name "InstallModuleWorkaround" -source "$env:TEMP\InstallModuleWorkaround\repo"
 
-        $ModuleFolders = Get-ChildItem -Directory | Where-Object {$_.Name -ne "repo"}
+        # $ModuleFolders = Get-ChildItem -Directory | Where-Object {$_.Name -ne "repo"}
 
-        Write-Host "rename folders ------"
-        foreach ($Folder in $ModuleFolders) {
-            $ShortName = $Folder.Name -replace '(.*)(\.\d+){3,4}', '$1'
-            Move-Item -Path $Folder.Name -Destination $ShortName
-        }
+        # Write-Host "rename folders ------"
+        # foreach ($Folder in $ModuleFolders) {
+        #     $ShortName = $Folder.Name -replace '(.*)(\.\d+){3,4}', '$1'
+        #     Move-Item -Path $Folder.Name -Destination $ShortName
+        # }
 
         Write-Host "publish and install ------"
         foreach ($ModuleName in $ModuleNames) {
-            Publish-Module -Path $ModuleName -Repository "InstallModuleWorkaround"
+            # Publish-Module -Path $ModuleName -Repository "InstallModuleWorkaround"
             Install-Module -Name $ModuleName -Repository "InstallModuleWorkaround" -AllowClobber -SkipPublisherCheck -Force -Scope CurrentUser
         }
 

--- a/.github/workflows/actions-pipeline.yml
+++ b/.github/workflows/actions-pipeline.yml
@@ -257,8 +257,6 @@ jobs:
             Install-Module -Name $ModuleName -Repository "InstallModuleWorkaround" -AllowClobber -SkipPublisherCheck -Force -Scope CurrentUser
         }
 
-        Remove-Item -Path "$env:TEMP\InstallModuleWorkaround" -Recurse -Force
-
         nuget sources remove -name "LocalNugetSource"
         Unregister-PSRepository -Name "InstallModuleWorkaround"
 

--- a/.github/workflows/actions-pipeline.yml
+++ b/.github/workflows/actions-pipeline.yml
@@ -188,6 +188,7 @@ jobs:
       uses: actions/download-artifact@v2
       with:
         name: test
+        path: ./test
 
     - name: Install module
       shell: pwsh

--- a/.github/workflows/actions-pipeline.yml
+++ b/.github/workflows/actions-pipeline.yml
@@ -257,7 +257,6 @@ jobs:
             Install-Module -Name $ModuleName -Repository "InstallModuleWorkaround" -AllowClobber -SkipPublisherCheck -Force -Scope CurrentUser
         }
 
-        Set-Location -Path "$env:TEMP"
         Remove-Item -Path "$env:TEMP\InstallModuleWorkaround" -Recurse -Force
 
         nuget sources remove -name "LocalNugetSource"
@@ -283,6 +282,7 @@ jobs:
 
     - name: Run Integration Tests
       run: |
+        Get-ChildItem ./test
         $env:ACCT='razorspoint-vsteamtests'
         $env:PAT='62hpgojrrkmx7rcoxyhzvag2ztkn2uk6fyh5w4x533pxjpcn6spq'
 

--- a/.github/workflows/actions-pipeline.yml
+++ b/.github/workflows/actions-pipeline.yml
@@ -291,11 +291,11 @@ jobs:
         $pesterArgs = [PesterConfiguration]::Default
         $pesterArgs.Run.Exit = $true
         $pesterArgs.Run.PassThru = $true
+        $pesterArgs.Run.Path = './test/integration/*'
         $pesterArgs.Output.Verbosity = "Detailed"
         $pesterArgs.TestResult.Enabled = $true
         $pesterArgs.TestResult.OutputFormat = 'JUnitXml'
         $pesterArgs.TestResult.OutputPath = 'test-results.xml'
-        $pesterArgs.Path = './test/integration/*'
 
         Invoke-Pester -Configuration $pesterArgs
       shell: pwsh

--- a/.github/workflows/actions-pipeline.yml
+++ b/.github/workflows/actions-pipeline.yml
@@ -134,7 +134,11 @@ jobs:
         # Load the psd1 file so you can read the version
         $manifest = Import-PowerShellDataFile ./dist/*.psd1
 
-        $package_version = "$($manifest.ModuleVersion).${{ github.run_number }}"
+        # load as semantic version
+        [version]$sem_version = $manifest.ModuleVersion
+        
+        # Build new semantic version with build number
+        $package_version = "$($sem_version.Major).$($sem_version.Minor).${{ github.run_number }}"
 
         Write-Host "Package Version Number: $package_version"
 
@@ -156,7 +160,7 @@ jobs:
 
         dotnet tool install gpr -g
 
-        gpr push ./dist/*.nupkg -k ${{secrets.GITHUB_TOKEN}} --repository MethodsAndPractices/vsteam
+        # gpr push ./dist/*.nupkg -k ${{secrets.GITHUB_TOKEN}} --repository MethodsAndPractices/vsteam
 
     - name: Upload nuget package as artifact
       uses: actions/upload-artifact@v2
@@ -184,48 +188,74 @@ jobs:
     - name: Install module
       shell: pwsh
       run: |
+        # Install Module Dependencies
+        Install-Module -Name SHiPS -Force
+        Install-Module -Name Trackyon.Utils -Force
+
+        # Import required modules
+        Import-Module -Name SHiPS
+        Import-Module -Name Trackyon.Utils
+
         $ModuleNames = @("VSTeam")
         $GitHubRepoVSTeamUri = "https://nuget.pkg.github.com/MethodsAndPractices/vsteam/index.json"
 
-        Write-Host "create temp path"
-        New-Item -Path "$env:TEMP\InstallModuleWorkaround" -Type Directory | Out-Null
-        New-Item -Path "$env:TEMP\InstallModuleWorkaround\repo" -Type Directory | Out-Null
-        # Set-Location -Path "$env:TEMP\InstallModuleWorkaround"
-        
-        # dotnet nuget add source --username USERNAME --password ${{ secrets.GITHUB_TOKEN }} --store-password-in-clear-text --name github $GitHubRepoVSTeamUri
-        
-        # Initialize the local nuget feed with local nupkg files
-        nuget init ./module "$env:TEMP\InstallModuleWorkaround"
+        Write-Host "create temp path for Nuget feed"
+        New-Item -Path "$env:TEMP\InstallModuleWorkaround\nuget" -Type Directory | Out-Null
 
-        Get-ChildItem -Directory "$env:TEMP\InstallModuleWorkaround"
+        Write-Host "create temp path for Powershell Module Repo"
+        New-Item -Path "$env:TEMP\InstallModuleWorkaround\repo" -Type Directory | Out-Null
         
-        # foreach ($ModuleName in $ModuleNames) {
-        #     nuget install $ModuleName -Source github
-        # }
+        Write-Host "create temp path for Nuget Install"
+        New-Item -Path "$env:TEMP\InstallModuleWorkaround\install" -Type Directory | Out-Null
+
+        # Local Nuget since I do not have access to github nuget
+        # Initialize the local nuget feed with local nupkg files
+        nuget init ./module "$env:TEMP\InstallModuleWorkaround\nuget"
+
+        # Add Nuget Source
+        # dotnet nuget add source --username USERNAME --password ${{ secrets.GITHUB_TOKEN }} --store-password-in-clear-text --name github $GitHubRepoVSTeamUri
+        Write-Host "nuget sources add ------"
+        nuget sources Add -Name "LocalNugetSource" -Source "$env:TEMP\InstallModuleWorkaround\nuget"
+        nuget sources Add -Name "PSGallery" -Source 'https://www.powershellgallery.com/api/v2/'
+
+        # install Dependencies
+        nuget install SHiPS -Source "PSGallery" -OutputDirectory "$env:TEMP\InstallModuleWorkaround\install"
+        nuget install Trackyon.Utils -Source "PSGallery" -OutputDirectory "$env:TEMP\InstallModuleWorkaround\install"
+
+        # Add Dependencies to local nuget feed as these Dependencies are specified as not external
+        nuget init $env:TEMP\InstallModuleWorkaround\install "$env:TEMP\InstallModuleWorkaround\nuget"
+
+        foreach ($ModuleName in $ModuleNames) {
+            # $feedName = "github"
+            $feedName = "LocalNugetSource"
+            nuget install $ModuleName -Source $feedName -OutputDirectory "$env:TEMP\InstallModuleWorkaround\install"
+        }
+
+        $ModuleFolders = Get-ChildItem "$env:TEMP\InstallModuleWorkaround\install" -Directory
+        Write-Host "rename folders ------"
+        Set-Location -Path "$env:TEMP\InstallModuleWorkaround\install"
+        foreach ($Folder in $ModuleFolders) {
+            $ShortName = $Folder.Name -replace '(.*)(\.\d+){3,4}', '$1'
+            Move-Item -Path $Folder.Name -Destination $ShortName
+        }
 
         Write-Host "Register-PSRepository------"
         Register-PSRepository -Name "InstallModuleWorkaround" -SourceLocation "$env:TEMP\InstallModuleWorkaround\repo"
-        Write-Host "nuget sources add ------"
-        nuget sources add -name "InstallModuleWorkaround" -source "$env:TEMP\InstallModuleWorkaround\repo"
 
-        # $ModuleFolders = Get-ChildItem -Directory | Where-Object {$_.Name -ne "repo"}
-
-        # Write-Host "rename folders ------"
-        # foreach ($Folder in $ModuleFolders) {
-        #     $ShortName = $Folder.Name -replace '(.*)(\.\d+){3,4}', '$1'
-        #     Move-Item -Path $Folder.Name -Destination $ShortName
-        # }
+        # Install Dependencies
+        Publish-Module -Path $env:TEMP\InstallModuleWorkaround\install\SHiPS   -Repository "InstallModuleWorkaround"  
+        Publish-Module -Path $env:TEMP\InstallModuleWorkaround\install\Trackyon.Utils   -Repository "InstallModuleWorkaround"
 
         Write-Host "publish and install ------"
         foreach ($ModuleName in $ModuleNames) {
-            # Publish-Module -Path $ModuleName -Repository "InstallModuleWorkaround"
+            Publish-Module -Path $env:TEMP\InstallModuleWorkaround\install\$ModuleName -Repository "InstallModuleWorkaround"
             Install-Module -Name $ModuleName -Repository "InstallModuleWorkaround" -AllowClobber -SkipPublisherCheck -Force -Scope CurrentUser
         }
 
         Set-Location -Path "$env:TEMP"
         Remove-Item -Path "$env:TEMP\InstallModuleWorkaround" -Recurse -Force
 
-        nuget sources remove -name "InstallModuleWorkaround"
+        nuget sources remove -name "LocalNugetSource"
         Unregister-PSRepository -Name "InstallModuleWorkaround"
 
     - name: Install module

--- a/.github/workflows/actions-pipeline.yml
+++ b/.github/workflows/actions-pipeline.yml
@@ -295,8 +295,9 @@ jobs:
         $pesterArgs.TestResult.Enabled = $true
         $pesterArgs.TestResult.OutputFormat = 'JUnitXml'
         $pesterArgs.TestResult.OutputPath = 'test-results.xml'
+        $pesterArgs.Path = './test/integration/*'
 
-        Invoke-Pester -Path ./test/integration/* -Configuration $pesterArgs
+        Invoke-Pester -Configuration $pesterArgs
       shell: pwsh
 
     - name: Publish PowerShell test results

--- a/.github/workflows/actions-pipeline.yml
+++ b/.github/workflows/actions-pipeline.yml
@@ -290,7 +290,7 @@ jobs:
         $pesterArgs = [PesterConfiguration]::Default
         $pesterArgs.Run.Exit = $true
         $pesterArgs.Run.PassThru = $true
-        $pesterArgs.Run.Path = './test/integration/*'
+        $pesterArgs.Run.Path = './test/Tests/integration/*'
         $pesterArgs.Output.Verbosity = "Detailed"
         $pesterArgs.TestResult.Enabled = $true
         $pesterArgs.TestResult.OutputFormat = 'JUnitXml'

--- a/.github/workflows/actions-pipeline.yml
+++ b/.github/workflows/actions-pipeline.yml
@@ -184,6 +184,10 @@ jobs:
       with:
         name: VSTeamPackage
         path: ./module
+    - name: Download test
+      uses: actions/download-artifact@v2
+      with:
+        name: test
 
     - name: Install module
       shell: pwsh
@@ -292,7 +296,7 @@ jobs:
         $pesterArgs.TestResult.OutputFormat = 'JUnitXml'
         $pesterArgs.TestResult.OutputPath = 'test-results.xml'
 
-        Invoke-Pester -Configuration $pesterArgs
+        Invoke-Pester -Path ./test/integration/* -Configuration $pesterArgs
       shell: pwsh
 
     - name: Publish PowerShell test results


### PR DESCRIPTION
# PR Summary

@SebastianSchuetze Here is as far as I am able to take it without spinning up an Azure DevOps organization. I Also had to resort to using a local Nuget feed as I did not have the credentials for the GitHub Project feed. 

Please let me know what you think.

Link to actions run getting past the Module Install: https://github.com/brittandeyoung/vsteam/actions/runs/1485308715
