### PR TITLE
fix: Use of ternary operator in Remove-VSTeamDirectAssignment breaks …

### DIFF
--- a/Source/Public/Remove-VSTeamDirectAssignment.ps1
+++ b/Source/Public/Remove-VSTeamDirectAssignment.ps1
@@ -11,7 +11,7 @@ function Remove-VSTeamDirectAssignment {
 
       $queryString = @{
          'api-version' = '5.0-preview.1'
-         'ruleOption'  = $Preview ? '1' : '0'
+         'ruleOption'  = if($Preview) {'1'} else {'0'}
          'select'      = 'grouprules'
       }
 

--- a/Source/VSTeam.psd1
+++ b/Source/VSTeam.psd1
@@ -12,7 +12,7 @@
    RootModule           = 'VSTeam.psm1'
 
    # Version number of this module.
-   ModuleVersion        = '7.15.1'
+   ModuleVersion        = '7.15.2'
 
    # Supported PSEditions
    CompatiblePSEditions = @('Core', 'Desktop')


### PR DESCRIPTION
…module in Powershell versions < 7

# PR Summary

<!-- summarize your PR between here and the checklist -->

## PR Checklist

- [x] [Write Help](https://github.com/DarqueWarrior/vsteam/blob/master/.github/CONTRIBUTING.md#write-help)
- [x] [Write Unit Test](https://github.com/DarqueWarrior/vsteam/blob/master/.github/CONTRIBUTING.md#write-unit-test)
- [x] [Update CHANGELOG.md](https://github.com/DarqueWarrior/vsteam/blob/master/.github/CONTRIBUTING.md#update-changelogmd)
