### PR TITLE
fixed a problem that prevented the module to load

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Changelog
 
 ## 7.9.0
+
+Merged [Pull Request](https://github.com/MethodsAndPractices/vsteam/pull/480) from [Sebastian Schütze](https://github.com/SebastianSchuetze) the following:
+- fixed a problem that prevented the module to load [#467](https://github.com/MethodsAndPractices/vsteam/issues/467)
+
 Merged [Pull Request](https://github.com/MethodsAndPractices/vsteam/pull/468) from [Michael19842](https://github.com/Michael19842) the following:
 - Added parameter `Templateparameter` for queue new build with custom template parameters
 

--- a/Source/Private/common.ps1
+++ b/Source/Private/common.ps1
@@ -269,7 +269,7 @@ function _getApiVersion {
       [parameter(ParameterSetName = 'Service', Mandatory = $true, Position = 0)]
       [ValidateSet('Build', 'Release', 'Core', 'Git', 'DistributedTask',
          'DistributedTaskReleased', 'VariableGroups', 'Tfvc',
-         'Packaging', 'MemberEntitlementManagement',
+         'Packaging', 'MemberEntitlementManagement','Version',
          'ExtensionsManagement', 'ServiceEndpoints', 'Graph',
          'TaskGroups', 'Policy', 'Processes', 'HierarchyQuery', 'Pipelines', 'Billing', 'Wiki', 'WorkItemTracking')]
       [string] $Service,

--- a/Source/VSTeam.psm1
+++ b/Source/VSTeam.psm1
@@ -17,19 +17,34 @@ Set-VSTeamAPIVersion -Target $([vsteam_lib.Versions]::Version)
 
 #compare versions and notify user
 # new versions for the module are only checked if $env:VSTEAM_NO_UPDATE_MESSAGE is not set
-if(($env:VSTEAM_NO_UPDATE_MESSAGE -eq $false) -or ($null -eq $env:VSTEAM_NO_UPDATE_MESSAGE)) {
+if (($env:VSTEAM_NO_UPDATE_MESSAGE -eq $false) -or ($null -eq $env:VSTEAM_NO_UPDATE_MESSAGE)) {
    _checkForModuleUpdates -ModuleVersion ([version][vsteam_lib.Versions]::ModuleVersion) -ErrorAction Continue
 }
 
 # display custom message if set and not $true
-if(($env:VSTEAM_NO_MODULE_MESSAGES -eq $false) -or ($null -eq $env:VSTEAM_NO_MODULE_MESSAGES)) {
+if (($env:VSTEAM_NO_MODULE_MESSAGES -eq $false) -or ($null -eq $env:VSTEAM_NO_MODULE_MESSAGES)) {
    _showModuleLoadingMessages -ModuleVersion ([version][vsteam_lib.Versions]::ModuleVersion) -ErrorAction Continue
 }
 
 # Check to see if the user stored the default project in an environment variable
 if ($null -ne $env:TEAM_PROJECT) {
-   # Make sure the value in the environment variable still exisits.
-   if (Get-VSTeamProject | Where-Object ProjectName -eq $env:TEAM_PROJECT) {
-      Set-VSTeamDefaultProject -Project $env:TEAM_PROJECT
+
+
+   # if not account and pat is set, then do not try to set the default project
+   if ($null -eq $env:TEAM_PAT -and $null -eq $env:TEAM_ACCT) {
+      Write-Warning "No PAT or Account set. You must set the environment variables TEAM_PAT or TEAM_ACCT before loading the module to use the default project."
    }
+   else {
+      # set vsteam account to initialize given variables properly
+      Set-VSTeamAccount -Account $env:TEAM_ACCT -PersonalAccessToken $env:TEAM_PAT
+      # Make sure the value in the environment variable still exisits.
+      if (Get-VSTeamProject | Where-Object ProjectName -eq $env:TEAM_PROJECT) {
+         Set-VSTeamDefaultProject -Project $env:TEAM_PROJECT
+      }
+      else {
+         Write-Warning "The default project '$env:TEAM_PROJECT' stored in the environment variable TEAM_PROJECT does not exist."
+      }
+   }
+
+
 }


### PR DESCRIPTION
on module load the default project is set
as well as the given project queried to check if the project exists
this causes a default exception since on module load no set-vsteamaccount is set.
This is fixed by returning warning messages

# PR Summary

<!-- summarize your PR between here and the checklist -->

## PR Checklist

- [ ] [Write Help](https://github.com/DarqueWarrior/vsteam/blob/master/.github/CONTRIBUTING.md#write-help)
- [ ] [Write Unit Test](https://github.com/DarqueWarrior/vsteam/blob/master/.github/CONTRIBUTING.md#write-unit-test)
- [x] [Update CHANGELOG.md](https://github.com/DarqueWarrior/vsteam/blob/master/.github/CONTRIBUTING.md#update-changelogmd)
