### PR TITLE
Update to .NET 6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ Merged [Pull Request](https://github.com/MethodsAndPractices/vsteam/pull/486) fr
 Merged [Pull Request](https://github.com/MethodsAndPractices/vsteam/pull/485) from [Sebastian Schütze](https://github.com/SebastianSchuetze) the following:
 - Added possibility to create, get and delete azure artifacts for projects [#379](https://github.com/MethodsAndPractices/vsteam/issues/379)
 
+Merged [Pull Request](https://github.com/MethodsAndPractices/vsteam/pull/502) from [Miguel Nieto](https://github.com/mnieto) the following:
+- Updated test c# project to .NET 6.0
+- Fixed test fail on ubuntu-latest
 
 ## 7.9.0
 

--- a/Tests/function/tests/Update-VSTeamProject.Tests.ps1
+++ b/Tests/function/tests/Update-VSTeamProject.Tests.ps1
@@ -84,7 +84,7 @@ Describe 'VSTeamProject' {
          ## Assert
          Should -Invoke Invoke-RestMethod -Exactly -Times 1 -Scope It -ParameterFilter {
             $Uri -eq "https://dev.azure.com/test/_apis/projects/00000000-0000-0000-0000-000000000000?api-version=$(_getApiVersion Core)" -and
-            $Method -eq 'Patch' -and $Body -like '*"visibility"*"public"}'
+            $Method -eq 'Patch' -and $Body -like '*"visibility"*"public"*'
          }
       }
    }

--- a/Tests/library/vsteam-lib.Test.csproj
+++ b/Tests/library/vsteam-lib.Test.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <RootNamespace>vsteam_lib.Test</RootNamespace>
 
     <IsPackable>false</IsPackable>


### PR DESCRIPTION
windows-lastest used in Github actions is updated and do not support net core 3.1 anymore

# PR Summary

windows-lastest used in Github actions is updated and do not support net core 3.1 anymore


## PR Checklist

- [ ] [Write Help](https://github.com/DarqueWarrior/vsteam/blob/master/.github/CONTRIBUTING.md#write-help)
- [ ] [Write Unit Test](https://github.com/DarqueWarrior/vsteam/blob/master/.github/CONTRIBUTING.md#write-unit-test)
- [ ] [Update CHANGELOG.md](https://github.com/DarqueWarrior/vsteam/blob/master/.github/CONTRIBUTING.md#update-changelogmd)
