### PR TITLE
Added option to create public project for add and update project

### DIFF
--- a/.docs/Add-VSTeamProject.md
+++ b/.docs/Add-VSTeamProject.md
@@ -34,17 +34,6 @@ template and TFVC source control.
 
 ## PARAMETERS
 
-### ProjectName
-
-The name of the project to create.
-
-```yaml
-Type: String
-Aliases: Name
-Required: True
-Position: 0
-```
-
 ### ProcessTemplate
 
 The name of the process template to use for the project.
@@ -71,6 +60,17 @@ Switches the source control from Git to TFVC.
 ```yaml
 Type: SwitchParameter
 ```
+
+### Visibility
+
+The visibility of the project.
+
+```yaml
+Type: String
+Accepted values: private, public
+```
+
+<!-- #include "./params/projectName.md" -->
 
 ## INPUTS
 

--- a/.docs/Update-VSTeamProject.md
+++ b/.docs/Update-VSTeamProject.md
@@ -22,6 +22,14 @@ Update-VSTeamProject -Name Demo -NewName aspDemo
 
 This command changes the name of your project from Demo to aspDemo.
 
+### Example 2: Make a project public
+
+```powershell
+Update-VSTeamProject -Name Demo -Visibility public
+```
+
+This command makes your project public.
+
 ## PARAMETERS
 
 ### NewName
@@ -49,6 +57,15 @@ Type: String
 Parameter Sets: (ByID)
 Aliases: ProjectId
 Accept pipeline input: true (ByPropertyName)
+```
+
+### Visibility
+
+The visibility of the project.
+
+```yaml
+Type: String
+Accepted values: private, public
 ```
 
 <!-- #include "./params/projectName.md" -->

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## 7.10.0
 
+Merged [Pull Request](https://github.com/MethodsAndPractices/vsteam/pull/486) from [Sebastian Schütze](https://github.com/SebastianSchuetze) the following:
+- Added option to create public project for add and update project [#469](https://github.com/MethodsAndPractices/vsteam/issues/469)
 
 Merged [Pull Request](https://github.com/MethodsAndPractices/vsteam/pull/485) from [Sebastian Schütze](https://github.com/SebastianSchuetze) the following:
 - Added possibility to create, get and delete azure artifacts for projects [#379](https://github.com/MethodsAndPractices/vsteam/issues/379)

--- a/Source/Private/common.ps1
+++ b/Source/Private/common.ps1
@@ -1276,3 +1276,7 @@ function _countParameters() {
    Write-Verbose "Found $counter parameters"
    $counter
 }
+
+function _invalidate() {
+   [vsteam_lib.ProjectCache]::Invalidate()
+}

--- a/Source/Public/Add-VSTeamProject.ps1
+++ b/Source/Public/Add-VSTeamProject.ps1
@@ -15,6 +15,9 @@ function Add-VSTeamProject {
 
       [string] $Description,
 
+      [validateset('private','public')]
+      [string] $Visibility = 'private',
+
       [switch] $TFVC,
 
       [vsteam_lib.ProcessTemplateValidateAttribute()]
@@ -51,6 +54,7 @@ function Add-VSTeamProject {
                templateTypeId = $templateTypeId
             }
          }
+         visibility = $Visibility
       }
 
       try {
@@ -63,7 +67,7 @@ function Add-VSTeamProject {
          _trackProjectProgress -resp $resp -title 'Creating team project' -msg "Name: $($ProjectName), Template: $($processTemplate), Src: $($srcCtrl)"
 
          # Invalidate any cache of projects.
-         [vsteam_lib.ProjectCache]::Invalidate()
+         _invalidate
          Start-Sleep -Seconds 5
 
          return Get-VSTeamProject $ProjectName

--- a/Source/Public/Remove-VSTeamProject.ps1
+++ b/Source/Public/Remove-VSTeamProject.ps1
@@ -25,7 +25,7 @@ function Remove-VSTeamProject {
          _trackProjectProgress -resp $resp -title 'Deleting team project' -msg "Deleting $ProjectName"
 
          # Invalidate any cache of projects.
-         [vsteam_lib.ProjectCache]::Invalidate()
+         _invalidate
 
          Write-Output "Deleted $ProjectName"
       }

--- a/Source/Public/Set-VSTeamAccount.ps1
+++ b/Source/Public/Set-VSTeamAccount.ps1
@@ -67,7 +67,7 @@ function Set-VSTeamAccount {
    process {
       # invalidate cache when changing account/collection
       # otherwise dynamic parameters being picked for a wrong collection
-      [vsteam_lib.ProjectCache]::Invalidate()
+      _invalidate
 
       # Bind the parameter to a friendly variable
       $vsteamProfile = $PSBoundParameters['Profile']

--- a/Tests/function/tests/Add-VSTeamProject.Tests.ps1
+++ b/Tests/function/tests/Add-VSTeamProject.Tests.ps1
@@ -46,6 +46,18 @@ Describe 'VSTeamProject' {
          }
       }
 
+      It 'should create public project' {
+         Add-VSTeamProject -Name Test -Visibility public
+
+
+         Should -Invoke Invoke-RestMethod -Times 1 -Scope It  -ParameterFilter {
+            $Method -eq 'Post' -and
+            $Uri -eq "https://dev.azure.com/test/_apis/projects?api-version=$(_getApiVersion Core)" -and
+            $Body -like '*"name":*"Test"*' -and
+            $Body -like '*"visibility":*public*'
+         }
+      }
+
       It 'with tfvc should create project with tfvc' {
          Add-VSTeamProject -Name Test -tfvc
 

--- a/Tests/function/tests/Update-VSTeamProject.Tests.ps1
+++ b/Tests/function/tests/Update-VSTeamProject.Tests.ps1
@@ -13,9 +13,7 @@ Describe 'VSTeamProject' {
    Context 'Update-VSTeamProject' {
       BeforeAll {
 
-         Mock Get-VSTeamProject {
-            Open-SampleFile 'Get-VSTeamProject-NamePeopleTracker.json'
-         }
+         Mock Get-VSTeamProject { Open-SampleFile 'Get-VSTeamProject-NamePeopleTracker.json' }
 
          Mock Invoke-RestMethod {
             return @{ status = 'inProgress'; url = 'https://someplace.com' }

--- a/Tests/function/tests/Update-VSTeamProject.Tests.ps1
+++ b/Tests/function/tests/Update-VSTeamProject.Tests.ps1
@@ -7,16 +7,20 @@ Describe 'VSTeamProject' {
 
       Mock _getApiVersion { return '1.0-unitTests' }
       Mock _getInstance { return 'https://dev.azure.com/test' }
+      Mock _invalidate
    }
 
    Context 'Update-VSTeamProject' {
       BeforeAll {
-         Mock Invoke-RestMethod { Open-SampleFile 'Get-VSTeamProject-NamePeopleTracker.json' }
-         
+
+         Mock Get-VSTeamProject {
+            Open-SampleFile 'Get-VSTeamProject-NamePeopleTracker.json'
+         }
+
          Mock Invoke-RestMethod {
             return @{ status = 'inProgress'; url = 'https://someplace.com' }
          } -ParameterFilter {
-            $Method -eq 'Patch' 
+            $Method -eq 'Patch'
          }
 
          Mock _trackProjectProgress
@@ -24,25 +28,25 @@ Describe 'VSTeamProject' {
 
       It 'with no op by id should not call Invoke-RestMethod' {
          ## Act
-         Update-VSTeamProject -id '123-5464-dee43'
+         Update-VSTeamProject -id '99081ca0-ec76-4a6b-840f-e70344e8784f' -Force
 
          ## Assert
-         Should -Invoke Invoke-RestMethod -Exactly 0
+         Should -Invoke Invoke-RestMethod -Exactly 1 -Scope It
       }
 
       It 'with newName should change name' {
          ## Act
-         Update-VSTeamProject -ProjectName Test -newName Testing123 -Force
+.         Update-VSTeamProject -ProjectName Test -newName Testing123 -Force
 
          ## Assert
          Should -Invoke Invoke-RestMethod -Exactly -Times 1 -Scope It -ParameterFilter {
-            $Uri -eq "https://dev.azure.com/test/_apis/projects/Test?api-version=$(_getApiVersion Core)" 
+            $Uri -eq "https://dev.azure.com/test/_apis/projects/00000000-0000-0000-0000-000000000000?api-version=$(_getApiVersion Core)"
          }
          Should -Invoke Invoke-RestMethod -Exactly -Times 1 -Scope It -ParameterFilter {
-            $Method -eq 'Patch' -and $Body -eq '{"name": "Testing123"}' 
+            $Method -eq 'Patch' -and $Body -like '*"name"*"Testing123"*'
          }
-         Should -Invoke Invoke-RestMethod -Exactly -Times 1 -Scope It -ParameterFilter { 
-            $Uri -eq "https://dev.azure.com/test/_apis/projects/Testing123?api-version=$(_getApiVersion Core)" 
+         Should -Invoke Invoke-RestMethod -Exactly -Times 1 -Scope It -ParameterFilter {
+            $Uri -eq "https://dev.azure.com/test/_apis/projects/00000000-0000-0000-0000-000000000000?api-version=$(_getApiVersion Core)"
          }
       }
 
@@ -51,11 +55,11 @@ Describe 'VSTeamProject' {
          Update-VSTeamProject -ProjectName Test -newDescription Testing123 -Force
 
          ## Assert
-         Should -Invoke Invoke-RestMethod -Exactly -Times 2 -Scope It -ParameterFilter { 
-            $Uri -eq "https://dev.azure.com/test/_apis/projects/Test?api-version=$(_getApiVersion Core)" 
+         Should -Invoke Invoke-RestMethod -Exactly -Times 1 -Scope It -ParameterFilter {
+            $Uri -eq "https://dev.azure.com/test/_apis/projects/00000000-0000-0000-0000-000000000000?api-version=$(_getApiVersion Core)"
          }
-         Should -Invoke Invoke-RestMethod -Exactly -Times 1 -Scope It -ParameterFilter { 
-            $Method -eq 'Patch' -and $Body -eq '{"description": "Testing123"}' 
+         Should -Invoke Invoke-RestMethod -Exactly -Times 1 -Scope It -ParameterFilter {
+            $Method -eq 'Patch' -and $Body -like '*"description"*"Testing123"*'
          }
       }
 
@@ -64,14 +68,25 @@ Describe 'VSTeamProject' {
          Update-VSTeamProject -ProjectName Test -newName Testing123 -newDescription Testing123 -Force
 
          ## Assert
-         Should -Invoke Invoke-RestMethod -Exactly -Times 1 -Scope It -ParameterFilter { 
-            $Uri -eq "https://dev.azure.com/test/_apis/projects/Test?api-version=$(_getApiVersion Core)" 
+         Should -Invoke Invoke-RestMethod -Exactly -Times 1 -Scope It -ParameterFilter {
+            $Uri -eq "https://dev.azure.com/test/_apis/projects/00000000-0000-0000-0000-000000000000?api-version=$(_getApiVersion Core)"
          }
-         Should -Invoke Invoke-RestMethod -Exactly -Times 1 -Scope It -ParameterFilter { 
-            $Method -eq 'Patch' 
+         Should -Invoke Invoke-RestMethod -Exactly -Times 1 -Scope It -ParameterFilter {
+            $Method -eq 'Patch'
          }
-         Should -Invoke Invoke-RestMethod -Exactly -Times 1 -Scope It -ParameterFilter { 
-            $Uri -eq "https://dev.azure.com/test/_apis/projects/Testing123?api-version=$(_getApiVersion Core)" 
+         Should -Invoke Invoke-RestMethod -Exactly -Times 1 -Scope It -ParameterFilter {
+            $Uri -eq "https://dev.azure.com/test/_apis/projects/00000000-0000-0000-0000-000000000000?api-version=$(_getApiVersion Core)"
+         }
+      }
+
+      It 'should change to public project' {
+         ## Act
+         Update-VSTeamProject -ProjectName Test -Visibility public -Force
+
+         ## Assert
+         Should -Invoke Invoke-RestMethod -Exactly -Times 1 -Scope It -ParameterFilter {
+            $Uri -eq "https://dev.azure.com/test/_apis/projects/00000000-0000-0000-0000-000000000000?api-version=$(_getApiVersion Core)" -and
+            $Method -eq 'Patch' -and $Body -like '*"visibility"*"public"}'
          }
       }
    }

--- a/Tests/function/tests/_testInitialize.ps1
+++ b/Tests/function/tests/_testInitialize.ps1
@@ -28,6 +28,7 @@ $sut = (Split-Path -Leaf $testPath).Replace(".Tests.", ".")
 
 . "$baseFolder/Source/Private/common.ps1"
 . "$baseFolder/Source/Private/applyTypes.ps1"
+. "$baseFolder/Source/Public/Clear-VSTeamDefaultProject.ps1"
 
 if ($private.IsPresent) {
    . "$baseFolder/Source/Private/$sut"


### PR DESCRIPTION
Fixes #469

publich projects can now be created or switched between private and public.

Also fixed some unit tests, which gave errors

<!-- summarize your PR between here and the checklist -->

## PR Checklist

- [x] [Write Help](https://github.com/DarqueWarrior/vsteam/blob/master/.github/CONTRIBUTING.md#write-help)
- [x] [Write Unit Test](https://github.com/DarqueWarrior/vsteam/blob/master/.github/CONTRIBUTING.md#write-unit-test)
- [x] [Update CHANGELOG.md](https://github.com/DarqueWarrior/vsteam/blob/master/.github/CONTRIBUTING.md#update-changelogmd)
