### PR TITLE
Fix #493 import-module loses previously stored configuration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ Merged [Pull Request](https://github.com/MethodsAndPractices/vsteam/pull/486) fr
 Merged [Pull Request](https://github.com/MethodsAndPractices/vsteam/pull/485) from [Sebastian Schütze](https://github.com/SebastianSchuetze) the following:
 - Added possibility to create, get and delete azure artifacts for projects [#379](https://github.com/MethodsAndPractices/vsteam/issues/379)
 
+-Fixed a regresion introduced in [#467](https://github.com/MethodsAndPractices/vsteam/issues/467) that prevens to recover configuration from `Set-VSTeamAccount -Account myOrganization -PersonalAccessToken myToken -Version AzD -Level User` next time `import-module VSTeam` is invoked
 
 ## 7.9.0
 

--- a/Source/VSTeam.psm1
+++ b/Source/VSTeam.psm1
@@ -31,18 +31,31 @@ if ($null -ne $env:TEAM_PROJECT) {
 
 
    # if not account and pat is set, then do not try to set the default project
-   if ($null -eq $env:TEAM_PAT -and $null -eq $env:TEAM_ACCT) {
-      Write-Warning "No PAT or Account set. You must set the environment variables TEAM_PAT or TEAM_ACCT before loading the module to use the default project."
+   if (($null -eq $env:TEAM_PAT -and $null -eq $env:TEAM_TOKEN) -and $null -eq $env:TEAM_ACCT) {
+      Write-Warning "No PAT or Account set. You must set the environment variables (TEAM_PAT or TEAM_TOKEN) and TEAM_ACCT before loading the module to use the default project."
    }
    else {
       # set vsteam account to initialize given variables properly
-      Set-VSTeamAccount -Account $env:TEAM_ACCT -PersonalAccessToken $env:TEAM_PAT
+      $commonArgs = @{
+         Account = $env:TEAM_ACCT
+         Version = $env:TEAM_VERSION
+      }
+
+      if (_useBearerToken) {
+         $commonArgs.Add("UseBearerToken", $env:TEAM_TOKEN)
+      } else {
+         $pat = [System.Text.Encoding]::UTF8.GetString([System.Convert]::FromBase64String($env:TEAM_PAT))   #decode base64 stored pat
+         $pat = $pat.Substring(1)                                                                           #remove the leading :
+         $commonArgs.Add("PersonalAccessToken", $env:TEAM_TOKEN)
+      }
+      $defaultProject = $env:TEAM_PROJECT                                                                   #save temporary defalt project because is removed during Set-VSTeamAccount call
+      Set-VSTeamAccount @commonArgs
       # Make sure the value in the environment variable still exisits.
-      if (Get-VSTeamProject | Where-Object ProjectName -eq $env:TEAM_PROJECT) {
-         Set-VSTeamDefaultProject -Project $env:TEAM_PROJECT
+      if (Get-VSTeamProject | Where-Object ProjectName -eq $defaultProject) {
+         Set-VSTeamDefaultProject -Project $defaultProject
       }
       else {
-         Write-Warning "The default project '$env:TEAM_PROJECT' stored in the environment variable TEAM_PROJECT does not exist."
+         Write-Warning "The default project '$defaultProject' stored in the environment variable TEAM_PROJECT does not exist."
       }
    }
 


### PR DESCRIPTION
# PR Summary

When the module is configured with Set-VSTeamAccount -Level user, the configuration is stored in env variables and then recovered next time while `import-module vsteam`
The problem was introduced in commit  0528c76 (#467 closed in #480)

## PR Checklist

Note: First 2 checks don't apply because the changes are in the vsteam.psm1 file
- [ ] [Write Help](https://github.com/DarqueWarrior/vsteam/blob/master/.github/CONTRIBUTING.md#write-help)
- [ ] [Write Unit Test](https://github.com/DarqueWarrior/vsteam/blob/master/.github/CONTRIBUTING.md#write-unit-test)
- [x] [Update CHANGELOG.md](https://github.com/DarqueWarrior/vsteam/blob/master/.github/CONTRIBUTING.md#update-changelogmd)
