### PR TITLE
Add option to Merge or Overwrite Bits in Add-VSTeamAccessControlEntry

### DIFF
--- a/.docs/Add-VSTeamAccessControlEntry.md
+++ b/.docs/Add-VSTeamAccessControlEntry.md
@@ -149,6 +149,14 @@ Bitmask for Deny Permissions
 Type: Int
 Required: True
 ```
+### OverwriteMask
+
+Switch to overwrite the mask values rather than merge them. 
+
+```yaml
+Type: Switch
+Required: False
+```
 
 <!-- #include "./params/projectName.md" -->
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 7.13.0
+
+Merged [Pull Request](https://github.com/MethodsAndPractices/vsteam/pull/515) from [mrwalters1988](https://github.com/mrwalters1988) the following:
+
+- feat: added parameter for Add-VSTeamAccessControlEntry to choose whether to merge the Bits or to Overwrite the bits.
+
 ## 7.12.0
 
 Merged [Pull Request](https://github.com/MethodsAndPractices/vsteam/pull/506) from [Miguel Nieto](https://github.com/mnieto) the following:

--- a/Source/Public/Add-VSTeamAccessControlEntry.ps1
+++ b/Source/Public/Add-VSTeamAccessControlEntry.ps1
@@ -37,18 +37,18 @@ function Add-VSTeamAccessControlEntry {
       [int] $DenyMask,
       
       [Parameter(Mandatory = $false)]
-      [switch] $OverrideMask = $false
+      [switch] $OverwriteMask = $false
    )
    process {
 
-      if ($AllowMask -eq 0 -and $DenyMask -eq 0 -and $OverrideMask -eq $false) {
+      if ($AllowMask -eq 0 -and $DenyMask -eq 0 -and $OverwriteMask -eq $false) {
          Write-Warning "Permission masks for Allow and Deny do not inlude any permission. No Permission will change!"
       }
 
       if ($SecurityNamespace) {
          $SecurityNamespaceId = $SecurityNamespace.ID
       }
-      $merge = !$OverrideMask
+      $merge = !$OverwriteMask
       $body =
       @"
    {

--- a/Source/Public/Add-VSTeamAccessControlEntry.ps1
+++ b/Source/Public/Add-VSTeamAccessControlEntry.ps1
@@ -34,23 +34,26 @@ function Add-VSTeamAccessControlEntry {
 
       [Parameter(Mandatory = $true)]
       [ValidateRange(0, [int]::MaxValue)]
-      [int] $DenyMask
+      [int] $DenyMask,
+      
+      [Parameter(Mandatory = $false)]
+      [switch] $OverrideMask = $false
    )
    process {
 
-      if ($AllowMask -eq 0 -and $DenyMask -eq 0) {
+      if ($AllowMask -eq 0 -and $DenyMask -eq 0 -and $OverrideMask -eq $false) {
          Write-Warning "Permission masks for Allow and Deny do not inlude any permission. No Permission will change!"
       }
 
       if ($SecurityNamespace) {
          $SecurityNamespaceId = $SecurityNamespace.ID
       }
-
+      $merge = !$OverrideMask
       $body =
       @"
    {
       "token": "$Token",
-      "merge": true,
+      "merge": $merge,
       "accessControlEntries": [
          {
             "descriptor": "$Descriptor",

--- a/Source/VSTeam.psd1
+++ b/Source/VSTeam.psd1
@@ -12,7 +12,7 @@
    RootModule           = 'VSTeam.psm1'
 
    # Version number of this module.
-   ModuleVersion        = '7.12.0'
+   ModuleVersion        = '7.13.0'
 
    # Supported PSEditions
    CompatiblePSEditions = @('Core', 'Desktop')

--- a/Tests/function/tests/Add-VSTeamAccessControlEntry.Tests.ps1
+++ b/Tests/function/tests/Add-VSTeamAccessControlEntry.Tests.ps1
@@ -113,7 +113,7 @@ Describe 'VSTeamAccessControlEntry' {
             -Token xyz `
             -AllowMask 12 `
             -DenyMask 15 `
-            -OverwriteMask $true
+            -OverwriteMask
 
             ## Assert
             Should -Invoke Invoke-RestMethod -Exactly -Times 1 -Scope It -ParameterFilter {

--- a/Tests/function/tests/Add-VSTeamAccessControlEntry.Tests.ps1
+++ b/Tests/function/tests/Add-VSTeamAccessControlEntry.Tests.ps1
@@ -104,5 +104,30 @@ Describe 'VSTeamAccessControlEntry' {
                -AllowMask 12 `
                -DenyMask 15 } | Should -Throw
       }
+
+      It 'should handle OverwriteMask' {
+
+            ## Act
+            Add-VSTeamAccessControlEntry -SecurityNamespaceId 5a27515b-ccd7-42c9-84f1-54c998f03866 `
+            -Descriptor abc `
+            -Token xyz `
+            -AllowMask 12 `
+            -DenyMask 15 `
+            -OverwriteMask $true
+
+            ## Assert
+            Should -Invoke Invoke-RestMethod -Exactly -Times 1 -Scope It -ParameterFilter {
+               $Uri -like "https://dev.azure.com/test/_apis/accesscontrolentries/5a27515b-ccd7-42c9-84f1-54c998f03866*" -and
+               $Uri -like "*api-version=$(_getApiVersion Core)*" -and
+               $Body -like "*`"token`": `"xyz`",*" -and
+               $Body -like "*`"descriptor`": `"abc`",*" -and
+               $Body -like "*`"allow`": 12,*" -and
+               $Body -like "*`"deny`": 15,*" -and
+               $Body -like "*`"merge`": false,*" -and
+               $Method -eq "Post"
+            }
+
+      }
+
    }
 }


### PR DESCRIPTION
# PR Summary

<!-- summarize your PR between here and the checklist -->

This enables the option mentioned in the inline comments of Add-VSTeamAccessControlEntry to choose whether to merge the Bits or to Overwrite the bits. 

## PR Checklist

- [x] [Write Help](https://github.com/DarqueWarrior/vsteam/blob/master/.github/CONTRIBUTING.md#write-help)
- [x] [Write Unit Test](https://github.com/DarqueWarrior/vsteam/blob/master/.github/CONTRIBUTING.md#write-unit-test)
- [x] [Update CHANGELOG.md](https://github.com/DarqueWarrior/vsteam/blob/master/.github/CONTRIBUTING.md#update-changelogmd)
