### PR TITLE
fix tests that involve dates fail when OS culture has 24 hours format

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 7.12.0
+
+Merged [Pull Request](https://github.com/MethodsAndPractices/vsteam/pull/506) from [Miguel Nieto](https://github.com/mnieto) the following:
+- fix tests that involve dates fail when OS culture has 24 hours format
+
 ## 7.10.0
 
 Merged [Pull Request](https://github.com/MethodsAndPractices/vsteam/pull/486) from [Sebastian Schütze](https://github.com/SebastianSchuetze) the following:
@@ -11,9 +16,6 @@ Merged [Pull Request](https://github.com/MethodsAndPractices/vsteam/pull/485) fr
 Merged [Pull Request](https://github.com/MethodsAndPractices/vsteam/pull/502) from [Miguel Nieto](https://github.com/mnieto) the following:
 - Updated test c# project to .NET 6.0
 - Fixed test fail on ubuntu-latest
-
-Merged [Pull Request](https://github.com/MethodsAndPractices/vsteam/pull/506) from [Miguel Nieto](https://github.com/mnieto) the following:
-- fix tests that involve dates fail when OS culture has 24 hours format
 
 ## 7.9.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,9 @@ Merged [Pull Request](https://github.com/MethodsAndPractices/vsteam/pull/502) fr
 - Updated test c# project to .NET 6.0
 - Fixed test fail on ubuntu-latest
 
+Merged [Pull Request](https://github.com/MethodsAndPractices/vsteam/pull/506) from [Miguel Nieto](https://github.com/mnieto) the following:
+- fix tests that involve dates fail when OS culture has 24 hours format
+
 ## 7.9.0
 
 Merged [Pull Request](https://github.com/MethodsAndPractices/vsteam/pull/481) from [Sebastian Schütze](https://github.com/SebastianSchuetze) the following:

--- a/Tests/library/CommonTests.cs
+++ b/Tests/library/CommonTests.cs
@@ -32,7 +32,7 @@ namespace vsteam_lib.Test
          Common.MoveProperties(target, source);
 
          // Assert
-         Assert.AreEqual("8/27/2020 10:37:32 am", target.CreatedOn.ToUniversalTime().ToString("M/d/yyyy h:mm:ss tt").ToLower());
+         Assert.AreEqual("8/27/2020 10:37:32 am", target.CreatedOn.ToUniversalTime().ToString("M/d/yyyy h:mm:ss tt", System.Globalization.CultureInfo.InvariantCulture).ToLower());
       }
    }
 }

--- a/Tests/library/Provider/BuildDefinitionTests.cs
+++ b/Tests/library/Provider/BuildDefinitionTests.cs
@@ -34,7 +34,7 @@ namespace vsteam_lib.Test.Provider
          Assert.AreEqual("projectCollection", actual.JobAuthorizationScope, "JobAuthorizationScope");
          Assert.AreEqual("$(date:yyyyMMdd)$(rev:.r)", actual.BuildNumberFormat, "BuildNumberFormat");
 
-         Assert.AreEqual("8/23/2020 3:12:41 pm", actual.CreatedOn.ToString("M/d/yyyy h:mm:ss tt").ToLower(), "CreatedOn");
+         Assert.AreEqual("8/23/2020 3:12:41 pm", actual.CreatedOn.ToString("M/d/yyyy h:mm:ss tt", System.Globalization.CultureInfo.InvariantCulture).ToLower(), "CreatedOn");
 
          Assert.IsNotNull(actual.Options, "Options");
          Assert.AreEqual(4, actual.Options.Count, "Options.Count");
@@ -103,7 +103,7 @@ namespace vsteam_lib.Test.Provider
          Assert.IsNull(actual.GitRepository, "GitRepository");
          Assert.IsNotNull(actual.RetentionRules, "RetentionRules");
 
-         Assert.AreEqual("8/23/2020 10:30:31 pm", actual.CreatedOn.ToString("M/d/yyyy h:mm:ss tt").ToLower(), "CreatedOn");
+         Assert.AreEqual("8/23/2020 10:30:31 pm", actual.CreatedOn.ToString("M/d/yyyy h:mm:ss tt", System.Globalization.CultureInfo.InvariantCulture).ToLower(), "CreatedOn");
 
          Assert.AreEqual(5, actual.JobCancelTimeoutInMinutes, "JobCancelTimeoutInMinutes");
          Assert.AreEqual("projectCollection", actual.JobAuthorizationScope, "JobAuthorizationScope");
@@ -145,7 +145,7 @@ namespace vsteam_lib.Test.Provider
          Assert.IsNotNull(actual.GitRepository, "GitRepository");
          Assert.IsNotNull(actual.RetentionRules, "RetentionRules");
 
-         Assert.AreEqual("8/23/2020 3:16:22 pm", actual.CreatedOn.ToString("M/d/yyyy h:mm:ss tt").ToLower(), "CreatedOn");
+         Assert.AreEqual("8/23/2020 3:16:22 pm", actual.CreatedOn.ToString("M/d/yyyy h:mm:ss tt", System.Globalization.CultureInfo.InvariantCulture).ToLower(), "CreatedOn");
 
          Assert.AreEqual(5, actual.JobCancelTimeoutInMinutes, "JobCancelTimeoutInMinutes");
          Assert.AreEqual("projectCollection", actual.JobAuthorizationScope, "JobAuthorizationScope"); 
@@ -205,7 +205,7 @@ namespace vsteam_lib.Test.Provider
 
          Assert.IsNull(actual.Demands, "Demands");
 
-         Assert.AreEqual("9/16/2019 2:34:16 am", actual.CreatedOn.ToString("M/d/yyyy h:mm:ss tt").ToLower(), "CreatedOn");
+         Assert.AreEqual("9/16/2019 2:34:16 am", actual.CreatedOn.ToString("M/d/yyyy h:mm:ss tt", System.Globalization.CultureInfo.InvariantCulture).ToLower(), "CreatedOn");
 
          // Not on this build def
          Assert.AreEqual(null, actual.BuildNumberFormat, "BuildNumberFormat");
@@ -266,7 +266,7 @@ namespace vsteam_lib.Test.Provider
 
          Assert.IsNull(actual.Demands, "Demands");
 
-         Assert.AreEqual("9/25/2019 8:55:54 pm", actual.CreatedOn.ToString("M/d/yyyy h:mm:ss tt").ToLower(), "CreatedOn");
+         Assert.AreEqual("9/25/2019 8:55:54 pm", actual.CreatedOn.ToString("M/d/yyyy h:mm:ss tt", System.Globalization.CultureInfo.InvariantCulture).ToLower(), "CreatedOn");
 
          // Not on this build def
          Assert.AreEqual(0, actual.JobCancelTimeoutInMinutes, "JobCancelTimeoutInMinutes");

--- a/Tests/library/Provider/BuildTests.cs
+++ b/Tests/library/Provider/BuildTests.cs
@@ -30,7 +30,7 @@ namespace vsteam_lib.Test.Provider
          Assert.AreEqual("PTracker-CI", actual.DefinitionName, "DefinitionName");
          Assert.AreEqual("Donovan Brown", actual.RequestedByUser, "RequestedByUser");
          Assert.AreEqual("Donovan Brown", actual.RequestedForUser, "RequestedForUser");
-         Assert.AreEqual("11/14/2019 12:49:37 am", actual.StartTime?.ToString("M/d/yyyy h:mm:ss tt").ToLower(), "startTime");
+         Assert.AreEqual("11/14/2019 12:49:37 am", actual.StartTime?.ToString("M/d/yyyy h:mm:ss tt", System.Globalization.CultureInfo.InvariantCulture).ToLower(), "startTime");
          Assert.AreEqual("Microsoft.VisualStudio.Services.ReleaseManagement", actual.LastChangedByUser, "LastChangedByUser");
 
          Assert.IsNotNull(actual.TriggerInfo, "TriggerInfo");
@@ -84,7 +84,7 @@ namespace vsteam_lib.Test.Provider
          Assert.AreEqual("Team Module-CI (1)", actual.DefinitionName, "DefinitionName");
          Assert.AreEqual("Donovan Brown", actual.RequestedByUser, "RequestedByUser");
          Assert.AreEqual("Donovan Brown", actual.RequestedForUser, "RequestedForUser");
-         Assert.AreEqual("9/23/2020 3:44:45 pm", actual.StartTime?.ToString("M/d/yyyy h:mm:ss tt").ToLower(), "startTime");
+         Assert.AreEqual("9/23/2020 3:44:45 pm", actual.StartTime?.ToString("M/d/yyyy h:mm:ss tt", System.Globalization.CultureInfo.InvariantCulture).ToLower(), "startTime");
          Assert.AreEqual("Microsoft.VisualStudio.Services.TFS", actual.LastChangedByUser, "LastChangedByUser");
 
          Assert.IsNotNull(actual.TriggerInfo, "TriggerInfo");

--- a/Tests/library/Provider/ExtensionTests.cs
+++ b/Tests/library/Provider/ExtensionTests.cs
@@ -27,7 +27,7 @@ namespace vsteam_lib.Test.Provider
          Assert.AreEqual("none", actual.InstallState.Flags, "InstallState.Flags");
          Assert.IsNotNull(actual.InstallState.InternalObject, "InstallState.InternalObject");
          Assert.IsTrue(actual.InstallState.ToString().StartsWith("Flags: none, Last Updated: "), "InstallState.ToString()");
-         Assert.AreEqual("8/10/2020 8:31:07 pm", actual.InstallState.LastUpdated.ToString("M/d/yyyy h:mm:ss tt").ToLower(), "InstallState.LastUpdated");
+         Assert.AreEqual("8/10/2020 8:31:07 pm", actual.InstallState.LastUpdated.ToString("M/d/yyyy h:mm:ss tt", System.Globalization.CultureInfo.InvariantCulture).ToLower(), "InstallState.LastUpdated");
       }
    }
 }

--- a/Tests/library/Provider/GitCommitRefTests.cs
+++ b/Tests/library/Provider/GitCommitRefTests.cs
@@ -30,7 +30,7 @@ namespace vsteam_lib.Test.Provider
          Assert.IsNotNull(target.Committer, "Committer");
          Assert.AreEqual("Donovan Brown", target.Committer.Name, "Committer.Name");
          Assert.AreEqual("Test@Test.com", target.Committer.Email, "Committer.Email");
-         Assert.AreEqual("8/8/2019 8:58:58 pm", target.Committer.Date.ToString("M/d/yyyy h:mm:ss tt").ToLower(), "Committer.Date");
+         Assert.AreEqual("8/8/2019 8:58:58 pm", target.Committer.Date.ToString("M/d/yyyy h:mm:ss tt", System.Globalization.CultureInfo.InvariantCulture).ToLower(), "Committer.Date");
       }
    }
 }

--- a/Tests/library/Provider/JobRequestTests.cs
+++ b/Tests/library/Provider/JobRequestTests.cs
@@ -27,10 +27,10 @@ namespace vsteam_lib.Test.Provider
          Assert.AreEqual("PTracker-CD", target.Pipeline, "Pipeline");
          Assert.AreEqual("------", target.DisplayMode, "DisplayMode");
          Assert.AreEqual(TimeSpan.Parse("00:10:58"), target.Duration, "Duration");
-         Assert.AreEqual("11/14/2019 12:56:12 am", target.QueueTime.ToString("M/d/yyyy h:mm:ss tt").ToLower(), "QueueTime");
-         Assert.AreEqual("11/14/2019 12:56:15 am", target.StartTime?.ToString("M/d/yyyy h:mm:ss tt").ToLower(), "StartTime");
-         Assert.AreEqual("11/14/2019 1:07:13 am", target.FinishTime?.ToString("M/d/yyyy h:mm:ss tt").ToLower(), "FinishTime");
-         Assert.AreEqual("11/14/2019 12:56:12 am", target.AssignedTime?.ToString("M/d/yyyy h:mm:ss tt").ToLower(), "AssignedTime");
+         Assert.AreEqual("11/14/2019 12:56:12 am", target.QueueTime.ToString("M/d/yyyy h:mm:ss tt", System.Globalization.CultureInfo.InvariantCulture).ToLower(), "QueueTime");
+         Assert.AreEqual("11/14/2019 12:56:15 am", target.StartTime?.ToString("M/d/yyyy h:mm:ss tt", System.Globalization.CultureInfo.InvariantCulture).ToLower(), "StartTime");
+         Assert.AreEqual("11/14/2019 1:07:13 am", target.FinishTime?.ToString("M/d/yyyy h:mm:ss tt", System.Globalization.CultureInfo.InvariantCulture).ToLower(), "FinishTime");
+         Assert.AreEqual("11/14/2019 12:56:12 am", target.AssignedTime?.ToString("M/d/yyyy h:mm:ss tt", System.Globalization.CultureInfo.InvariantCulture).ToLower(), "AssignedTime");
       }
 
       [TestMethod]

--- a/Tests/library/Provider/PackageVersionTests.cs
+++ b/Tests/library/Provider/PackageVersionTests.cs
@@ -26,7 +26,7 @@ namespace vsteam_lib.Test.Provider
          Assert.AreEqual("@DonovanBrown", actual.Author, "author");
          Assert.AreEqual(expectedDesc, actual.Description, "Description");
          Assert.AreEqual("998abe34-23de-0000-9668b73891e2dada", actual.Id, "Id");
-         Assert.AreEqual("9/7/2018 1:33:39 pm", actual.PublishDate.ToString("M/d/yyyy h:mm:ss tt").ToLower(), "PublishDate");
+         Assert.AreEqual("9/7/2018 1:33:39 pm", actual.PublishDate.ToString("M/d/yyyy h:mm:ss tt", System.Globalization.CultureInfo.InvariantCulture).ToLower(), "PublishDate");
       }
    }
 }

--- a/Tests/library/Provider/ReleaseDefinitionTests.cs
+++ b/Tests/library/Provider/ReleaseDefinitionTests.cs
@@ -43,8 +43,8 @@ namespace vsteam_lib.Test.Provider
          Assert.AreEqual("", actual.ReleaseNameFormat, "ReleaseNameFormat");
          Assert.AreEqual("Chuck Reinhart", actual.CreatedByUser, "CreatedByUser");
          Assert.AreEqual("ReleaseDefinition", actual.ResourceType, "ResourceType");
-         Assert.AreEqual("12/11/2018 4:48:42 am", actual.CreatedOn.ToString("M/d/yyyy h:mm:ss tt").ToLower(), "CreatedOn");
-         Assert.AreEqual("12/11/2018 4:48:42 am", actual.ModifiedOn.ToString("M/d/yyyy h:mm:ss tt").ToLower(), "ModifiedOn");
+         Assert.AreEqual("12/11/2018 4:48:42 am", actual.CreatedOn.ToString("M/d/yyyy h:mm:ss tt", System.Globalization.CultureInfo.InvariantCulture).ToLower(), "CreatedOn");
+         Assert.AreEqual("12/11/2018 4:48:42 am", actual.ModifiedOn.ToString("M/d/yyyy h:mm:ss tt", System.Globalization.CultureInfo.InvariantCulture).ToLower(), "ModifiedOn");
          Assert.AreEqual("https://vsrm.dev.azure.com/fabrikam/00000000-0000-0000-0000-000000000000/_apis/Release/definitions/40", actual.Url, "Url");
       }
 
@@ -82,8 +82,8 @@ namespace vsteam_lib.Test.Provider
          Assert.AreEqual(null, actual.Description, "Description");
          Assert.AreEqual("Donovan Brown", actual.CreatedByUser, "CreatedByUser");
          Assert.AreEqual("Release-$(rev:r)", actual.ReleaseNameFormat, "ReleaseNameFormat");
-         Assert.AreEqual("3/24/2019 4:46:08 pm", actual.CreatedOn.ToString("M/d/yyyy h:mm:ss tt").ToLower(), "CreatedOn");
-         Assert.AreEqual("9/16/2019 2:32:37 pm", actual.ModifiedOn.ToString("M/d/yyyy h:mm:ss tt").ToLower(), "ModifiedOn");
+         Assert.AreEqual("3/24/2019 4:46:08 pm", actual.CreatedOn.ToString("M/d/yyyy h:mm:ss tt", System.Globalization.CultureInfo.InvariantCulture).ToLower(), "CreatedOn");
+         Assert.AreEqual("9/16/2019 2:32:37 pm", actual.ModifiedOn.ToString("M/d/yyyy h:mm:ss tt", System.Globalization.CultureInfo.InvariantCulture).ToLower(), "ModifiedOn");
          Assert.AreEqual("https://vsrm.dev.azure.com/Test/00000000-0000-0000-0000-000000000000/_apis/Release/definitions/2", actual.Url, "Url");
       }
    }

--- a/Tests/library/Provider/ReleaseTests.cs
+++ b/Tests/library/Provider/ReleaseTests.cs
@@ -37,7 +37,7 @@ namespace vsteam_lib.Test.Provider
 
          Assert.AreEqual("Test@Test.com", target.ModifiedBy.UniqueName, "ModifiedBy.UniqueName");
          Assert.AreEqual("Donovan Brown", target.CreatedBy.DisplayName, "CreatedBy.DisplayName");
-         Assert.AreEqual("11/14/2019 12:56:09 am", target.CreatedOn.ToString("M/d/yyyy h:mm:ss tt").ToLower(), "CreatedOn.ToString()");
+         Assert.AreEqual("11/14/2019 12:56:09 am", target.CreatedOn.ToString("M/d/yyyy h:mm:ss tt", System.Globalization.CultureInfo.InvariantCulture).ToLower(), "CreatedOn.ToString()");
 
          Assert.AreEqual("Donovan Brown", target.CreatedByUser, "CreatedByUser");
          Assert.AreEqual("Donovan Brown", target.ModifiedByUser, "ModifiedByUser");
@@ -66,7 +66,7 @@ namespace vsteam_lib.Test.Provider
 
          Assert.AreEqual("test@test.com", target.ModifiedBy.UniqueName, "ModifiedBy.UniqueName");
          Assert.AreEqual("Donovan Brown", target.CreatedBy.DisplayName, "CreatedBy.DisplayName");
-         Assert.AreEqual("7/13/2019 3:49:31 pm", target.CreatedOn.ToString("M/d/yyyy h:mm:ss tt").ToLower(), "CreatedOn.ToString()");
+         Assert.AreEqual("7/13/2019 3:49:31 pm", target.CreatedOn.ToString("M/d/yyyy h:mm:ss tt", System.Globalization.CultureInfo.InvariantCulture).ToLower(), "CreatedOn.ToString()");
       }
 
       [TestMethod]

--- a/Tests/library/Provider/UserEntitlementTests.cs
+++ b/Tests/library/Provider/UserEntitlementTests.cs
@@ -27,7 +27,7 @@ namespace vsteam_lib.Test.Provider
          Assert.AreEqual("Math lastName", target.DisplayName, "DisplayName");
          Assert.AreEqual("mlastName@test.com", target.UniqueName, "UniqueName");
          Assert.AreEqual("Early Adopter", target.AccessLevelName, "AccessLevelName");
-         Assert.AreEqual("9/9/2020 6:43:29 am", target.LastAccessedDate.ToString("M/d/yyyy h:mm:ss tt").ToLower(), "LastAccessedDate");
+         Assert.AreEqual("9/9/2020 6:43:29 am", target.LastAccessedDate.ToString("M/d/yyyy h:mm:ss tt", System.Globalization.CultureInfo.InvariantCulture).ToLower(), "LastAccessedDate");
       }
 
       [TestMethod]


### PR DESCRIPTION
# PR Summary

Inside the vsteam-lib.Test project, tests that have Asserts based on date format (i.e. `actual.CreatedOn.ToString("M/d/yyyy h:mm:ss tt").`) fails when ran in a Windows machine configured with 24h format, for example Spanish. 
See: https://stackoverflow.com/q/38976486/777551

Example of error:
![image](https://user-images.githubusercontent.com/7962206/208730583-767d9a9c-4e8f-4907-bbf5-f3b71ea9ee85.png)

The solution is to use an invariant culture so tests will be independent of the local configuration

## PR Checklist

- [x] [Write Help](https://github.com/DarqueWarrior/vsteam/blob/master/.github/CONTRIBUTING.md#write-help)
- [x] [Write Unit Test](https://github.com/DarqueWarrior/vsteam/blob/master/.github/CONTRIBUTING.md#write-unit-test)
- [x] [Update CHANGELOG.md](https://github.com/DarqueWarrior/vsteam/blob/master/.github/CONTRIBUTING.md#update-changelogmd)
