### PR TITLE
Unify date/time format and make it cultureInfo independent

### DIFF
--- a/Source/Private/common.ps1
+++ b/Source/Private/common.ps1
@@ -1199,7 +1199,7 @@ function _showModuleLoadingMessages {
 
             # dont show messages if display until date is in the past
             $currentDate = Get-Date
-            $filteredMessages = $filteredMessages | Where-Object { $currentDate -le ([DateTime]::Parse($_.toDate))
+            $filteredMessages = $filteredMessages | Where-Object { $currentDate -le ([DateTime]::ParseExact($_.toDate, "dd/MM/yyyy HH:mm:ss", [cultureInfo]::InvariantCulture))
             }
 
             # stop processing if no messages left

--- a/Tests/SampleFiles/moduleMessages.json
+++ b/Tests/SampleFiles/moduleMessages.json
@@ -1,25 +1,25 @@
 [
    {
       "msg": "Message for minimum version 5.6.0",
-      "toDate": "2099-02-14 13:36:17Z",
+      "toDate": "14/02/2099 13:36:17",
       "displayFromVersion": "5.6.0",
       "type": "info"
    },
    {
       "msg": "Message for minimum version 7.0.0",
-      "toDate": "2099-02-13 13:36:17Z",
+      "toDate": "13/02/2099 13:36:17",
       "displayFromVersion": "7.0.0",
       "type": "warning"
    },
    {
       "msg": "Message for minimum version 6.9.0",
-      "toDate": "2021-12-31 23:59:59Z",
+      "toDate": "31/12/2021 23:59:59",
       "displayFromVersion": "6.9.0",
       "type": "warning"
    },
    {
       "msg": "Message for minimum version 7.8.0 to maximum version 8.0.0",
-      "toDate": "2099-12-31 23:59:59Z",
+      "toDate": "31/12/2099 23:59:59",
       "displayFromVersion": "7.8.0",
       "displayToVersion": "8.0.0",
       "type": "warning"

--- a/Tests/function/tests/common.Tests.ps1
+++ b/Tests/function/tests/common.Tests.ps1
@@ -451,6 +451,14 @@ Describe 'Common' {
          { _showModuleLoadingMessages -ModuleVersion 'notaversion' } | Should -Throw -ExpectedMessage '*Cannot convert value "notaversion" to type "System.Version*'
       }
 
+      It 'should have correct datetime format' {
+         $moduleMessagesRes = Open-SampleFile 'moduleMessages.json'
+         $moduleMessagesRes | ForEach-Object {
+            $outDate = [datetime]::Now
+            [datetime]::TryParseExact($_.toDate, "dd/MM/yyyy HH:mm:ss", [cultureInfo]::InvariantCulture, [System.Globalization.DateTimeStyles]::None, [ref] $outDate) | Should -BeTrue
+         }
+      }
+
    }
 
    Context '_checkForModuleUpdates' {


### PR DESCRIPTION
# PR Summary

Fix #511 
Date format in .github/moduleMessages.json is different than test/sampleFiles/moduleMessages.json
Also the [DateTime]::Parse can throw execption depending on the current locale.

This change unifies the date format in `_showModuleLoadingMessages` function using ParseExact instead Parse

The field toDate in moduleMessages.json should have dd/MM/yyyy HH:mm:ss format

## PR Checklist

- [X] [Write Help](https://github.com/DarqueWarrior/vsteam/blob/master/.github/CONTRIBUTING.md#write-help)
- [X] [Write Unit Test](https://github.com/DarqueWarrior/vsteam/blob/master/.github/CONTRIBUTING.md#write-unit-test)
- [] [Update CHANGELOG.md](https://github.com/DarqueWarrior/vsteam/blob/master/.github/CONTRIBUTING.md#update-changelogmd)
