### PR TITLE
Powershell 5 compatibility for Build-Module.ps1

### DIFF
--- a/Build-Module.ps1
+++ b/Build-Module.ps1
@@ -140,7 +140,14 @@ Write-Output '  Updating: Functions To Export'
 $newValue = ((Get-ChildItem -Path "./Source/Public" -Filter '*.ps1').BaseName |
    ForEach-Object -Process { Write-Output "'$_'" }) -join ','
 
-(Get-Content "./Source/VSTeam.psd1") -Replace ("FunctionsToExport.+", "FunctionsToExport = ($newValue)") | Set-Content "$output/VSTeam.psd1" -Encoding utf8BOM
+if($PSVersionTable.PSVersion.Major -gt 5) {
+   $enc = 'utf8BOM'
+}
+else {
+   $enc = 'utf8'
+}
+
+(Get-Content "./Source/VSTeam.psd1") -Replace ("FunctionsToExport.+", "FunctionsToExport = ($newValue)") | Set-Content "$output/VSTeam.psd1" -Encoding $enc
 
 if (-not $skipLibBuild.IsPresent) {
    Write-Output "  Building: C# project ($configuration config)"


### PR DESCRIPTION
# PR Summary

Encoding `UTF8BOM` for Set-Content was not available is PS5. This PR makes the encoding value conditional.

The readme states the lower bound of Powershell compatibility at 5.

The only way to test that is to introduce an explicitly PS5 build in the CI scripts. That's a maintainer level decision.

The CI will fail over the Update-VSTeamProject autotest issue. Only merge when/if either #494 or #495 lands.

## PR Checklist

- [ ] [Write Help](https://github.com/DarqueWarrior/vsteam/blob/master/.github/CONTRIBUTING.md#write-help)
- [ ] [Write Unit Test](https://github.com/DarqueWarrior/vsteam/blob/master/.github/CONTRIBUTING.md#write-unit-test)
- [ ] [Update CHANGELOG.md](https://github.com/DarqueWarrior/vsteam/blob/master/.github/CONTRIBUTING.md#update-changelogmd)
