### PR TITLE
Send valid json body with add vs team access control entry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## 7.13.3
 Merged [Pull Request](https://github.com/MethodsAndPractices/vsteam/pull/539) from [Erik Sijnja](https://github.com/esijnja) the following:
-- Send valid json body with Add-VSTeamAccessControlEntity
+- Send valid json body with Add-VSTeamAccessControlEntity [538](https://github.com/MethodsAndPractices/vsteam/issues/538)
 
 ## 7.13.2
 Merged [Pull Request](https://github.com/MethodsAndPractices/vsteam/pull/536) from [Sebastian Schütze](https://github.com/SebastianSchuetze) the following:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 7.13.3
+Merged [Pull Request](https://github.com/MethodsAndPractices/vsteam/pull/539) from [Erik Sijnja](https://github.com/esijnja) the following:
+- Send valid json body with Add-VSTeamAccessControlEntity
+
 ## 7.13.2
 Merged [Pull Request](https://github.com/MethodsAndPractices/vsteam/pull/536) from [Sebastian Schütze](https://github.com/SebastianSchuetze) the following:
 - Fix missing switch OverwriteMask to all cmdlets who are dependant to Add-VSTeamAccessControlList

--- a/Source/Public/Add-VSTeamAccessControlEntry.ps1
+++ b/Source/Public/Add-VSTeamAccessControlEntry.ps1
@@ -48,7 +48,8 @@ function Add-VSTeamAccessControlEntry {
       if ($SecurityNamespace) {
          $SecurityNamespaceId = $SecurityNamespace.ID
       }
-      $merge = !$OverwriteMask
+      [string]$merge = (!$OverwriteMask)
+      $merge = $merge.ToLowerInvariant()
       $body =
       @"
    {

--- a/Source/VSTeam.psd1
+++ b/Source/VSTeam.psd1
@@ -12,7 +12,7 @@
    RootModule           = 'VSTeam.psm1'
 
    # Version number of this module.
-   ModuleVersion        = '7.13.2'
+   ModuleVersion        = '7.13.3'
 
    # Supported PSEditions
    CompatiblePSEditions = @('Core', 'Desktop')

--- a/Tests/function/tests/Add-VSTeamAccessControlEntry.Tests.ps1
+++ b/Tests/function/tests/Add-VSTeamAccessControlEntry.Tests.ps1
@@ -123,11 +123,11 @@ Describe 'VSTeamAccessControlEntry' {
                $Body -like "*`"descriptor`": `"abc`",*" -and
                $Body -like "*`"allow`": 12,*" -and
                $Body -like "*`"deny`": 15,*" -and
-               $Body -like "*`"merge`": false,*" -and
+               $Body -cmatch "`"merge`": false," -and
                $Method -eq "Post"
             }
 
       }
-
+      
    }
 }


### PR DESCRIPTION
# PR Summary

This PR Fixes Issue #538
Add-VSTeamAccessControl was sending invalid json in the body which results in a (400) bad request and the unit test covering this had a incorrect check so it was not detected.

## PR Checklist

- [x] [Write Help](https://github.com/DarqueWarrior/vsteam/blob/master/.github/CONTRIBUTING.md#write-help)
- [x] [Write Unit Test](https://github.com/DarqueWarrior/vsteam/blob/master/.github/CONTRIBUTING.md#write-unit-test)
- [x] [Update CHANGELOG.md](https://github.com/DarqueWarrior/vsteam/blob/master/.github/CONTRIBUTING.md#update-changelogmd)
