### PR TITLE
Fix #493 import-module loses previously stored configuration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ Merged [Pull Request](https://github.com/MethodsAndPractices/vsteam/pull/502) fr
 - Updated test c# project to .NET 6.0
 - Fixed test fail on ubuntu-latest
 
+Merged [Pull Request](https://github.com/MethodsAndPractices/vsteam/pull/508) from [Miguel Nieto](https://github.com/mnieto) the following:
+- Fix import-module vsteam loses previously stored configuration: [issue #493](https://github.com/MethodsAndPractices/vsteam/issues/493)
+- Fixed test Versions fail on local machine
+
 ## 7.9.0
 
 Merged [Pull Request](https://github.com/MethodsAndPractices/vsteam/pull/481) from [Sebastian Schütze](https://github.com/SebastianSchuetze) the following:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,13 +3,13 @@
 ## 7.13.0
 
 Merged [Pull Request](https://github.com/MethodsAndPractices/vsteam/pull/515) from [mrwalters1988](https://github.com/mrwalters1988) the following:
-
 - feat: added parameter for Add-VSTeamAccessControlEntry to choose whether to merge the Bits or to Overwrite the bits.
-
-## 7.12.0
 
 Merged [Pull Request](https://github.com/MethodsAndPractices/vsteam/pull/508) from [Miguel Nieto](https://github.com/mnieto) the following:
 - Fix import-module loses previously stored configuration [493](https://github.com/MethodsAndPractices/vsteam/issues/493)
+
+## 7.12.0
+
 
 Merged [Pull Request](https://github.com/MethodsAndPractices/vsteam/pull/506) from [Miguel Nieto](https://github.com/mnieto) the following:
 - fix tests that involve dates fail when OS culture has 24 hours format

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## 7.12.0
 
+Merged [Pull Request](https://github.com/MethodsAndPractices/vsteam/pull/508) from [Miguel Nieto](https://github.com/mnieto) the following:
+- Fix import-module loses previously stored configuration [493](https://github.com/MethodsAndPractices/vsteam/issues/493)
+
 Merged [Pull Request](https://github.com/MethodsAndPractices/vsteam/pull/506) from [Miguel Nieto](https://github.com/mnieto) the following:
 - fix tests that involve dates fail when OS culture has 24 hours format
 

--- a/Source/Classes/Versions.cs
+++ b/Source/Classes/Versions.cs
@@ -79,6 +79,9 @@ namespace vsteam_lib
             case APIs.WorkItemTracking:
                WorkItemTracking = version;
                break;
+            case APIs.Version:
+               Version = version;
+               break;
          }
       }
 

--- a/Source/VSTeam.psm1
+++ b/Source/VSTeam.psm1
@@ -31,7 +31,7 @@ if ($null -ne $env:TEAM_PROJECT) {
 
 
    # if not account and pat is set, then do not try to set the default project
-   if (($null -eq $env:TEAM_PAT -and $null -eq $env:TEAM_TOKEN) -and $null -eq $env:TEAM_ACCT) {
+   if (($null -eq $env:TEAM_PAT -or $null -eq $env:TEAM_TOKEN) -and $null -eq $env:TEAM_ACCT) {
       Write-Warning "No PAT or Account set. You must set the environment variables (TEAM_PAT or TEAM_TOKEN) and TEAM_ACCT before loading the module to use the default project."
    }
    else {


### PR DESCRIPTION
# PR Summary

This fix #493 issue

When the module is configured with Set-VSTeamAccount -Level user, the configuration is stored in env variables and then recovered next time while import-module vsteam
The problem was introduced in commit https://github.com/MethodsAndPractices/vsteam/commit/0528c762bf9d1508a5cba76890c3323039d92fb8 (https://github.com/MethodsAndPractices/vsteam/issues/467 closed in https://github.com/MethodsAndPractices/vsteam/pull/480)

Also fixed a related problem with test ran in local: If the user calls Set-VSTeamAccount with -Local parameter, the TEAM_VERSION environment variable is preserved in the user's profile. The Versions.SetApiVersion did not manage the APIs.Version value and the test failed. This behaviour does not occur in during the GitHub build because the TEAM_VERSION variable is not set (it gets the default value).

## PR Checklist

- [x] [Write Help](https://github.com/DarqueWarrior/vsteam/blob/master/.github/CONTRIBUTING.md#write-help)
- [x] [Write Unit Test](https://github.com/DarqueWarrior/vsteam/blob/master/.github/CONTRIBUTING.md#write-unit-test)
- [x] [Update CHANGELOG.md](https://github.com/DarqueWarrior/vsteam/blob/master/.github/CONTRIBUTING.md#update-changelogmd)
